### PR TITLE
Breadcrumb: Aligned with HTML reccomendation to use arrow

### DIFF
--- a/src/sass/_breadcrumbs.scss
+++ b/src/sass/_breadcrumbs.scss
@@ -1,0 +1,26 @@
+/*
+ Breadcrumbs
+ */
+#wb-bc {
+        background: #F5F5F5;
+        .breadcrumb {
+                margin-bottom: 0;
+                border-radius: 0;
+        }
+        li {
+                &:before, &:after {
+                        font-family: "Glyphicons Halflings";
+                        font-size: 0.7em;
+                        color: #000;
+                }
+                &:before {
+                        content: "\e092";
+                }
+                white-space: nowrap;
+                &:first-child {
+                        &:before {
+                                content: "";
+                        }
+                }
+        }
+}

--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -425,6 +425,7 @@ aside.features {
 @import "promo";
 @import "fonts";
 @import "splash";
+@import "breadcrumbs";
 @import "examples";
 
 footer a {


### PR DESCRIPTION
- Corrected ">" and "\" treatment in CSS to align with HTML5 recommendation on breadcrumb navigation http://www.w3.org/TR/html51/common-idioms.html#rel-up
