### PR TITLE
Advanced service initiation pages: Fixed content consistency issues.

### DIFF
--- a/site/pages/advancedservice/index-en.hbs
+++ b/site/pages/advancedservice/index-en.hbs
@@ -1,7 +1,7 @@
 ---
 {
 	"title": "[Service name] - 1. [Step / section page name]",
-	"secondTitle": "1. [Step name / section page]",
+	"secondTitle": "1. [Step / section page name]",
 	"language": "en",
 	"altLangPrefix": "index",
 	"breadcrumb": [
@@ -13,7 +13,7 @@
 	"secondlevel": false,
 	"dateModified": "2017-04-07",
 	"share": "true",
-	"next": [ { "title": "2. [Step name / section page]", "link": "page2-en.html" } ],
+	"next": [ { "title": "2. [Step / section page name]", "link": "page2-en.html" } ],
 	"pageType": "advance service"
 }
 ---
@@ -34,7 +34,7 @@
 <div class="row">
 	<section class="col-md-8">
 		<h2>{{secondTitle}}</h2>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et a adipisci nostrum optio dolorum sint ipsa facilis nisi quisquam laboriosam.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium odio adipisci ad neque distinctio quod molestias, molestiae accusamus quo aspernatur expedita blanditiis quam! Esse cum modi atque, beatae aliquam, dolor.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem aliquid hic numquam obcaecati ea, laborum accusamus culpa atque voluptate distinctio et omnis! Alias, beatae, tenetur.</p>
 		<section>

--- a/site/pages/advancedservice/page2-en.hbs
+++ b/site/pages/advancedservice/page2-en.hbs
@@ -27,14 +27,13 @@
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step / section page name]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step / section page name]</a></li>
 		</ul>
 	</div>
 </div>
 <div class="row">
 	<section class="col-md-8">
 		<h2>{{secondTitle}}</h2>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et a adipisci nostrum optio dolorum sint ipsa facilis nisi quisquam laboriosam.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium odio adipisci ad neque distinctio quod molestias, molestiae accusamus quo aspernatur expedita blanditiis quam! Esse cum modi atque, beatae aliquam, dolor.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem aliquid hic numquam obcaecati ea, laborum accusamus culpa atque voluptate distinctio et omnis! Alias, beatae, tenetur.</p>

