### PR TITLE
Corporate information includes: Simplified div/section markup.

### DIFF
--- a/site/includes/corp-info-roles.hbs
+++ b/site/includes/corp-info-roles.hbs
@@ -1,4 +1,4 @@
-<section>
+<section class="col-md-4">
 	<h3>{{{i18n "corp-info-job"}}}</h3>
 	{{>corp-info-figure}}
 </section>

--- a/site/includes/corp-info.hbs
+++ b/site/includes/corp-info.hbs
@@ -14,20 +14,12 @@
 		</div>
 		<div class="col-md-8">
 			<div class="row">
-				<div class="col-md-4">
-					{{>corp-info-roles}}
-				</div>
+				{{>corp-info-roles}}
 			{{#is page.pageType "institution"}}
-				<div class="col-md-4">
-					{{>corp-info-roles}}
-				</div>
-				<div class="col-md-4">
-					{{>corp-info-roles}}
-				</div>
+				{{>corp-info-roles}}
+				{{>corp-info-roles}}
 				<div class="clearfix"><!-- after every third section --></div>
-				<div class="col-md-4">
-					{{>corp-info-roles}}
-				</div>
+				{{>corp-info-roles}}
 			{{/is}}
 			</div>
 		</div>


### PR DESCRIPTION
Div elements using a class="col-md-4" attribute were previously wrapped around each role's section element. Since there's only one section for each div, the div elements aren't necessary.

This commit removes the divs in question and moves their class attributes onto the sections themselves.