### PR TITLE
Secondary menu: Hid secondary menu in print SCSS.

### DIFF
--- a/src/secondary-menu/_print.scss
+++ b/src/secondary-menu/_print.scss
@@ -1,6 +1,6 @@
 /*
  Secondary menu (print view)
 */
-#gc-sec {
+#wb-sec {
 	@extend %gcweb-print-display-none-important;
 }


### PR DESCRIPTION
It was originally hidden prior to #1058 (dc150a9059f461e38c081b65675c077e0c96b47f). One of its changes renamed #wb-sec to #gc-sec in secondary-menu/_print.scss. But #gc-sec doesn't exist, which resulted in the secondary menu becoming unveiled when printing. This commit renames it back to #wb-sec.

Fixes #1204.

CC @rlambert27 @karinne @shawnthompson