### PR TITLE
Footer: remove img-responsive class in the footer images

### DIFF
--- a/site/includes/footer-en.hbs
+++ b/site/includes/footer-en.hbs
@@ -45,14 +45,14 @@
 <div class="col-sm-3 col-lg-3 brdr-lft">
 	<section>
 		<h3>Feedback</h3>
-		<p><a href="http://www.canada.ca/en/contact/feedback.html"><img src="{{assets}}/assets/feedback.png" class="img-responsive" alt="Feedback about this Web site" /></a></p>
+		<p><a href="http://www.canada.ca/en/contact/feedback.html"><img src="{{assets}}/assets/feedback.png" alt="Feedback about this Web site" /></a></p>
 	</section>
 	<section>
 		<h3>Social media</h3>
-		<p><a href="http://www.canada.ca/en/social/index.html"><img src="{{assets}}/assets/social.png" alt="Social media" class="img-responsive" /></a></p>
+		<p><a href="http://www.canada.ca/en/social/index.html"><img src="{{assets}}/assets/social.png" alt="Social media" /></a></p>
 	</section>
 	<section>
 		<h3>Mobile centre</h3>
-		<p><a href="http://www.canada.ca/en/mobile/index.html"><img src="{{assets}}/assets/mobile.png" alt="Mobile centre" class="img-responsive" /></a></p>
+		<p><a href="http://www.canada.ca/en/mobile/index.html"><img src="{{assets}}/assets/mobile.png" alt="Mobile centre" /></a></p>
 	</section>
 </div>

--- a/site/includes/footer-fr.hbs
+++ b/site/includes/footer-fr.hbs
@@ -45,14 +45,14 @@
 <div class="col-sm-3 col-lg-3 brdr-lft">
 	<section>
 		<h3>Rétroaction</h3>
-		<p><a href="http://www.canada.ca/fr/contact/retroaction.html"><img src="{{assets}}/assets/feedback.png" class="img-responsive" alt="Rétroaction sur ce site Web" /></a></p>
+		<p><a href="http://www.canada.ca/fr/contact/retroaction.html"><img src="{{assets}}/assets/feedback.png" alt="Rétroaction sur ce site Web" /></a></p>
 	</section>
 	<section>
 		<h3>Médias sociaux</h3>
-		<p><a href="http://www.canada.ca/fr/sociaux/index.html"><img src="{{assets}}/assets/social.png" class="img-responsive" alt="Médias sociaux" /></a></p>
+		<p><a href="http://www.canada.ca/fr/sociaux/index.html"><img src="{{assets}}/assets/social.png" alt="Médias sociaux" /></a></p>
 	</section>
 	<section>
 		<h3>Centre mobile</h3>
-		<p><a href="http://www.canada.ca/fr/mobile/index.html"><img src="{{assets}}/assets/mobile.png" class="img-responsive" alt="Centre mobile" /></a></p>
+		<p><a href="http://www.canada.ca/fr/mobile/index.html"><img src="{{assets}}/assets/mobile.png" alt="Centre mobile" /></a></p>
 	</section>
 </div>


### PR DESCRIPTION
Fixes: #793 
The `class="img-responsive"` didn't do anything in latest browsers because the images were always smaller than the containing box. Although in IE8 it made the image's width 100% of the container which is why it was larger in IE8. Fixed it even though we no longer support IE8.
