### PR TITLE
Enabled secondary menu to work without the a element on the top header

### DIFF
--- a/site/includes/secondarymenu-en.hbs
+++ b/site/includes/secondarymenu-en.hbs
@@ -1,6 +1,6 @@
 <ul class="list-group menu list-unstyled">
 	<li>
-		<h3><a class="wb-navcurr">{{title}}</a></h3>
+		<h3 class="wb-navcurr">{{{title}}}</h3>
 		<ul class="list-group menu list-unstyled">
 			<li><a class="list-group-item" href="http://www.canada.ca/en/services/jobs/find.html">Find a job</a></li>
 			<li><a class="list-group-item" href="http://www.canada.ca/en/services/jobs/training.html">Training</a></li>

--- a/site/includes/secondarymenu-fr.hbs
+++ b/site/includes/secondarymenu-fr.hbs
@@ -1,6 +1,6 @@
 <ul class="list-group menu list-unstyled">
 	<li>
-		<h3><a class="wb-navcurr">{{title}}</a></h3>
+		<h3 class="wb-navcurr">{{{title}}}</h3>
 		<ul class="list-group menu list-unstyled">
 			<li><a class="list-group-item" href="http://www.canada.ca/fr/services/emplois/trouver.html">Trouver un emploi</a></li>
 			<li><a class="list-group-item" href="http://www.canada.ca/fr/services/emplois/formation.html">Formation</a></li>

--- a/src/sass/parts/_secMenu.scss
+++ b/src/sass/parts/_secMenu.scss
@@ -16,10 +16,10 @@
 		border-bottom: 3px solid #666;
 		margin: 0;
 		padding: 15px;
+		font-size: 1em;
 
 		a {
 			color: #333;
-			font-size: 0.8em;
 			text-decoration: none;
 		}
 	}


### PR DESCRIPTION
Note that the old way will continue to work as well so this is non-breaking.
