### PR TITLE
[Print CSS] Removed top margin for page title.

### DIFF
--- a/src/views/_print.scss
+++ b/src/views/_print.scss
@@ -14,3 +14,7 @@
 .glyphicon {
 	@extend %gcweb-print-display-none-important;
 }
+
+h1 {
+	margin-top: 0;
+}


### PR DESCRIPTION
To reduce the amount of space taken up by the document header when printing.
