### PR TITLE
DO NOT MERGE disabled selector format for SCSS-Lint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -30,3 +30,5 @@ linters:
     enabled: false
   NestingDepth:
     enabled: false
+  SelectorFormat:
+    enabled: false


### PR DESCRIPTION
_wrapper is added to classes and we are styling that in theme.css, need to allow _underscores in selector names

https://github.com/brigade/scss-lint/blob/master/config/default.yml#L158