### PR TITLE
Added feedback form to theme examples

### DIFF
--- a/site/pages/feedback-en.hbs
+++ b/site/pages/feedback-en.hbs
@@ -1,0 +1,167 @@
+---
+{
+	"title": "Feedback form",
+	"language": "en",
+	"description": "Allows users to submit feedback for a specific Web page or Web site.",
+	"altLangPrefix": "feedback",
+	"breadcrumb": [
+		{ "title": "Home", "link": "http://canada.ca/en/index.html" }
+	],
+	"css": "demos/feedback/demo/feedback",
+	"js": "demos/feedback/demo/feedback",
+	"dateModified": "2014-02-28"
+}
+---
+<div class="wb-formvalid wb-fdbck nojs-hide">
+	<p>If you have difficulty with the following form, you can use any of our <a href="#osc-avs">other service channels</a> to contact us. Please read the <a href="#pics-ecrp">Personal Information Collection Statement</a> before completing this form.</p>
+	<form action="#" method="get" id="fdbck-frm">
+		<input type="hidden" name="language" value="en" />
+		<div id="type">
+			<label for="fbrsn"><span class="field-name">Reason for contacting us</span> <strong>(required)</strong></label>
+			<select name="fbrsn" id="fbrsn" required="required">
+				<option value=""></option>
+				<option value="web">Critical problem with the website</option>
+				<option value="improvement">Suggested improvement for the website</option>
+				<option value="subject1">Question/comment about subject 1</option>
+				<option value="subject2">Question/comment about subject 2</option>
+				<option value="subject3">Question/comment about subject 3</option>
+				<option value="other">Other</option>
+			</select>
+			<label for="fbsbj"><span class="field-name">Subject</span></label>
+			<input type="text" id="fbsbj" name="fbsbj" size="45" maxlength="60" />
+			<label for="fbmsg"><span class="field-name">Message</span> <strong>(required)</strong></label>
+			<textarea id="fbmsg" name="fbmsg" rows="5" cols="45" required="required"></textarea>
+		</div>
+
+		<section id="fbweb">
+			<h2>Website Issues</h2>
+			<a class="wb-show-onfocus" href="#fbcntc">Skip to Contact Information</a>
+			<label for="fbpg"><span class="field-name">What page address (URL) or page description?</span></label>
+			<input type="text" id="fbpg" name="fbpg" size="80" maxlength="400" />
+			<label for="fbprb">What were you trying to do when you encountered the problem?</label>
+			<textarea id="fbprb" name="fbprb" rows="5" cols="45"></textarea>
+			<fieldset>
+				<legend>What were the problems?</legend>
+				<label for="fbq1"><input class="problems" type="checkbox" name="problems[]" id="fbq1" value="small font that can't be adjusted" /> small font that can't be adjusted</label>
+				<label for="fbq2"><input class="problems" type="checkbox" name="problems[]" id="fbq2" value="poor colour contrast" /> poor colour contrast</label>
+				<label for="fbq3"><input class="problems" type="checkbox" name="problems[]" id="fbq3" value="unclear information, typos or poor grammar" /> unclear information, typos or poor grammar</label>
+				<label for="fbq4"><input class="problems" type="checkbox" name="problems[]" id="fbq4" value="acronym or jargon not explained" /> acronym or jargon not explained</label>
+				<label for="fbq5"><input class="problems" type="checkbox" name="problems[]" id="fbq5" value="confusing search results" /> confusing search results</label>
+				<label for="fbq6"><input class="problems" type="checkbox" name="problems[]" id="fbq6" value="poor keyboard navigation" /> poor keyboard navigation</label>
+				<label for="fbq7"><input class="problems" type="checkbox" name="problems[]" id="fbq7" value="some elements are too small to click on" /> some elements are too small to click on</label>
+				<label for="fbq8"><input class="problems" type="checkbox" name="problems[]" id="fbq8" value="images with no text alternative provided" /> images with no text alternative provided</label>
+				<label for="fbq9"><input class="problems" type="checkbox" name="problems[]" id="fbq9" value="multimedia without captions or text equivalent" /> multimedia without captions or text equivalent</label>
+				<label for="fbq10"><input class="problems" type="checkbox" name="problems[]" id="fbq10" value="moving or flashing object that can’t be controlled" /> moving or flashing object that can’t be controlled</label>
+				<label for="fbq11"><input class="problems" type="checkbox" name="problems[]" id="fbq11" value="incomplete or non-existent page (for example, “Page not found” error)" /> incomplete or non-existent page (for example, “Page not found” error)</label>
+				<label for="fbq12"><input class="problems" type="checkbox" name="problems[]" id="fbq12" value="error notification is confusing or no error notification" /> error notification is confusing or no error notification</label>
+				<label for="fbop">other problem</label>
+				<input class="problems" type="text" id="fbop" name="fbop" size="45" maxlength="60" />
+			</fieldset>
+
+			<label for="fbaxs">How were you accessing the Web site today?</label>
+			<select name="fbaxs" id="fbaxs">
+				<option value="desktop">Desktop computer</option>
+				<option value="laptop">Laptop</option>
+				<option value="mobile">Mobile device</option>
+			</select>
+
+			<section id="fbcomp">
+				<h3>Desktop &amp; Laptop Information</h3>
+				<fieldset>
+					<legend>Please include the version and other clarifying details</legend>
+					<label for="fbos">Operating System</label>
+					<input type="text" id="fbos" name="fbos" size="20" maxlength="100" />
+					<label for="fbdbrwsr">Browser</label>
+					<input type="text" id="fbdbrwsr" name="fbdbrwsr" size="20" maxlength="100" />
+					<label for="fbdaad">Adaptive or assistive device</label>
+					<input type="text" id="fbdaad" name="fbdaad" size="20" maxlength="100" />
+				</fieldset>
+			</section>
+
+			<section id="fbmob">
+				<h3>Mobile Information</h3>
+				<fieldset>
+					<legend>Please include the version and other clarifying details</legend>
+					<label for="fbsphn">Smartphone type</label>
+					<input type="text" id="fbsphn" name="fbsphn" size="20" maxlength="100" />
+					<label for="fbmbrwsr">Browser</label>
+					<input type="text" id="fbmbrwsr" name="fbmbrwsr" size="20" maxlength="100" />
+					<label for="fbmaad">Adaptive or assistive device</label>
+					<input type="text" id="fbmaad" name="fbmaad" size="20" maxlength="100" />
+				</fieldset>
+			</section>
+		</section>
+
+		<section id="fbcntc">
+			<h2 class="wb-inv">Follow-up</h2>
+			<label for="fbcntc1"><input type="checkbox" name="fbcntc1" id="fbcntc1" value="yes" /> Please contact me if you require further details.</label>
+			<label for="fbcntc2"><input type="checkbox" name="fbcntc2" id="fbcntc2" value="yes" /> Send me a response.</label>
+
+			<section id="fbinfo">
+				<h3>Contact Information</h3>
+				<fieldset>
+					<legend>Please provide information that we could use to contact you</legend>
+					<label for="fbnm"><span class="field-name">Name</span></label>
+					<input type="text" id="fbnm" name="fbnm" size="45" maxlength="45" pattern=".{2,}" data-rule-minlength="2" />
+					<label for="fbeml"><span class="field-name">E-mail address</span> <strong>(required)</strong></label>
+					<input type="fbeml" id="fbeml" name="fbeml" size="45" maxlength="60" required="required" />
+					<label for="fbhphn"><span class="field-name">Home phone number</span> including area code (for example, 999-999-9999)</label>
+					<input type="tel" id="fbhphn" name="fbhphn" size="12" maxlength="12" data-rule-phoneUS="true" />
+					<label for="fbwphn"><span class="field-name">Work phone number</span> including area code (for example, 999-999-9999)</label>
+					<input type="tel" id="fbwphn" name="fbwphn" size="12" maxlength="12" data-rule-phoneUS="true" />
+					<label for="fbwphnxt"><span class="field-name">Work phone number extension</span></label>
+					<input type="text" id="fbwphnxt" name="fbwphnxt" size="8" maxlength="8" />
+				</fieldset>
+			</section>
+		</section>
+
+		<input type="submit" name="fbsbmt" id="fbsbmt" value="Submit feedback" class="btn btn-primary" /> <input type="reset" value="Reset" class="btn btn-default" />
+	</form>
+
+	<section>
+		<h2 id="pics-ecrp">Personal Information Collection Statement</h2>
+		<p>All personal information created, held or collected by this department is protected under the <a href="http://laws-lois.justice.gc.ca/eng/acts/P-21/index.html" rel="external"><em>Privacy Act</em></a>. This means that you will be informed of the purpose for which it is being collected and how to exercise your right of access to that information. You will be asked for your consent where appropriate.</p>
+		<section>
+			<h3 id="pc-cp">Public Communications</h3>
+			<p>Provision of the information requested on this form is voluntary. The personal information you include in an inquiry may be used to prepare a reply. The personal information is collected pursuant to the <em class="highlight">[appropriate provision in department’s enabling statute]</em>. Such information may be used for statistical, evaluation and reporting purposes. The information is included in the personal information bank <em class="highlight">[<abbr title="personal information bank">PIB</abbr> Number - <abbr title="personal information bank">PIB</abbr> Title]</em>. The information may be shared with programs and activities of <em class="highlight">[Applied Title of the Department]</em> should your inquiry pertain to a specific program or activity of the department. In such cases, the information is included in the personal information bank of the program or activity.</p>
+			<p>The transmission of this information is not secure so sensitive personal information, such as your Social Insurance Number, should not be included in your message.</p>
+			<p>If after reading this statement, you prefer not to submit your inquiry via the Internet, you may use one of the following methods:</p>
+			<address>
+				<dl id="osc-avs">
+					<dt><strong>By Telephone:</strong></dt>
+					<dd><em>[telephone number]</em></dd>
+					<dt><strong>By Mail:</strong></dt>
+					<dd><em>[mailing address]</em></dd>
+					<dt><strong>In Person at:</strong></dt>
+					<dd><em>[building address]</em></dd>
+					<dt><strong>Teletypewriter:</strong></dt>
+					<dd><em>[teletypewriter number]</em></dd>
+				</dl>
+			</address>
+		</section>
+		<section>
+			<h3 id="pi-divp">Privacy inquiry</h3>
+			<p>Any questions, comments, concerns or complaints regarding the administration of the <em><a href="http://laws-lois.justice.gc.ca/eng/acts/P-21/index.html" rel="external">Privacy Act</a></em> and privacy policies may be directed to the departmental Privacy Coordinator by email to <em class="highlight">[Privacy Coordinator email]</em>, by calling <em class="highlight">[Privacy Coordinator phone number]</em> or writing to:</p>
+			<p><em class="highlight">[Privacy Coordinator mailing address]</em></p>
+			<p>If you are not satisfied with our response to your privacy concern, you may wish to contact the <a href="http://www.priv.gc.ca/index_e.cfm" rel="external">Office of the Privacy Commissioner</a> by e-mail at <a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a> or by telephone at 1-800-282-1376.</p>
+		</section>
+	</section>
+</div>
+
+<div class="nojs-show">
+	<p>You may use one of the following methods to contact us:</p>
+	<address>
+		<dl>
+			<dt><strong>By E-mail:</strong></dt>
+			<dd><em>[e-mail address]</em></dd>
+			<dt><strong>By Telephone:</strong></dt>
+			<dd><em>[telephone number]</em></dd>
+			<dt><strong>By Mail:</strong></dt>
+			<dd><em>[mailing address]</em></dd>
+			<dt><strong>In Person at:</strong></dt>
+			<dd><em>[building address]</em></dd>
+			<dt><strong>Teletypewriter:</strong></dt>
+			<dd><em>[teletypewriter number]</em></dd>
+		</dl>
+	</address>
+</div>

