### PR TITLE
Fixed spacing between secondary menu, site menu and site information sections of the mobile panel

### DIFF
--- a/src/sass/_menus.scss
+++ b/src/sass/_menus.scss
@@ -148,8 +148,11 @@
 			margin-top: 1px;
 		}
 	}
-	section, nav {
+	section {
 		padding: 1em 20px;
+	}
+	nav {
+		padding: 10px 20px;
 	}
 	.modal-body {
 		background: #0E4164;
@@ -231,13 +234,10 @@
 	}
 	.sm-pnl{
 		background: #0E4164;
-		padding-bottom: 10px;
-		padding-top: 20px;
 		margin-bottom: 0;
 	}
 	.info-pnl{
 		background: #193451;
-		padding-top: 10px;
 		color: #325375 !important;
 	}
 	.active {
@@ -247,8 +247,6 @@
 	}
 	.sec-pnl {
 		background: #cdd4da !important;
-		padding-top: 10px;
-		padding-bottom: 5px;
 		a, summary {
 			color: #2e5576 !important;
 		}


### PR DESCRIPTION
Spacing was pretty inconsistent (ranging from 5px to 20px of padding on each side) so normalized it to 10px on each side for all three sections (left search and language sections alone).
