### PR TITLE
Restored the DataTables 'information' indicator to the top of the table

### DIFF
--- a/site/pages/mobile-centre/index-en.hbs
+++ b/site/pages/mobile-centre/index-en.hbs
@@ -18,7 +18,7 @@
 <div class="row">
 	<div class="col-md-12">
 		<p class="pagetag">Use our mobile applications and pages to access Government of Canada information and services.</p>
-		<table id="mobile-centre" class="product-listing wb-tables" data-wet-boew='{"bDeferRender": true, "aoColumns": [ { "sClass": "product-name h3" },  { "sClass": "product-pubdate wb-inv" }, { "sClass": "product-platforms" }, { "sClass": "product-shortdescription" }, { "sClass": "product-longdescription" }, { "sClass": "product-department" },{ "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/mob-en.json","aaSorting": [[1,"desc"]],"oLanguage": {"sSearch": "Filter:"} }'>
+		<table id="mobile-centre" class="product-listing wb-tables" data-wet-boew='{"bDeferRender": true, "aoColumns": [ { "sClass": "product-name h3" },  { "sClass": "product-pubdate wb-inv" }, { "sClass": "product-platforms" }, { "sClass": "product-shortdescription" }, { "sClass": "product-longdescription" }, { "sClass": "product-department" },{ "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/mob-en.json","aaSorting": [[1,"desc"]],"oLanguage": {"sSearch": "Filter:"}, "sDom": "<\"wrapper\"flitp>" }'>
 	        <thead class="wb-inv">
 	            <tr>
 	                <th>Name</th>

--- a/site/pages/mobile-centre/index-fr.hbs
+++ b/site/pages/mobile-centre/index-fr.hbs
@@ -18,7 +18,7 @@
 <div class="row">
 	<div class="col-md-12">
 		<p class="pagetag">Utilisez nos applications et pages mobiles pour accéder aux services et aux renseignements du gouvernement du Canada.</p>
-		<table id="mobile-centre" class="product-listing wb-tables" data-wet-boew='{"bDeferRender": true, "aoColumns": [ { "sClass": "product-name h3" },  { "sClass": "product-pubdate wb-inv" }, { "sClass": "product-platforms" }, { "sClass": "product-shortdescription" }, { "sClass": "product-longdescription" }, { "sClass": "product-department" },{ "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/mob-fr.json","aaSorting": [[1,"desc"]],"oLanguage": {"sSearch": "Filtrer&nbps;:"} }'>
+		<table id="mobile-centre" class="product-listing wb-tables" data-wet-boew='{"bDeferRender": true, "aoColumns": [ { "sClass": "product-name h3" },  { "sClass": "product-pubdate wb-inv" }, { "sClass": "product-platforms" }, { "sClass": "product-shortdescription" }, { "sClass": "product-longdescription" }, { "sClass": "product-department" },{ "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/mob-fr.json","aaSorting": [[1,"desc"]],"oLanguage": {"sSearch": "Filtrer&nbps;:"}, "sDom": "<\"wrapper\"flitp>" }'>
             <thead class="wb-inv">
                 <tr>
                     <th>Nom</th>

--- a/site/pages/social-media-centre/index-en.hbs
+++ b/site/pages/social-media-centre/index-en.hbs
@@ -18,7 +18,7 @@
 <div class="row">
 	<div class="col-md-12">
 		<p class="pagetag">The following is a listing of official Government of Canada social media channels.</p>
-		<table id="social-media-centre" class="product-listing wb-tables wb-inview" data-wet-boew='{ "bDeferRender": true, "aoColumns": [ { "sClass": "product-name" }, { "sClass": "product-platforms" }, { "sClass": "product-department" },{ "sClass": "product-language" }, { "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/sm-en.json","oLanguage": {"sSearch": "Filter:"} }'>
+		<table id="social-media-centre" class="product-listing wb-tables wb-inview" data-wet-boew='{ "bDeferRender": true, "aoColumns": [ { "sClass": "product-name" }, { "sClass": "product-platforms" }, { "sClass": "product-department" },{ "sClass": "product-language" }, { "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/sm-en.json","oLanguage": {"sSearch": "Filter:"}, "sDom": "<\"wrapper\"flitp>" }'>
 	        <thead class="wb-inv">
 	            <tr>
 	                <th>Name</th>

--- a/site/pages/social-media-centre/index-fr.hbs
+++ b/site/pages/social-media-centre/index-fr.hbs
@@ -18,7 +18,7 @@
 <div class="row">
 	<div class="col-md-12">
 		<p class="pagetag">Vous trouverez ci-après une liste des médias sociaux officiels du gouvernement du Canada.</p>
-		<table id="social-media-centre" class="product-listing wb-tables" data-wet-boew='{ "bDeferRender": true, "aoColumns": [ { "sClass": "product-name" }, { "sClass": "product-platforms" }, { "sClass": "product-department" },{ "sClass": "product-language" }, { "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/sm-en.json","oLanguage": {"sSearch": "Filtrer&nbps;:"}}'>
+		<table id="social-media-centre" class="product-listing wb-tables" data-wet-boew='{ "bDeferRender": true, "aoColumns": [ { "sClass": "product-name" }, { "sClass": "product-platforms" }, { "sClass": "product-department" },{ "sClass": "product-language" }, { "sClass": "product-link-container" } ], "sAjaxSource": "../ajax/sm-en.json","oLanguage": {"sSearch": "Filtrer&nbps;:"}, "sDom": "<\"wrapper\"flitp>" }'>
             <thead class="wb-inv">
                 <tr>
                     <th>Nom</th>


### PR DESCRIPTION
Fixed problem reported in https://github.com/bci-web/GCWeb/pull/248#issuecomment-30438528.
