### PR TITLE
[Theme CSS] Fixed the font sizes for the headings in IE8

### DIFF
--- a/src/sass/theme.scss
+++ b/src/sass/theme.scss
@@ -33,7 +33,23 @@ h6, .h6 {
 /* IE */
 .lt-ie9 {
 	h1, .h1 {
-		font-size: 30px !important;
+		font-size: 27px !important;
+	}
+	h2, .h2 {
+		font-size: 25px;
+	}
+	h3, .h3 {
+		font-size: 22px;
+	}
+	h4, .h4 {
+		font-size: 20px;
+	}
+	h5, .h5 {
+		font-size: 18px;
+	}
+	h6, .h6 {
+		font-size: 16px;
+		font-weight: bold;
 	}
 	// overrides from ie8-wet-boew.css for thumbnails
 	.priorities, .features {


### PR DESCRIPTION
Fixes issue https://github.com/bci-web/GCWeb/issues/454.
