### PR TITLE
Removed CSS to hide the breadcrumb on home pages

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -329,10 +329,6 @@ aside.features {
 
 /* Home page */
 .home {
-    // Hide the breadcrumbs on homepage
-    #wb-bc {
-        display: none;
-    }
     h2, .departments h3 {
         font-size: 27px;
         border-bottom: 1px solid $border-red;


### PR DESCRIPTION
The breadcrumb was removed from home pages using the template in #206.
