### PR TITLE
Menu: Replaced minus hyphens with en dashes in "– More/Autres" links.

### DIFF
--- a/site/includes/fullmenu-en.hbs
+++ b/site/includes/fullmenu-en.hbs
@@ -40,7 +40,7 @@
 					<li><a href="http://travel.gc.ca/returning">Returning to Canada</a></li>
 					<li><a href="http://travel.gc.ca/assistance">Assistance abroad</a></li>
 					<li><a href="http://travel.gc.ca/stay-connected">Stay connected</a></li>
-					<li class="slflnk"><a href="http://travel.gc.ca">Travel - More</a></li>
+					<li class="slflnk"><a href="http://travel.gc.ca">Travel – More</a></li>
 				</ul>
 			</li>
 			<li><a href="#business" class="item">Business</a>
@@ -65,7 +65,7 @@
 					<li><a href="http://www.canada.ca/en/services/benefits/education/index.html">Education and training</a></li>
 					<li><a href="http://www.canada.ca/en/services/benefits/housing.html">Housing benefits</a></li>
 					<li><a href="http://www.canada.ca/en/services/benefits/disability/index.html">Disability benefits</a></li>
-					<li class="slflnk"><a href="http://www.canada.ca/en/services/benefits/index.html">Benefits - More</a></li>
+					<li class="slflnk"><a href="http://www.canada.ca/en/services/benefits/index.html">Benefits – More</a></li>
 				</ul>
 			</li>
 			<li><a href="#health" class="item">Health</a>
@@ -87,7 +87,7 @@
 					<li><a href="http://www.canada.ca/en/services/taxes/businesses/index.html">Businesses</a></li>
 					<li><a href="http://www.canada.ca/en/services/taxes/representatives/index.html">Representatives and tax professionals</a></li>
 					<li><a href="http://www.canada.ca/en/services/taxes/charities/index.html">Charities and giving</a></li>			
-					<li class="slflnk"><a href="http://www.canada.ca/en/services/taxes/index.html">Taxes - More</a></li>
+					<li class="slflnk"><a href="http://www.canada.ca/en/services/taxes/index.html">Taxes – More</a></li>
 				</ul>
 			</li>
 			<li><a href="#more-services" class="item">More services</a>

--- a/site/includes/fullmenu-fr.hbs
+++ b/site/includes/fullmenu-fr.hbs
@@ -65,7 +65,7 @@
 					<li><a href="http://www.canada.ca/fr/services/prestations/etudes/index.html">Études et formation</a></li>
 					<li><a href="http://www.canada.ca/fr/services/prestations/logement.html">Prestations relatives au logement</a></li>
 					<li><a href="http://www.canada.ca/fr/services/prestations/handicap/index.html">Prestations relatives aux personnes handicapées</a></li>
-					<li class="slflnk"><a href="http://www.canada.ca/fr/services/prestations/index.html">Prestations - Autres</a></li>
+					<li class="slflnk"><a href="http://www.canada.ca/fr/services/prestations/index.html">Prestations – Autres</a></li>
 				</ul>
 			</li>
 			<li><a href="#sante" class="item">Santé</a>
@@ -87,7 +87,7 @@
 					<li><a href="http://www.canada.ca/fr/services/impots/entreprises/index.html">Entreprises</a></li>
 					<li><a href="http://www.canada.ca/fr/services/impots/representants/index.html">Représentants et professionnels d'impôts</a></li>
 					<li><a href="http://www.canada.ca/fr/services/impots/bienfaisance/index.html">Organismes de bienfaisance et dons</a></li>					
-					<li class="slflnk"><a href="http://www.canada.ca/fr/services/impots/index.html">Impôt - Autres</a></li>					
+					<li class="slflnk"><a href="http://www.canada.ca/fr/services/impots/index.html">Impôt – Autres</a></li>					
 				</ul>
 			</li>
 			<li><a href="#autres-services" class="item">Autres services</a>


### PR DESCRIPTION
This ensures that en dashes are used consistently across all of those kinds of links. Previously, a mix of minus hyphens and en dash characters were used.