### PR TITLE
corrected the reference to ie8-vapour.js adding in IE8 support

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!--[if IE 8]><html class="no-js lt-ie9" lang="{{language}}"><![endif]-->
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="{{language}}"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="{{language}}">
 <!--<![endif]-->
@@ -17,9 +17,8 @@
         <link rel="stylesheet" href="{{assets}}/css/bootstrap{{environment.suffix}}.css">
         <link rel="stylesheet" href="{{assets}}/css/theme{{environment.suffix}}.css">
 
-        <!-- IE8 Support -->
-        <!--[if IE 8]>
-        <script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js"></script>
+        <!--[if lt IE 9]>
+        <script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
         <![endif]-->
 
     </head>

--- a/site/layouts/partners.hbs
+++ b/site/layouts/partners.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!--[if IE 8]><html class="no-js lt-ie9" lang="{{language}}"><![endif]-->
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="{{language}}"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="{{language}}">
 <!--<![endif]-->
@@ -17,9 +17,8 @@
         <link rel="stylesheet" href="{{assets}}/css/bootstrap{{environment.suffix}}.css">
         <link rel="stylesheet" href="{{assets}}/css/theme{{environment.suffix}}.css">
 
-        <!-- IE8 Support -->
-        <!--[if IE 8]>
-        <script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js"></script>
+        <!--[if lt IE 9]>
+        <script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
         <![endif]-->
 
     </head>


### PR DESCRIPTION
- There is still the issue of the wordmark being SVG , and there is work to look at better fallback solutions ( image or fontglyph )
