### PR TITLE
Limit SCSS linting to the src and theme folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
   - scripts/setup
 
 script:
-  - scss-lint .
+  - scss-lint src site
   - grunt && ./scripts/travis_artifacts.sh


### PR DESCRIPTION
Prevents running SCSS lint on dependencies
