### PR TITLE
Switched the WET core bower dependency to a GitHub endpoint

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "tests"
   ],
   "devDependencies": {
-    "wet-boew": "https://github.com/wet-boew/wet-boew/archive/v4.0.zip"
+    "wet-boew": "git://github.com/wet-boew/wet-boew.git#v4.0"
   },
   "resolutions": {
     "jquery": ">= 1.9.0"


### PR DESCRIPTION
This allows to update WET by using `bower update wet-boew`
