### PR TITLE
Secondary menu: Fix hover issue for contrast ratio on GCWeb theme.

### DIFF
--- a/src/secondary-menu/_base.scss
+++ b/src/secondary-menu/_base.scss
@@ -3,7 +3,7 @@
 */
 
 %secmenu-canada-theme-menuitem-curr-hover-focus {
-	background-color: darken($menu-background, 50%);
+	background-color: darken($menu-background, 60%);
 	color: lighten($menu-colour, 75%);
 }
 


### PR DESCRIPTION
Contrast ratio fails at 3.0:1, fixed to 60% and achieves 5.7:1.