### PR TITLE
added spacing for definition list items DT DD

### DIFF
--- a/src/sass/_defaults.scss
+++ b/src/sass/_defaults.scss
@@ -102,6 +102,14 @@ caption {
 	font-weight: bold;
 }
 
+dt {
+	margin-bottom: 3px;
+}
+
+dd {
+	margin-bottom: 15px;
+}
+
 //Related site links before the footer features and after the main
 aside {
 	&.site-related {


### PR DESCRIPTION
@thomasgohard and @pjackson28: what do you think about making this change in the base instead of the theme? It adds more space between the `dl` items.

http://www.canada.ca/en/gov/ministers/index.html
