### PR TITLE
Fixed appearance of mobile panel language links now that li elements are used

### DIFF
--- a/src/sass/_menus.scss
+++ b/src/sass/_menus.scss
@@ -173,10 +173,10 @@
 		}
 		ul {
 			list-style-type: none;
-			li {
-				list-style-type: none;
-				line-height: 2;
-			}
+		}
+		li {
+			list-style-type: none;
+			line-height: 2;
 		}
 	}
 	.mfp-close {
@@ -186,6 +186,10 @@
 		text-align: right;
 		padding-right: 30px;
 		padding-top: 2em;
+		li {
+			padding-left: 10px;
+			line-height: normal;				
+		}
 	}
 	.srch-pnl {
 		form {


### PR DESCRIPTION
Note: There was no GCWeb markup changes made or a need to update any markup, this is just to align the CSS with the updates to the JS plugin upstream.
