### PR TITLE
CSS: Added missing unit measurement for H1 margin-top property.

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -42,7 +42,7 @@ h1 {
 	border-bottom: 1px solid $border-red;
 	font-size: 34px;
 	margin-bottom: 0.2em;
-	margin-top: 1.25;
+	margin-top: 1.25em;
 	padding-bottom: 0.2em;
 }
 


### PR DESCRIPTION
Prevents Firefox from sometimes misinterpreting 1.25 as 1.25px. That kind of unit-less measurement is normally ignored by browsers.