### PR TITLE
Add new Travis private cache setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: node_js
 node_js:
   - "0.10"
 
+cache:
+  directories:
+  - lib
+  - node_modules
+
 env:
   global:
     - secure: "hXpNHvTscBbHFaFLHzQ5vZCY8ujebENLnZRMKItEbsoqkSnlumypFLGGm7yOqxuGzY5ccfO0Q4tM1FDmYsvqSaD2RIfVaQQ6Dzd8cCf2tBPkBy/EMNsTd+F54Z+FMVuCgRz3Y/ckYU96G21FXQkJyqfk5zzTxtZYwkrzoeaVpAU=" #Github Token


### PR DESCRIPTION
Travis has added caching to the Pro site http://about.travis-ci.org/docs/user/caching/
These will get sanity checked by the `npm install` and `bower install` to see if anything is out of date.
