### PR TITLE
Updated the assemble task to add fallbacks

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -20,11 +20,11 @@ module.exports = ->
 				marked:
 					sanitize: false
 				production: false
-				data: 'site/data/*.{yml,json}'
+				data: ['lib/wet-boew/site/data/**/*.{yml,json}', 'site/data/**/*.{yml,json}']
+				helpers: ['lib/wet-boew/site/helpers/helper-*.js', 'site/helpers/helper-*.js']
+				partials: ['lib/wet-boew/site/includes/**/*.hbs', 'site/includes/**/*.hbs']
+				layoutdir: 'lib/wet-boew/theme/layouts'
 				assets: 'dist'
-				helpers: 'site/helpers/helper-*.js'
-				layoutdir: 'site/layouts'
-				partials: ['site/includes/**/*.hbs']
 
 			site:
 				options:


### PR DESCRIPTION
Configured assemble to look for partials and data in both the wet-boew library as well as the current theme. If a theme partial or data file has the same name as one in the current them, the theme takes precedence
