### PR TITLE
Use tarball for WET dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "tests"
   ],
   "devDependencies": {
-    "wet-boew": "git://github.com/wet-boew/wet-boew.git#v4.0"
+    "wet-boew": "https://github.com/wet-boew/wet-boew/tarball/v4.0"
   },
   "resolutions": {
     "jquery": ">= 1.9.0"


### PR DESCRIPTION
Prevents the SemVer fuzzy matching the Beta 1 tag.
For https://github.com/bci-web/GCWeb/pull/491#issuecomment-31669537
