### PR TITLE
[Print CSS] Set the print CSS for the page header elements.

### DIFF
--- a/src/views/_print.scss
+++ b/src/views/_print.scss
@@ -15,6 +15,26 @@
 	@extend %gcweb-print-display-none-important;
 }
 
+#wb-lng,
+#wb-glb-mn,
+#wb-srch,
+#wb-sm {
+	@extend %gcweb-print-display-none-important;
+}
+
+
+header {
+	.brand {
+		margin-bottom: 0;
+	}
+}
+
+#wb-bc {
+	.breadcrumb {
+		padding-top: 0;
+	}
+}
+
 h1 {
 	margin-top: 0;
 }


### PR DESCRIPTION
To reduce the amount of space taken up by the document header when printing and ensure interactive elements (e.g., search, menus, language toggle) are not printed.

This is a continuation of #813.
