### PR TITLE
Replaced GC signature link aria-label with text hidden by wb-inv (non-breaking markup change)

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,10 +1,9 @@
 {{#unless experimental}}
 	<div class="brand col-xs-8 col-sm-9 col-md-6">
-		<a href="http://www.canada.ca/{{language}}/index.html"><object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/assets/sig-blk-{{language}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}}"></object>
-		</a>
+		<a href="http://www.canada.ca/{{language}}/index.html"><object type="image/svg+xml" tabindex="-1" data="{{assets}}/assets/sig-blk-{{language}}.svg"></object><span class="wb-inv"> {{{i18n "tmpl-gc-sig"}}}</span></a>
 	</div>
 {{else}}
 	<div class="brand col-xs-6">
-		<a href="http://www.canada.ca/{{language}}/index.html"><i class="cndwrdmrk"><span class="wb-inv">{{{i18n "tmpl-gc-wmms"}}}</span></i></a>
+		<a href="http://www.canada.ca/{{language}}/index.html"><span class="cndwrdmrk"><span class="wb-inv"> {{{i18n "tmpl-gc-wmms"}}}</span></span></a>
 	</div>
 {{/unless}}


### PR DESCRIPTION
Read better by old screen readers and prevents newer screen readers from reading the text twice

@masterbee fyi
