### PR TITLE
Theme: Hid GC activities and initiatives in print view.

### DIFF
--- a/src/ie8-theme.scss
+++ b/src/ie8-theme.scss
@@ -143,6 +143,7 @@
 	@import "footer/print";
 	@import "menu/print";
 	@import "promo/print";
+	@import "priorities/print";
 	@import "search/print";
 	@import "secondary-menu/print";
 	@import "share/print";

--- a/src/priorities/_print.scss
+++ b/src/priorities/_print.scss
@@ -1,0 +1,7 @@
+/*
+ * Priorities (Government of Canada activities and initiatives) (print view)
+ */
+
+.gc-nttvs {
+	display: none;
+}

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -148,6 +148,7 @@
 	@import "views/print";
 	@import "footer/print";
 	@import "menu/print";
+	@import "priorities/print";
 	@import "promo/print";
 	@import "search/print";
 	@import "secondary-menu/print";


### PR DESCRIPTION
Reasoning:

* It's not main content (it's outside the ``<main>`` element). If anyone wants to print out a particular activity/initiative, in practice the odds are high that they'd click the link to it in their browser to open up that item's dedicated page, then print that out.
* It usually adds 1-2 extra pages when printing (depending on how many items are used).
* Its current print layout looks broken. If a given activity/initiative splits across pages, it looks really strange and creates large empty gaps of space.

CC @nicolasraymond @shawnthompson