### PR TITLE
Splash page: Replaced hardcoded text with relevant i18n variables.

### DIFF
--- a/site/pages/splashpage.hbs
+++ b/site/pages/splashpage.hbs
@@ -11,7 +11,7 @@
 	"subject-fr": "Gouvernement du Canada, services",
 	"language": "en",
 	"section": "message",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-05-04"
 }
 ---
 
@@ -20,27 +20,27 @@
 		<h1 property="name" class="wb-inv">{title}}</h1>
 		<div class="row">
 			<div class="col-xs-11 col-md-8">
-				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" aria-label="Government of Canada / Gouvernement du Canada"></object>
+				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" aria-label="{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}"></object>
 			</div>
 		</div>
 		<div class="row">
 			<section class="col-xs-6 text-right">
-				<h2 class="wb-inv">Government of Canada</h2>
-				<p><a href="./index-en.html" class="btn btn-primary">English</a></p>
+				<h2 class="wb-inv">{{{i18n "tmpl-gc-sig"}}}</h2>
+				<p><a href="./index-en.html" class="btn btn-primary">{{{i18n "lang-native"}}}</a></p>
 			</section>
 			<section class="col-xs-6" lang="fr">
-				<h2 class="wb-inv">Gouvernement du Canada</h2>
-				<p><a href="./index-fr.html" class="btn btn-primary">Français</a></p>
+				<h2 class="wb-inv">{{{i18n "tmpl-gc-sig" language="fr"}}}</h2>
+				<p><a href="./index-fr.html" class="btn btn-primary">{{{i18n "lang-native" language="fr"}}}</a></p>
 			</section>
 		</div>
 	</div>
 	<div class="sp-bx-bt col-xs-12">
 		<div class="row">
 			<div class="col-xs-7 col-md-8">
-				<a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">Terms & conditions</a> <span class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html" class="sp-lk" lang="fr">Avis</a>
+				<a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">{{{i18n "tmpl-terms"}}}</a> <span class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html" class="sp-lk" lang="fr">{{{i18n "tmpl-terms" language="fr"}}}</a>
 			</div>
 			<div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
-				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-spl.svg" width="127" aria-label="Symbol of the Government of Canada / Symbole du gouvernement du Canada"></object>
+				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-spl.svg" width="127" aria-label="{{{i18n "tmpl-gc-wmms"}}} / {{{i18n "tmpl-gc-wmms" language="fr"}}}"></object>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Affects the following strings:
* Government of Canada FIP alt text
* Language links
* Hidden Government of Canada headings
* Terms and conditions links (note: replaces "&" with "and" in English link)
* Canada wordmark alt text