### PR TITLE
Removed role=menu from secondary menu

### DIFF
--- a/site/includes/secondarymenu-en.hbs
+++ b/site/includes/secondarymenu-en.hbs
@@ -1,6 +1,6 @@
-<ul class="list-group menu list-unstyled" role="menu">
+<ul class="list-group menu list-unstyled">
 	<li><a class="list-group-item item" href="#jbs">Jobs</a>
-		<ul class="list-group list-unstyled" role="menu" id="jbs">
+		<ul class="list-group list-unstyled" id="jbs">
 			<li><a class="list-group-item" href="http://canada.ca/en/jobs/find.html">Find a job</a></li>
 			<li><a class="list-group-item" href="http://canada.ca/en/jobs/training.html">Training</a></li>
 			<li><a class="list-group-item" href="http://canada.ca/en/jobs/pensions.html">Pensions &amp; retirement</a></li>

--- a/site/includes/secondarymenu-fr.hbs
+++ b/site/includes/secondarymenu-fr.hbs
@@ -1,6 +1,6 @@
-<ul class="list-group list-unstyled menu" role="menu">
+<ul class="list-group menu list-unstyled">
 	<li><a class="list-group-item item" href="#jbs">Emplois</a>
-		<ul class="list-group sm menu list-unstyled" id="jbs">
+		<ul class="list-group list-unstyled" id="jbs">
 			<li><a class="list-group-item" href="http://canada.ca/fr/emplois/trouver.html">Trouver un emploi</a></li>
 			<li><a class="list-group-item" href="http://canada.ca/fr/emplois/formation.html">Formation</a></li>
 			<li><a class="list-group-item" href="http://canada.ca/fr/emplois/pensions.html">Pension et retraite</a></li>


### PR DESCRIPTION
Either fully implement the WAI-ARIA menu design pattern (role=menu and role=menuitem + focus handling) or fully remove it (as is done in this PR). More harm than good to only partially implement the menu design pattern.
