### PR TITLE
Site: Fixed sectioning issues in Ministerial profile page.

### DIFF
--- a/site/pages/ministerial-en.hbs
+++ b/site/pages/ministerial-en.hbs
@@ -41,7 +41,7 @@
 					<small><time>2014-01-01 08:45</time> - Type of news product</small>
 					<p>Brief description of the news item.</p>
 				</div>
-				<section class="col-md-6 pull-right">
+				<div class="col-md-6 pull-right">
 					<ul class="list-unstyled lst-spcd">
 						<li>
 							<a href="#">[Title of announcement made by the Minister, URL embedded]</a><br />
@@ -61,7 +61,7 @@
 						</li>
 					</ul>
 					<p class="text-right"><strong><a href="#">All news</a></strong></p>
-				</section>
+				</div>
 			</div>
 		</section>
 	</div>
@@ -70,13 +70,15 @@
 		<p><strong>Minister of <a href="#">[Portfolio #1 name]</a></strong></p>
 		<p><strong>Minister of <a href="#">[Portfolio #2 name]</a></strong></p>
 		<p>Represents the riding of <a href="#">[riding name]</a></p>
-		<h2 class="h5">Contact information</h2>
-		<p>[<a href="mailto:">first.last@canada.ca</a>]<br />
-		House of Commons<br />
-		Ottawa, Ontario<br />
-		K1A 0A6<br />
-		Telephone: 123-456-7890<br />
-		Fax: 123-456-7890</p>
+		<section>
+			<h2 class="h5">Contact information</h2>
+			<p>[<a href="mailto:">first.last@canada.ca</a>]<br />
+			House of Commons<br />
+			Ottawa, Ontario<br />
+			K1A 0A6<br />
+			Telephone: 123-456-7890<br />
+			Fax: 123-456-7890</p>
+		</section>
 	</div>
 </div>
 <div class="clearfix"></div>

--- a/site/pages/ministerial-fr.hbs
+++ b/site/pages/ministerial-fr.hbs
@@ -41,7 +41,7 @@
 					<small><time>2014-01-01 08:45</time> - Type of news product</small>
 					<p>Brief description of the news item.</p>
 				</div>
-				<section class="col-md-6 pull-right">
+				<div class="col-md-6 pull-right">
 					<ul class="list-unstyled lst-spcd">
 						<li>
 							<a href="#">[Titre de l’annonce faite par le ministre, contenant une adresse URL]</a><br />
@@ -61,7 +61,7 @@
 						</li>
 					</ul>
 					<p class="text-right"><strong><a href="#">Toutes les nouvelles</a></strong></p>
-				</section>
+				</div>
 			</div>
 		</section>
 	</div>
@@ -70,13 +70,15 @@
 		<p><strong>Ministre de <a href="#">[nom du portefeuille no1]</a></strong></p>
 		<p><strong>Ministre de <a href="#">[nom du portefeuille no2]</a></strong></p>
 		<p>Représente la circonscription de <a href="#">[nom de la circonscription]</a></p>
-		<h2 class="h5">Coordonnées</h2>
-		<p>[<a href="mailto:">prénom.nom@canada.ca</a>]<br />
-		Chambre des communes<br />
-		Ottawa (Ontario)<br />
-		K1A 0A6<br />
-		Téléphone : 123-456-7890<br />
-		Télécopieur : 123-456-7890</p>
+		<section>
+			<h2 class="h5">Coordonnées</h2>
+			<p>[<a href="mailto:">prénom.nom@canada.ca</a>]<br />
+			Chambre des communes<br />
+			Ottawa (Ontario)<br />
+			K1A 0A6<br />
+			Téléphone : 123-456-7890<br />
+			Télécopieur : 123-456-7890</p>
+		</section>
 	</div>
 </div>
 <div class="clearfix"></div>


### PR DESCRIPTION
* Added a ``<section>`` element around the "Contact information" heading and its associated content.
* Replaced a hollow ``<section>`` with a ``<div>`` in the "Recent announcements" section. Prevents HTML 5.1 validation warnings about heading-less sections.