### PR TITLE
i18n: Removed French "tmpl-about-site" variable.

### DIFF
--- a/site/data/i18n/fr.json
+++ b/site/data/i18n/fr.json
@@ -9,7 +9,6 @@
 	"tmpl-gc-ca": "Canada.gc.ca",
 	"tmpl-toppage": "Haut de la page",
 	"tmpl-share-page": "Partager cette page",
-	"tmpl-about-site": "À propos du site",
 	"tmpl-about-government": "Au sujet du gouvernement",
 	"tmpl-features": "Activités et initiatives du gouvernement du Canada",
 	"dlg-close": "Fermez la boîte de dialogue",


### PR DESCRIPTION
GCWeb doesn't contain an English version of that variable. Both variables already exist in wet-boew and are inherited from it when building GCWeb.