### PR TITLE
Various tweaks for CSS to accomdate issues raised

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -190,12 +190,17 @@ main {
         margin-bottom: 1em;
         font-weight: 300;
     }
-    .btn-primary {
-        padding: 1em;
+
+    .btn-primary{
         background-color: $accent-blue;
         border-color: $accent-blue;
-        text-transform: uppercase;
+
     }
+    a.btn-primary {
+            padding: 1em;
+            text-transform: uppercase;
+    }
+
     .thumbnail {
         border-radius: 0;
         background: $profile-gray;


### PR DESCRIPTION
-  Glyphicon: Corrected centering of glphicon in search button in header due to `top:1px` set as base
-  Canada Wordmark in IE9 was miscalculating the height of the object giving it a very large of whitespace below the wordmark. Setting the `max-height` control IE9's height value normalizing the whitespace to match the design requirements
-  10px of header spacing was given to meet the design requirements
- Corrected the `.btn-primary` issue raised in #242
