### PR TITLE
CSS: Removed legacy z-index CSS to theme

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -71,7 +71,6 @@ caption {
 /*Header */
 header {
     position: relative;
-    z-index: 20;
     #wb-lng {
         padding-top: 10px;
     }
@@ -174,7 +173,6 @@ header {
 
 main {
     position: relative;
-    z-index: 10;
     a {
         text-decoration: underline;
     }


### PR DESCRIPTION
- Removed legacy z-index in `main` and `header` elements
- Correcting #270
