### PR TITLE
removed 100% width for feature images

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -319,11 +319,7 @@ aside.features {
 
         img {
             border: solid 1px #eee;
-            width: 100%;
         }
-    }
-    figcaption a {
-        text-decoration: underline;
     }
 }
 


### PR DESCRIPTION
Also removed the underline for the link in the features because it's default underline for all links
