### PR TITLE
Fixed the Canada wordmark link

### DIFF
--- a/src/sass/_fonts.scss
+++ b/src/sass/_fonts.scss
@@ -27,9 +27,6 @@ header .brand {
     a {
         position: relative;
         text-decoration: none;
-        &:after {
-            position: static;
-        }
     }
 }
 


### PR DESCRIPTION
@masterbee For some reason you had that CSS property in _fonts.scss. That disabled the fix for the Canada wordmark link.
