### PR TITLE
Theme: Prevent fonts folder's .scss file from getting copied into dist.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -203,7 +203,10 @@ module.exports = (grunt) ->
 			fonts:
 				expand: true
 				cwd: "src/fonts"
-				src: "**/*.*"
+				src: [
+					"**/*.*"
+					"!**/*.scss"
+				]
 				dest: "<%= themeDist %>/fonts"
 			deploy:
 				files: [


### PR DESCRIPTION
When running ``grunt`` or ``grunt dist`` in GCWeb, ``src/fonts/_base.scss`` currently gets copied into ``dist/fonts/_base.scss``. That file is also present in GCWeb 4.21's release package. This PR will prevent it from getting copied in the first place.

@LaurentGoderre @nschonni @shawnthompson FYI.