### PR TITLE
Advanced service initiation pages: Added clear left classes to ToC links.

### DIFF
--- a/site/pages/advancedservice/index-en.hbs
+++ b/site/pages/advancedservice/index-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"next": [ { "title": "2. [Step name]", "link": "page2-en.html" } ]
 }
@@ -22,9 +22,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="index-en.html">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/index-fr.hbs
+++ b/site/pages/advancedservice/index-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"next": [ { "title": "2. [Nom de l'étape]", "link": "page2-fr.html" } ]
 }
@@ -22,9 +22,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="index-fr.html">1. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de l'étape]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page2-en.hbs
+++ b/site/pages/advancedservice/page2-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "1. [Step name]", "link": "index-en.html" } ],
 	"next": [ { "title": "3. [Step name]", "link": "page3-en.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page2-en.html">{{secondTitle}}</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-en.html">4. Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-en.html">5. Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. Step name]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page2-fr.hbs
+++ b/site/pages/advancedservice/page2-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "1. [Nom de l'étape]", "link": "index-fr.html" } ],
 	"next": [ { "title": "3. [Nom de l'étape]", "link": "page3-fr.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page2-fr.html">2. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de l'étape]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page3-en.hbs
+++ b/site/pages/advancedservice/page3-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "2. [Step name]", "link": "page2-en.html" } ],
 	"next": [ { "title": "4. [Step name]", "link": "page4-en.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page3-en.html">{{secondTitle}}</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page3-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page3-fr.hbs
+++ b/site/pages/advancedservice/page3-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "2. [Nom de l'étape]", "link": "page2-fr.html" } ],
 	"next": [ { "title": "4. [Nom de l'étape]", "link": "page4-fr.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page3-fr.html">3. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page3-fr.html">3. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de l'étape]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page4-en.hbs
+++ b/site/pages/advancedservice/page4-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "3. [Step name]", "link": "page3-en.html" } ],
 	"next": [ { "title": "5. [Step name]", "link": "page5-en.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page4-en.html">{{secondTitle}}</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active" href="page4-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page4-fr.hbs
+++ b/site/pages/advancedservice/page4-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "3. [Nom de l'étape]", "link": "page3-fr.html" } ],
 	"next": [ { "title": "5. [Nom de l'étape]", "link": "page5-fr.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page4-fr.html">4. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active" href="page4-fr.html">4. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de l'étape]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page5-en.hbs
+++ b/site/pages/advancedservice/page5-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "4. [Step name]", "link": "page4-en.html" } ],
 	"next": [ { "title": "6. [Step name]", "link": "page6-en.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page5-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page5-en.html">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page5-fr.hbs
+++ b/site/pages/advancedservice/page5-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "4. [Nom de l'étape]", "link": "page4-fr.html" } ],
 	"next": [ { "title": "6. [Nom de l'étape]", "link": "page6-fr.html" } ]
@@ -23,9 +23,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page5-fr.html">5. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page5-fr.html">5. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de l'étape]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page6-en.hbs
+++ b/site/pages/advancedservice/page6-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "5. [Step name]", "link": "page5-en.html" } ]
 }
@@ -22,9 +22,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page6-en.html">{{secondTitle}}</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page6-fr.hbs
+++ b/site/pages/advancedservice/page6-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-23",
+	"dateModified": "2016-03-16",
 	"share": "true",
 	"previous": [ { "title": "5. [Nom de l'étape]", "link": "page5-fr.html" } ]
 }
@@ -22,9 +22,9 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de l'étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de l'étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page6-fr.html">6. [Nom de l'étape]</a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
Prevents broken layouts when one or more ToC links contain significantly longer step names than the others.

I've provided some screenshots below to show off the scenarios this PR fixes...

**1)**
**Small view - before:**
![1_advancedservice_sm_before](https://cloud.githubusercontent.com/assets/1907279/13813762/b362e866-eb59-11e5-8d5e-7a3f26e80cd1.png)

**Small view - after:**
![2_advancedservice_sm_after](https://cloud.githubusercontent.com/assets/1907279/13813770/b9db7d0c-eb59-11e5-8ef5-1cea144749a5.png)

**2)**
**Medium view - before:**
![3_advancedservice_md_before](https://cloud.githubusercontent.com/assets/1907279/13813789/ca0d53da-eb59-11e5-8f20-38abe777abd0.png)

**Medium view - after:**
![4_advancedservice_md_after](https://cloud.githubusercontent.com/assets/1907279/13813802/d0efcce6-eb59-11e5-9143-dd02270d9d70.png)