--- a/site/pages/advancedservice/page3-en.hbs
+++ b/site/pages/advancedservice/page3-en.hbs
@@ -1,7 +1,7 @@
 ---
 {
-	"title": "[Service name] - 3. [Step name / section page]",
-	"secondTitle": "3. [Step name / section page]",
+	"title": "[Service name] - 3. [Step / section page name]",
+	"secondTitle": "3. [Step / section page name]",
 	"language": "en",
 	"altLangPrefix": "page3",
 	"breadcrumb": [
@@ -13,8 +13,8 @@
 	"secondlevel": false,
 	"dateModified": "2017-04-07",
 	"share": "true",
-	"previous": [ { "title": "2. [Step name / section page]", "link": "page2-en.html" } ],
-	"next": [ { "title": "4. [Step name / section page]", "link": "page4-en.html" } ]
+	"previous": [ { "title": "2. [Step / section page name]", "link": "page2-en.html" } ],
+	"next": [ { "title": "4. [Step / section page name]", "link": "page4-en.html" } ]
 }
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
@@ -22,19 +22,18 @@
 <div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">{{secondTitle}}</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step / section page name]</a></li>
 		</ul>
 	</div>
 </div>
 <div class="row">
 	<section class="col-md-8">
 		<h2>{{secondTitle}}</h2>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et a adipisci nostrum optio dolorum sint ipsa facilis nisi quisquam laboriosam.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium odio adipisci ad neque distinctio quod molestias, molestiae accusamus quo aspernatur expedita blanditiis quam! Esse cum modi atque, beatae aliquam, dolor.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem aliquid hic numquam obcaecati ea, laborum accusamus culpa atque voluptate distinctio et omnis! Alias, beatae, tenetur.</p>

--- a/site/pages/advancedservice/page4-en.hbs
+++ b/site/pages/advancedservice/page4-en.hbs
@@ -1,7 +1,7 @@
 ---
 {
-	"title": "[Service name] - 4. [Step name / section page]",
-	"secondTitle": "4. [Step name / section page]",
+	"title": "[Service name] - 4. [Step / section page name]",
+	"secondTitle": "4. [Step / section page name]",
 	"language": "en",
 	"altLangPrefix": "page4",
 	"breadcrumb": [
@@ -13,8 +13,8 @@
 	"secondlevel": false,
 	"dateModified": "2017-04-07",
 	"share": "true",
-	"previous": [ { "title": "3. [Step name / section page]", "link": "page3-en.html" } ],
-	"next": [ { "title": "5. [Step name / section page]", "link": "page5-en.html" } ]
+	"previous": [ { "title": "3. [Step / section page name]", "link": "page3-en.html" } ],
+	"next": [ { "title": "5. [Step / section page name]", "link": "page5-en.html" } ]
 }
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
@@ -22,19 +22,18 @@
 <div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item active">{{secondTitle}}</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step / section page name]</a></li>
 		</ul>
 	</div>
 </div>
 <div class="row">
 	<section class="col-md-8">
 		<h2>{{secondTitle}}</h2>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et a adipisci nostrum optio dolorum sint ipsa facilis nisi quisquam laboriosam.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium odio adipisci ad neque distinctio quod molestias, molestiae accusamus quo aspernatur expedita blanditiis quam! Esse cum modi atque, beatae aliquam, dolor.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem aliquid hic numquam obcaecati ea, laborum accusamus culpa atque voluptate distinctio et omnis! Alias, beatae, tenetur.</p>

--- a/site/pages/advancedservice/page5-en.hbs
+++ b/site/pages/advancedservice/page5-en.hbs
@@ -1,7 +1,7 @@
 ---
 {
-	"title": "[Service name] - 5. [Step name / section page]",
-	"secondTitle": "5. [Step name / section page]",
+	"title": "[Service name] - 5. [Step / section page name]",
+	"secondTitle": "5. [Step / section page name]",
 	"language": "en",
 	"altLangPrefix": "page5",
 	"breadcrumb": [
@@ -13,8 +13,8 @@
 	"secondlevel": false,
 	"dateModified": "2017-04-07",
 	"share": "true",
-	"previous": [ { "title": "4. [Step name / section page]", "link": "page4-en.html" } ],
-	"next": [ { "title": "6. [Step name / section page]", "link": "page6-en.html" } ]
+	"previous": [ { "title": "4. [Step / section page name]", "link": "page4-en.html" } ],
+	"next": [ { "title": "6. [Step / section page name]", "link": "page6-en.html" } ]
 }
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
@@ -22,19 +22,18 @@
 <div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">{{secondTitle}}</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-en.html">6. [Step / section page name]</a></li>
 		</ul>
 	</div>
 </div>
 <div class="row">
 	<section class="col-md-8">
 		<h2>{{secondTitle}}</h2>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et a adipisci nostrum optio dolorum sint ipsa facilis nisi quisquam laboriosam.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium odio adipisci ad neque distinctio quod molestias, molestiae accusamus quo aspernatur expedita blanditiis quam! Esse cum modi atque, beatae aliquam, dolor.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem aliquid hic numquam obcaecati ea, laborum accusamus culpa atque voluptate distinctio et omnis! Alias, beatae, tenetur.</p>

--- a/site/pages/advancedservice/page5-fr.hbs
+++ b/site/pages/advancedservice/page5-fr.hbs
@@ -1,7 +1,7 @@
 ---
 {
-	"title": "[Nom du service] - 5. [Nom de la page de la section ou de l’étape ]",
-	"secondTitle": "5. [Nom de la page de la section ou de l’étape ]",
+	"title": "[Nom du service] - 5. [Nom de la page de la section ou de l’étape]",
+	"secondTitle": "5. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPrefix": "page4",
 	"breadcrumb": [
@@ -13,8 +13,8 @@
 	"secondlevel": false,
 	"dateModified": "2017-04-07",
 	"share": "true",
-	"previous": [ { "title": "4. [Nom de la page de la section ou de l’étape ]", "link": "page4-fr.html" } ],
-	"next": [ { "title": "6. [Nom de la page de la section ou de l’étape ]", "link": "page6-fr.html" } ]
+	"previous": [ { "title": "4. [Nom de la page de la section ou de l’étape]", "link": "page4-fr.html" } ],
+	"next": [ { "title": "6. [Nom de la page de la section ou de l’étape]", "link": "page6-fr.html" } ]
 }
 ---
 <p class="gc-byline"><strong>De <a href="../institution-fr.html">[nom de l'institution]</a></strong></p>
@@ -22,12 +22,12 @@
 <div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape ]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape ]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape ]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape ]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. [Nom de la page de la section ou de l’étape ]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de la page de la section ou de l’étape ]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-fr.html">1. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-fr.html">2. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-fr.html">3. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-fr.html">4. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item active">5. [Nom de la page de la section ou de l’étape]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page6-fr.html">6. [Nom de la page de la section ou de l’étape]</a></li>
 		</ul>
 	</div>
 </div>

