### PR TITLE
Removed display:block from .product-listing has it was causing the tbody to collapse when only one record was displayed

### DIFF
--- a/src/sass/social-media-centre.scss
+++ b/src/sass/social-media-centre.scss
@@ -60,7 +60,6 @@
 
 	.product-listing {
 		border: none;
-		display: block;
 		width: 100%;
 	}
 


### PR DESCRIPTION
Fixes issue https://github.com/bci-web/GCWeb/issues/433.
