### PR TITLE
CSS: Mediaplayer controls corrected due to theme override

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -351,10 +351,7 @@ aside.features {
             }
         }
     }
-    .btn-default {
-        background: #eee;
-        border-color: #eee;
-    }
+
     .followus {
         line-height: 2;
         padding-top: 0;


### PR DESCRIPTION
Correct `.btn-default` styling that interfered with media player controls.
