### PR TITLE
Theme: Removed body font-weight property from CSS.

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -5,7 +5,6 @@ body {
 	background: #f8f8f8;
 	font-family: Helvetica, Arial, sans-serif;
 	font-size: 16px;
-	font-weight: 300;
 }
 
 a {


### PR DESCRIPTION
Makes GCWeb consistent with other WET themes in this respect. As a result, table THs now appear bolded in IE8-11 (in line with every other browser).

Fixes #1040 and resolves wet-boew/wet-boew#7170.

@masterbee I noticed you originally introduced ``font-weight: 300;`` via commit c2723ef. Would you have any concerns with my PR removing it? From what I can tell, its removal doesn't change anything at all in other browsers. Just makes tables less strange-looking in IE :).