### PR TITLE
line-height in list items

### DIFF
--- a/src/sass/_defaults.scss
+++ b/src/sass/_defaults.scss
@@ -52,7 +52,11 @@ input[placeholder], [placeholder], *[placeholder]  {
 
 main ul, ol {
 	li {
-		line-height: 2;
+		line-height: 1.4375;
+		margin-bottom: 1em;
+		ul, ol {
+			margin-top: 1em;
+		}
 	}
 }
 


### PR DESCRIPTION
changed li line-height to margin-bottom to account for list items that wrap