--- a/site/pages/feedback-fr.hbs
+++ b/site/pages/feedback-fr.hbs
@@ -1,0 +1,168 @@
+---
+{
+	"title": "Formulaire de rétroaction",
+	"language": "fr",
+	"description": "Un formulaire normalisé pour soumettre une rétroaction au sujet d'une page ou d'un site Web particulier.",
+	"altLangPrefix": "feedback",
+	"breadcrumb": [
+		{ "title": "Accueil", "link": "http://canada.ca/fr/index.html" }
+	],
+	"css": "demos/feedback/demo/feedback",
+	"js": "demos/feedback/demo/feedback",
+	"dateModified": "2014-02-28"
+}
+---
+<div class="wb-formvalid wb-fdbck nojs-hide">
+		<p>Si vous avez des problèmes avec le formulaire suivant, vous pouvez utiliser une des <a href="#osc-avs">autres voies de service</a> pour communiquer avec nous. S'il vous plaît lire l'<a href="#pics-ecrp">énoncé de collecte de renseignements personnels</a> avant de compléter ce formulaire.</p>
+	<form action="#" method="get" id="fdbck-frm">
+		<input type="hidden" name="language" value="fr" />
+		<div id="type">
+			<label for="fbrsn"><span class="field-name">Raison pour communiquer avec nous</span> <strong>(obligatoire)</strong></label>
+			<select name="fbrsn" id="fbrsn" required="required">
+				<option value=""></option>
+				<option value="web">Problème critique avec le site Web</option>
+				<option value="improvement">Suggestion pour améliorer le site Web</option>
+				<option value="subject1">Question/commentaire sur sujet 1</option>
+				<option value="subject2">Question/commentaire sur sujet 2</option>
+				<option value="subject3">Question/commentaire sur sujet 3</option>
+				<option value="other">Autre</option>
+			</select>
+			<label for="fbsbj"><span class="field-name">Objet</span></label>
+			<input type="text" id="fbsbj" name="fbsbj" size="45" maxlength="60" />
+			<label for="fbmsg"><span class="field-name">Message</span> <strong>(obligatoire)</strong></label>
+			<textarea id="fbmsg" name="fbmsg" rows="5" cols="45" required="required"></textarea>
+		</div>
+
+		<section id="fbweb">
+			<h2>Problèmes avec le site Web</h2>
+			<a class="wb-show-onfocus" href="#fbcntc">Passer aux Coordonnées</a>
+			<label for="fbpg"><span class="field-name">Adresse de la page (URL) ou description de la page</span></label>
+			<input type="text" id="fbpg" name="fbpg" size="80" maxlength="400" />
+			<label for="fbprb">Que faisiez-vous lorsque le problème s'est produit?</label>
+			<textarea id="fbprb" name="fbprb" rows="5" cols="45"></textarea>
+			<fieldset>
+				<legend>Avez-vous connu les problèmes suivants?</legend>
+				<label for="fbq1"><input class="problems" type="checkbox" name="problems[]" id="fbq1" value="petite police qui ne peut pas être modifiée?" /> petite police qui ne peut pas être modifiée?</label>
+				<label for="fbq2"><input class="problems" type="checkbox" name="problems[]" id="fbq2" value="contraste de couleurs qui ne peut pas être ajusté?" /> contraste de couleurs qui ne peut pas être ajusté?</label>
+				<label for="fbq3"><input class="problems" type="checkbox" name="problems[]" id="fbq3" value="information incertaine, erreurs typographiques ou fautes de grammaire?" />information incertaine, erreurs typographiques ou fautes de grammaire?</label>
+				<label for="fbq4"><input class="problems" type="checkbox" name="problems[]" id="fbq4" value="acronyme ou jargon inexpliqué?" /> acronyme ou jargon inexpliqué?</label>
+				<label for="fbq5"><input class="problems" type="checkbox" name="problems[]" id="fbq5" value="résultats de recherche confus?" /> résultats de recherche confus?</label>
+				<label for="fbq6"><input class="problems" type="checkbox" name="problems[]" id="fbq6" value="navigation clavier de piètre qualité?" /> navigation clavier de piètre qualité?</label>
+				<label for="fbq7"><input class="problems" type="checkbox" name="problems[]" id="fbq7" value="certains éléments trop petits pour cliquer dessus?" /> certains éléments trop petits pour cliquer dessus?</label>
+				<label for="fbq8"><input class="problems" type="checkbox" name="problems[]" id="fbq8" value="images sans alternative texte?" /> images sans alternative texte?</label>
+				<label for="fbq9"><input class="problems" type="checkbox" name="problems[]" id="fbq9" value="multimédia sans sous-titre ou texte équivalent?" /> multimédia sans sous-titre ou texte équivalent?</label>
+				<label for="fbq10"><input class="problems" type="checkbox" name="problems[]" id="fbq10" value="objets qui se déplacent ou qui clignotent de façon incontrôlable?" /> objets qui se déplacent ou qui clignotent de façon incontrôlable?</label>
+				<label for="fbq11"><input class="problems" type="checkbox" name="problems[]" id="fbq11" value="page incomplète ou inexistante (p. ex.&#160;: erreur «&#160;Page ne peut être trouvée&#160;»)" /> page incomplète ou inexistante (<abbr title="par example">p. ex.</abbr>&#160;: erreur &#171;&#160;Page ne peut être trouvée&#160;&#187;)</label>
+				<label for="fbq12"><input class="problems" type="checkbox" name="problems[]" id="fbq12" value="message d'erreur confus ou manquant?" /> message d'erreur confus ou manquant?</label>
+				<label for="fbop">autre problème</label>
+				<input class="problems" type="text" id="fbop" name="fbop" size="45" maxlength="60" />
+			</fieldset>
+
+			<label for="fbaxs">Comment avez-vous accédé au site Web aujourd'hui?</label>
+			<select name="fbaxs" id="fbaxs">
+				<option value="desktop">Ordinateur de bureau</option>
+				<option value="laptop">Ordinateur portable</option>
+				<option value="mobile">Appareil sans fil</option>
+			</select>
+
+			<section id="fbcomp">
+				<h3>Information sur l'ordinateur de bureau et l'ordinateur portable</h3>
+				<fieldset>
+					<legend>Veuillez préciser la version et d'autres détails</legend>
+					<label for="fbos">Système d'exploitation</label>
+					<input type="text" id="fbos" name="fbos" size="20" maxlength="100" />
+					<label for="fbdbrwsr">Navigateur</label>
+					<input type="text" id="fbdbrwsr" name="fbdbrwsr" size="20" maxlength="100" />
+					<label for="fbdaad">Matériel adapté/fonctionnel</label>
+					<input type="text" id="fbdaad" name="fbdaad" size="20" maxlength="100" />
+				</fieldset>
+			</section>
+
+			<section id="fbmob">
+				<h3>Information sur l'appareil sans fil</h3>
+				<fieldset>
+					<legend>Veuillez préciser la version et d'autres détails</legend>
+					<label for="fbsphn">Type Smartphone</label>
+					<input type="text" id="fbsphn" name="fbsphn" size="20" maxlength="100" />
+					<label for="fbmbrwsr">Navigateur</label>
+					<input type="text" id="fbmbrwsr" name="fbmbrwsr" size="20" maxlength="100" />
+					<label for="fbmaad">Matériel adapté où fonctionnel</label>
+					<input type="text" id="fbmaad" name="fbmaad" size="20" maxlength="100" />
+				</fieldset>
+			</section>
+		</section>
+
+		<section id="fbcntc">
+			<h2 class="wb-inv">Suivi</h2>
+			<label for="fbcntc1"><input type="checkbox" name="fbcntc1" id="fbcntc1" value="yes" /> Veuillez communiquer avec moi si vous avez besoin de plus amples renseignements.</label>
+			<label for="fbcntc2"><input type="checkbox" name="fbcntc2" id="fbcntc2" value="yes" /> Veuillez me fournir une réponse.</label>
+
+			<section id="fbinfo">
+				<h3>Coordonnées</h3>
+				<fieldset>
+					<legend>Veuillez fournir des renseignements qui pourraient servir à vous joindre</legend>
+					<label for="fbnm"><span class="field-name">Nom</span></label>
+					<input type="text" id="fbnm" name="fbnm" size="45" maxlength="45" pattern=".{2,}" data-rule-minlength="2" />
+					<label for="fbeml"><span class="field-name">Adresse de courriel</span> <strong>(obligatoire)</strong></label>
+					<input type="fbeml" id="fbeml" name="fbeml" size="45" maxlength="60" required="required" />
+					<label for="fbhphn"><span class="field-name">Numéro de téléphone à domicile</span>, y compris l'indicatif régional (<abbr title="par example">p. ex.</abbr>&#160;: 123-456-7890)</label>
+					<input type="tel" id="fbhphn" name="fbhphn" size="12" maxlength="12" data-rule-phoneUS="true" />
+					<label for="fbwphn"><span class="field-name">Numéro de téléphone au travail</span>, y compris l'indicatif régional (<abbr title="par example">p. ex.</abbr>&#160;: 123-456-7890)</label>
+					<input type="tel" id="fbwphn" name="fbwphn" size="12" maxlength="12" data-rule-phoneUS="true" />
+					<label for="fbwphnxt"><span class="field-name">Numéro du poste au travail</span></label>
+					<input type="text" id="fbwphnxt" name="fbwphnxt" size="8" maxlength="8" />
+				</fieldset>
+			</section>
+		</section>
+
+		<input type="submit" name="fbsbmt" id="fbsbmt" value="Soumettre la rétroaction" class="btn btn-primary" /> <input type="reset" value="Réinitialiser" class="btn btn-default" />
+	</form>
+
+	<section>
+		<h2 id="pics-ecrp">Énoncé de collecte de renseignements personnels</h2>
+		<p>Tous les renseignements personnels créés, recueillis ou conservés par le ministère sont protégés par la <em><a href="http://laws-lois.justice.gc.ca/fra/lois/P-21/index.html" rel="external">Loi sur la protection des renseignements personnels</a></em>. Cela signifie qu’on vous informera des fins auxquelles ces renseignements sont recueillis et de la façon dont vous pouvez exercer votre droit d'accès à ces renseignements. Le cas échéant, on vous demandera d’exprimer votre consentement par rapport à ces renseignements.</p>
+		<section>
+			<h3 id="pc-cp">Communications publiques</h3>
+			<p>Les renseignements personnels que vous fournissez dans une demande d’informations peuvent être utilisés pour préparer une réponse. Ces renseignements personnels sont recueillis conformément à la <em class="highlight">[disposition pertinente de la loi habilitante du ministère]</em>. Ces renseignements peuvent être utilisés à des fins d’évaluation, de compilation de statistiques et d’établissement de rapports. Ces informations sont versées dans le fichier de renseignements personnels <em class="highlight">[Numéro du <abbr title="fichier de renseignements personnels">FRP</abbr> - Titre du <abbr title="fichier de renseignements personnels">FRP</abbr>]</em>. Il se peut que ces renseignements soient communiqués aux services responsables des programmes et des activités de <em class="highlight">[Titre d’usage du ministère]</em> si votre demande porte sur les programmes ou les activités de ce ministère. Dans ces cas, ces renseignements sont compris dans le fichier de renseignements personnels du service responsable du programme ou de l’activité.</p>
+			<p>La transmission de ces renseignements n'est pas protégée. Vous ne devriez donc pas inclure de renseignements personnels de nature délicate, comme votre numéro d'assurance sociale, dans votre message.</p>
+			<p>Si, après avoir lu cet avis, vous préférez ne pas présenter votre demande d'information par Internet, veuillez utiliser l’une des autres méthodes précisées ci-dessous.</p>
+			<address>
+				<dl id="osc-avs">
+					<dt><strong>Par téléphone&#160;:</strong></dt>
+					<dd><em class="highlight">[numéro de téléphone]</em></dd>
+					<dt><strong>Par la poste&#160;:</strong></dt>
+					<dd><em class="highlight">[adresse postale]</em></dd>
+					<dt><strong>En personne&#160;:</strong></dt>
+					<dd><em class="highlight">[adresse de l'édifice]</em></dd>
+					<dt><strong>Téléimprimeur&#160;:</strong></dt>
+					<dd><em class="highlight">[numéro de téléimprimeur]</em></dd>
+				</dl>
+			</address>
+		</section>
+
+		<section>
+			<h3 id="pi-divp">Demande d’informations sur la vie privée</h3>
+			<p>Si vous avez une question, un commentaire, une préoccupation ou une plainte au sujet de l’application de la <em><a href="http://laws-lois.justice.gc.ca/fra/lois/P-21/index.html" rel="external">Loi sur la protection des renseignements personnels</a></em> et des politiques connexes, veuillez communiquer avec le coordonnateur ministériel de la protection des renseignements personnels par courriel, à <em class="highlight">[Courriel du coordonnateur de la protection des renseignements personnels]</em> par téléphone, au <em class="highlight">[Numéro de téléphone du coordonnateur de la protection des renseignements personnels]</em> ou en écrivant à&#160;:</p>
+			<p><em class="highlight">[Adresse postale du coordonnateur de la protection des renseignements personnels]</em>.</p>
+			<p>Si vous n'êtes pas satisfait(e) de notre réponse à l'égard de vos préoccupations au sujet de la protection de vos renseignements personnels, vous pouvez communiquer le <a href="http://www.priv.gc.ca/index_f.cfm" rel="external">Commissariat à la protection de la vie privée du Canada</a> par courriel, à&#160;: <a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a> ou par téléphone, au 1-800-282-1376.</p>
+		</section>
+	</section>
+</div>
+
+<div class="nojs-show">
+	<p>Veuillez utiliser une des méthodes précisées ci-dessous pour communiquer avec nous&#160;:</p>
+	<address>
+		<dl>
+			<dt><strong>Par courriel&#160;:</strong></dt>
+			<dd><em class="highlight">[adresse de courriel]</em></dd>
+			<dt><strong>Par téléphone&#160;:</strong></dt>
+			<dd><em class="highlight">[numéro de téléphone]</em></dd>
+			<dt><strong>Par la poste&#160;:</strong></dt>
+			<dd><em class="highlight">[adresse postale]</em></dd>
+			<dt><strong>En personne&#160;:</strong></dt>
+			<dd><em class="highlight">[adresse de l'édifice]</em></dd>
+			<dt><strong>Téléimprimeur&#160;:</strong></dt>
+			<dd><em class="highlight">[numéro de téléimprimeur]</em></dd>
+		</dl>
+	</address>
+</div>

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -7,7 +7,7 @@
 		{ "title": "Home", "link": false }
 	],
 	"tag": "GCWeb",
-	"dateModified": "2014-02-19",
+	"dateModified": "2014-02-28",
 	"share": "false"
 }
 ---
@@ -20,6 +20,7 @@
 		<li><a href="video-en.html">Video content page</a></li>
 		<li><a href="mobile-centre/index-en.html">Mobile centre</a></li>
 		<li><a href="social-media-centre/index-en.html">Social media centre</a></li>
+		<li><a href="feedback-en.html">Feedback form</a></li>
 		<li><a href="index.html">Splash page</a></li>
 	</ul>
 </section>
@@ -33,6 +34,7 @@
 		<li><a href="video-fr.html">Video content page</a></li>
 		<li><a href="mobile-centre/index-fr.html">Mobile centre</a></li>
 		<li><a href="social-media-centre/index-fr.html">Social media centre</a></li>
+		<li><a href="feedback-en.html">Feedback form</a></li>
 		<li><a href="index.html">Splash page</a></li>
 	</ul>
 </section>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -7,7 +7,7 @@
 		{ "title": "Accueil", "link": false}
 	],
 	"tag": "GCWeb",
