### PR TITLE
Theme: Fixed header FIP image's incomplete alt text.

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,6 +1,6 @@
 {{#unless experimental}}
 	<div class="brand col-xs-8 col-sm-9 col-md-6">
-		<a href="https://www.canada.ca/{{language}}.html"><object type="image/svg+xml" tabindex="-1" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg"></object><span class="wb-inv"> {{{i18n "tmpl-gc-sig"}}}</span></a>
+		<a href="https://www.canada.ca/{{language}}.html"><object type="image/svg+xml" tabindex="-1" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg"></object><span class="wb-inv"> {{{i18n "tmpl-gc-sig"}}} / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span></a>
 	</div>
 {{else}}
 	<div class="brand col-xs-6">

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -18,7 +18,7 @@
 		<header role="banner" id="wb-bnr" class="container">
 			<div class="row">
 				<div class="col-sm-6">
-					<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}}"></object>
+					<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}"></object>
 				</div>
 				<div class="col-sm-6">
 					<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>


### PR DESCRIPTION
A bilingual FIP image is situated in the top-right of all of GCWeb's pages. Until now, in all standard/server message page templates, the image's alt text was unilingual, which isn't an accurate representation of the text in the image.

This commit adds extra handlebars conditions to make the FIP's alt text bilingual depending on the current page language.

**PS:** The issue this PR fixes likely affects all pre-existing GCWeb implementations (e.g. Canada.ca, CDTS, web applications based on GCWeb, etc...).