### PR TITLE
Add david dm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 GCWeb
 =====
 
-[![Build Status](https://magnum.travis-ci.com/bci-web/GCWeb.png?token=eiMz5uhCjPQ917z2QpnW&branch=master)](https://magnum.travis-ci.com/bci-web/GCWeb)
+[![Build Status](https://travis-ci.org/wet-boew/GCWeb.png?branch=master)](https://travis-ci.org/wet-boew/GCWeb)
 [![devDependency Status](https://david-dm.org/wet-boew/GCWeb/dev-status.png?theme=shields.io)](https://david-dm.org/wet-boew/GCWeb#info=devDependencies)
 
 canada.ca theme


### PR DESCRIPTION
Also fixes the Travis-CI bage.

PS: The Travis-CI.com token should be revoked (if still applicable) as it was publicly available in the markdown.
