### PR TITLE
Advanced service initiation pages: Changed ToC's current page links into placeholder ones.

### DIFF
--- a/site/pages/advancedservice/index-en.hbs
+++ b/site/pages/advancedservice/index-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"next": [ { "title": "2. [Step name / section page]", "link": "page2-en.html" } ],
 	"pageType": "advance service"
@@ -22,7 +22,7 @@
 <div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="index-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item active">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step / section page name]</a></li>

--- a/site/pages/advancedservice/index-fr.hbs
+++ b/site/pages/advancedservice/index-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"next": [ { "title": "2. [Nom de la page de la section ou de l’étape]", "link": "page2-fr.html" } ]
 }
@@ -21,7 +21,7 @@
 <div class="mrgn-tp-md brdr-bttm">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item active">1. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page2-en.hbs
+++ b/site/pages/advancedservice/page2-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "1. [Step / section page name]", "link": "index-en.html" } ],
 	"next": [ { "title": "3. [Step / section page name]", "link": "page3-en.html" } ]
@@ -23,7 +23,7 @@
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step / section page name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page2-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item active">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step / section page name]</a></li>

--- a/site/pages/advancedservice/page2-fr.hbs
+++ b/site/pages/advancedservice/page2-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "1. [Nom de la page de la section ou de l’étape]", "link": "index-fr.html" } ],
 	"next": [ { "title": "3. [Nom de la page de la section ou de l’étape]", "link": "page3-fr.html" } ]
@@ -23,7 +23,7 @@
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item active">2. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page3-en.hbs
+++ b/site/pages/advancedservice/page3-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "2. [Step name / section page]", "link": "page2-en.html" } ],
 	"next": [ { "title": "4. [Step name / section page]", "link": "page4-en.html" } ]
@@ -24,7 +24,7 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page3-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name / section page]</a></li>

--- a/site/pages/advancedservice/page3-fr.hbs
+++ b/site/pages/advancedservice/page3-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "2. [Nom de la page de la section ou de l’étape]", "link": "page2-fr.html" } ],
 	"next": [ { "title": "4. [Nom de la page de la section ou de l’étape]", "link": "page4-fr.html" } ]
@@ -24,7 +24,7 @@
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">3. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page4-en.hbs
+++ b/site/pages/advancedservice/page4-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "3. [Step name / section page]", "link": "page3-en.html" } ],
 	"next": [ { "title": "5. [Step name / section page]", "link": "page5-en.html" } ]
@@ -25,7 +25,7 @@
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active" href="page4-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name / section page]</a></li>
 		</ul>

--- a/site/pages/advancedservice/page4-fr.hbs
+++ b/site/pages/advancedservice/page4-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "3. [Nom de la page de la section ou de l’étape]", "link": "page3-fr.html" } ],
 	"next": [ { "title": "5. [Nom de la page de la section ou de l’étape]", "link": "page5-fr.html" } ]
@@ -25,7 +25,7 @@
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">4. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de la page de la section ou de l’étape]</a></li>
 		</ul>

--- a/site/pages/advancedservice/page5-en.hbs
+++ b/site/pages/advancedservice/page5-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "4. [Step name / section page]", "link": "page4-en.html" } ],
 	"next": [ { "title": "6. [Step name / section page]", "link": "page6-en.html" } ]
@@ -26,7 +26,7 @@
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page5-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">{{secondTitle}}</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name / section page]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page5-fr.hbs
+++ b/site/pages/advancedservice/page5-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "4. [Nom de la page de la section ou de l’étape ]", "link": "page4-fr.html" } ],
 	"next": [ { "title": "6. [Nom de la page de la section ou de l’étape ]", "link": "page6-fr.html" } ]
@@ -26,7 +26,7 @@
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape ]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape ]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape ]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active" href="page5-fr.html">5. [Nom de la page de la section ou de l’étape ]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. [Nom de la page de la section ou de l’étape ]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de la page de la section ou de l’étape ]</a></li>
 		</ul>
 	</div>

--- a/site/pages/advancedservice/page6-en.hbs
+++ b/site/pages/advancedservice/page6-en.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Service name]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "5. [Step name / section page]", "link": "page5-en.html" } ]
 }
@@ -26,7 +26,7 @@
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name / section page]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page6-en.html">{{secondTitle}}</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item active">{{secondTitle}}</a></li>
 		</ul>
 	</div>
 </div>

--- a/site/pages/advancedservice/page6-fr.hbs
+++ b/site/pages/advancedservice/page6-fr.hbs
@@ -11,7 +11,7 @@
 		{ "title": "[Nom du service]", "link": "#" }
 	],
 	"secondlevel": false,
-	"dateModified": "2016-11-04",
+	"dateModified": "2017-04-07",
 	"share": "true",
 	"previous": [ { "title": "5. [Nom de la page de la section ou de l’étape]", "link": "page5-fr.html" } ]
 }
@@ -26,7 +26,7 @@
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-fr.html">5. [Nom de la page de la section ou de l’étape]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="page6-fr.html">6. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item active">6. [Nom de la page de la section ou de l’étape]</a></li>
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
The ToC's current page links use the "active" class to create a visual highlighting effect on them. However, apart from that class, those links were previously coded identically to all non-current links. Meaning visual design was being used to convey meaningful information without any supporting HTML markup.

This change removes the href attribute from current page links to give them a semantic meaning. The HTML spec considers a elements without href attributes to be placeholders for where links might've gone if they had been relevant.