### PR TITLE
Removed the top margin and floated the follow us buttons in mobile views

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -267,7 +267,11 @@ aside.features {
         line-height: 2;
         padding-top: 0;
         padding-bottom: 0;
-        margin-top: 4em;
+        float: right;
+        @media (min-width: 992px) {
+            float: none;
+            margin-top: 4em;
+        }
         .youtube {
             position: relative;
             display: inline-block;


### PR DESCRIPTION
@shawnthompson This is the layout change you asked me about at the last code sprint. I also removed the 4em top margin on mobile as it made no sense to have that much white space above those buttons when they are on their own baseline.
