### PR TITLE
Moved SCSS placeholders to file root

### DIFF
--- a/src/sass/parts/_secMenu.scss
+++ b/src/sass/parts/_secMenu.scss
@@ -2,6 +2,10 @@
  Secondary Navigation
 */
 
+%secmenu-canada-theme-menuitem-curr-hover-focus {
+	background-color: darken($menu-background, 50%);
+	color: lighten($menu-colour, 75%);
+}
 .wb-sec {
 	margin-top: 20px;
 	padding-bottom: 2em;
@@ -14,10 +18,6 @@
 				border-radius: 0;
 				margin-top: -1px;
 				text-decoration: none;
-				%secmenu-canada-theme-menuitem-curr-hover-focus {
-					background-color: darken($menu-background, 50%);
-					color: lighten($menu-colour, 75%);
-				}
 				&.wb-navcurr {
 					@extend %secmenu-canada-theme-menuitem-curr-hover-focus;
 				}


### PR DESCRIPTION
A recent version bump for node-sass seems to cause nested placeholders to be ignored.