-	"dateModified": "2014-02-19",
+	"dateModified": "2014-02-28",
 	"share": "false"
 }
 ---
@@ -20,6 +20,7 @@
 		<li><a href="video-en.html">Page de contenu vidéo</a></li>
 		<li><a href="mobile-centre/index-en.html">Centre mobile</a></li>
 		<li><a href="social-media-centre/index-en.html">Centre des médias sociaux</a></li>
+		<li><a href="feedback-fr.html">Formulaire de rétroaction</a></li>
 		<li><a href="index.html">Page d'entrée</a></li>
 	</ul>
 </section>
@@ -33,6 +34,7 @@
 		<li><a href="video-fr.html">Page de contenu vidéo</a></li>
 		<li><a href="mobile-centre/index-en.html">Centre mobile</a></li>
 		<li><a href="social-media-centre/index-en.html">Centre des médias sociaux</a></li>
+		<li><a href="feedback-fr.html">Formulaire de rétroaction</a></li>
 		<li><a href="index.html">Page d'entrée</a></li>
 	</ul>
 </section>


### PR DESCRIPTION
Note that the Feedback form has been separated out from core (so CSS and JS is now separate like archiving) and was generecized in core (GC specific notices removed). The GC specific notices have instead been added to GCWU and GCWeb theme-specific implementations.
