### PR TITLE
Advanced service initiation pages: Updated ToC list's class in most pages.

### DIFF
--- a/site/pages/advancedservice/index-fr.hbs
+++ b/site/pages/advancedservice/index-fr.hbs
@@ -18,7 +18,7 @@
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page2-en.hbs
+++ b/site/pages/advancedservice/page2-en.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step / section page name]</a></li>

--- a/site/pages/advancedservice/page2-fr.hbs
+++ b/site/pages/advancedservice/page2-fr.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page3-en.hbs
+++ b/site/pages/advancedservice/page3-en.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>

--- a/site/pages/advancedservice/page3-fr.hbs
+++ b/site/pages/advancedservice/page3-fr.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page4-en.hbs
+++ b/site/pages/advancedservice/page4-en.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>

--- a/site/pages/advancedservice/page4-fr.hbs
+++ b/site/pages/advancedservice/page4-fr.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>

--- a/site/pages/advancedservice/page5-en.hbs
+++ b/site/pages/advancedservice/page5-en.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>

--- a/site/pages/advancedservice/page5-fr.hbs
+++ b/site/pages/advancedservice/page5-fr.hbs
@@ -19,7 +19,7 @@
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape ]</a></li>

--- a/site/pages/advancedservice/page6-en.hbs
+++ b/site/pages/advancedservice/page6-en.hbs
@@ -18,7 +18,7 @@
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>

--- a/site/pages/advancedservice/page6-fr.hbs
+++ b/site/pages/advancedservice/page6-fr.hbs
@@ -18,7 +18,7 @@
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
 
-<div class="mrgn-tp-md brdr-bttm">
+<div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
 			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>


### PR DESCRIPTION
The first English page's ToC uses a class called "gc-stp-stp", but its French counterpart and pages 2-6 were using "mrgn-tp-md brdr-bttm". As a result of that inconsistency, the top of the right panel was "sticking" against the ToC's bottom border in all of the latter pages.

This commit updates all affected pages' ToCs to use the "gc-stp-stp" class, which increases consistency and resolves the aforementioned spacing issue.