### PR TITLE
Build: Add htmllint exclusions for ajax menus

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -484,11 +484,12 @@ module.exports = (grunt) ->
 					ignore: [
 						"XHTML element “head” is missing a required instance of child element “title”."
 						"The “details” element is not supported properly by browsers yet. It would probably be better to wait for implementations."
+						"The value of attribute “title” on element “a” from namespace “http://www.w3.org/1999/xhtml” is not in Unicode Normalization Form C." #required for vietnamese translations
+						"Text run is not in Unicode Normalization Form C." #required for vietnamese translations
 					]
 				src: [
 					"dist/unmin/ajax/**/*.html"
 					"dist/unmin/demos/menu/demo/*.html"
-
 				]
 			ajaxFragments:
 				options:


### PR DESCRIPTION
Required now that upstream is generating the menu in multiple languages.
