### PR TITLE
fixed .thumbnail in IE8 for priorities and features

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -33,6 +33,17 @@ h6, .h6 {
     h1, .h1 {
         font-size: 30px !important;
     }
+    // overrides from ie8-wet-boew.css for thumbnails
+    .priorities, .features {
+        .thumbnail {
+          display: inline-block;
+          background-color: $profile-gray;
+        }
+        .thumbnail > img,
+        .thumbnail a > img {
+          display: inline-block;
+        }
+    }
 }
 
 table {


### PR DESCRIPTION
This fixes the display for .thumbnails in IE8 to override bootstraps display:block.