--- a/site/pages/advancedservice/page6-en.hbs
+++ b/site/pages/advancedservice/page6-en.hbs
@@ -1,7 +1,7 @@
 ---
 {
-	"title": "[Service name] - 6. [Step name / section page]",
-	"secondTitle": "6. [Step name / section page]",
+	"title": "[Service name] - 6. [Step / section page name]",
+	"secondTitle": "6. [Step / section page name]",
 	"language": "en",
 	"altLangPrefix": "page6",
 	"breadcrumb": [
@@ -13,7 +13,7 @@
 	"secondlevel": false,
 	"dateModified": "2017-04-07",
 	"share": "true",
-	"previous": [ { "title": "5. [Step name / section page]", "link": "page5-en.html" } ]
+	"previous": [ { "title": "5. [Step / section page name]", "link": "page5-en.html" } ]
 }
 ---
 <p class="gc-byline"><strong>From <a href="../institution-en.html">[Institution name]</a></strong></p>
@@ -21,11 +21,11 @@
 <div class="gc-stp-stp">
 	<div class="row">
 		<ul class="toc lst-spcd col-md-12">
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step name / section page]</a></li>
-			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step name / section page]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="index-en.html">1. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6"><a class="list-group-item" href="page2-en.html">2. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page3-en.html">3. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-md clr-lft-lg"><a class="list-group-item" href="page4-en.html">4. [Step / section page name]</a></li>
+			<li class="col-md-4 col-sm-6 clr-lft-sm"><a class="list-group-item" href="page5-en.html">5. [Step / section page name]</a></li>
 			<li class="col-md-4 col-sm-6"><a class="list-group-item active">{{secondTitle}}</a></li>
 		</ul>
 	</div>
@@ -33,7 +33,6 @@
 <div class="row">
 	<section class="col-md-8">
 		<h2>{{secondTitle}}</h2>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et a adipisci nostrum optio dolorum sint ipsa facilis nisi quisquam laboriosam.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium odio adipisci ad neque distinctio quod molestias, molestiae accusamus quo aspernatur expedita blanditiis quam! Esse cum modi atque, beatae aliquam, dolor.</p>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem aliquid hic numquam obcaecati ea, laborum accusamus culpa atque voluptate distinctio et omnis! Alias, beatae, tenetur.</p>


### PR DESCRIPTION
* Renamed all instances of "Step name / section page" to "Step / section page name" in the English versions of page 1 and pages 3-6.
* Revised first lorem ipsum paragraph in the English version of page 1 for consistency with its French counterpart.
* Removed first lorem ipsum paragraph from the English versions of pages 2-6 for consistency with their French counterparts.
* Added an opening bracket to the ToC's 6th list item in the English version of page 2.
* Removed a space prior to the closing bracket in all instances of "[Nom de la page de la section ou de l’étape ]" in the French version of page 5.