### PR TITLE
added heading to the promotional asides, including carousel

### DIFF
--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -11,6 +11,7 @@
 	"%tmpl-site-menu": "Site menu",
 	"%tmpl-bcrumb": "Breadcrumb trail",
 	"%tmpl-home": "Home",
+	"%tmpl-promo-title": "Promotions",
 	"%tmpl-sec-menu": "Secondary menu",
 	"%tmpl-sup-cont": "Supplemental content",
 	"%tmpl-foot": "Footer",

--- a/site/data/i18n/fr.json
+++ b/site/data/i18n/fr.json
@@ -11,6 +11,7 @@
 	"%tmpl-site-menu": "Menu du site",
 	"%tmpl-bcrumb": "Fil d'Ariane",
 	"%tmpl-home": "Accueil",
+	"%tmpl-promo-title": "Promotions",
 	"%tmpl-sec-menu": "Menu secondaire",
 	"%tmpl-sup-cont": "Contenu supplémentaire",
 	"%tmpl-foot": "Pied de page",

--- a/site/includes/promotion1.hbs
+++ b/site/includes/promotion1.hbs
@@ -1,6 +1,7 @@
 <aside class="jumbotron pagebrand promo-one visible-md visible-lg">
 	<div class="container">
 		<div class="row">
+			<h2 class="wb-inv">{{#i18n "%tmpl-promo-title"}}{{/i18n}}</h2>
 			<figure class="col-md-12">
 				<img src="{{assets}}/img/promos/one.jpg" alt="">
 				<figcaption>

--- a/site/includes/promotion2.hbs
+++ b/site/includes/promotion2.hbs
@@ -1,6 +1,7 @@
 <aside class="jumbotron sub-promo visible-md visible-lg">
 	<div class="container">
 		<div class="row">
+			<h2 class="wb-inv">{{#i18n "%tmpl-promo-title"}}{{/i18n}}</h2>
 			<figure class="col-md-12">
 				<img src="{{assets}}/img/promos/subpromo.jpg" alt="">
 				<figcaption class="col-md-3 col-md-offset-1 margin-top-medium">

--- a/site/includes/promotion3.hbs
+++ b/site/includes/promotion3.hbs
@@ -1,9 +1,7 @@
----
-
----
 <aside class="jumbotron sub-promo visible-md visible-lg">
 	<div class="container">
 		<div class="row">
+			<h2 class="wb-inv">{{#i18n "%tmpl-promo-title"}}{{/i18n}}</h2>
 			<div class="col-md-6 col-offset-1">
 				<h2 class="h3">{{#startsWith "en" language }}Remembrance Vignette{{else}}Capsule commémorative{{/startsWith}}</h2>
 				<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde, quas, ipsa error modi sequi odio doloribus vero. Veniam error facilis voluptates Optio.</p>

--- a/site/includes/promotion4.hbs
+++ b/site/includes/promotion4.hbs
@@ -1,6 +1,7 @@
 <aside class="jumbotron pagebrand flpr">
     <div class="container">
         <div class="row">
+            <h2 class="wb-inv">{{#i18n "%tmpl-promo-title"}}{{/i18n}}</h2>            
             <div class="wb-tabs carousel-s2 playing" data-speed="slow">
                 <ul role="tablist">
                     <li class="active"><a href="#tab7" title="Tab 1"><img src="{{assets}}/img/promos/one.jpg" alt=""></a></li>


### PR DESCRIPTION
One of the changes for #180. Still need to fix the missing heading to the nav in the mobile menu.
