### PR TITLE
Enabled the IE-specific CSS for the mobile and social media centres on all versions of IE from 9 and below

### DIFF
--- a/site/includes/headresources.hbs
+++ b/site/includes/headresources.hbs
@@ -6,6 +6,8 @@
 <!--[if lt IE 9]>
 <link rel="stylesheet" href="{{assets}}/css/ie8{{environment.suffix}}.css" />
 <script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
+<![endif]-->
+<!--[if lte IE 9]>
 {{#compare section "==" "mobile-centre" }}<link rel="stylesheet" href="{{assets}}/css/mobile-centre-ie{{environment.suffix}}.css" />{{/compare}}
 {{#compare section "==" "social-media-centre" }}<link rel="stylesheet" href="{{assets}}/css/social-media-centre-ie{{environment.suffix}}.css" />{{/compare}}
 <![endif]-->


### PR DESCRIPTION
IE9 also has rendering issues. Applying the same CSS created for IE8 renders the same layout as IE8 in IE9.
