### PR TITLE
Fieldflow - Improved list items selector and new config to prevent inserting required label

### DIFF
--- a/src/plugins/fieldflow/basic-en.hbs
+++ b/src/plugins/fieldflow/basic-en.hbs
@@ -357,6 +357,32 @@
 
 <p>Field flow plugin allow you several way to customize and specify how you want setup label of the generated control.</p>
 
+<h3>Prevent to auto-insert the "required" red label</h3>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{ "noreqlabel": true }'>
+	<p>Find the plugin for the action you need:</p>
+	<ul>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; <strong>data-wb-fieldflow='{ &quot;noreqlabel&quot;: true }'</strong>&gt;
+	&lt;p&gt;Find the plugin for the action you need:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
 <h3>Specify a quick label</h3>
 
 <p>By default Field flow will take all the content of the first element, usually a paragraph, but you can specify what text to use by wrapping content with <code>&lt;span class=&quot;wb-fieldflow-label&quot;&gt;...&lt;/span&gt;</code>. This should allow a better progressive enhencement integration by the interaction designer.</p>

--- a/src/plugins/fieldflow/basic-fr.hbs
+++ b/src/plugins/fieldflow/basic-fr.hbs
@@ -354,6 +354,32 @@
 
 <p>Le déroulement de champs permet de personalisé les étiquettes de plusieurs façons.</p>
 
+<h3>Empêcher l'ajout automatique de l'étiquette rouge "requis"</h3>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{ "noreqlabel": true }'>
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+	<ul>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; <strong>data-wb-fieldflow='{ &quot;noreqlabel&quot;: true }'</strong>&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
 <h3>Définir un étiquette</h3>
 
 <p>Par défaut tous le contenu du premier éléments, habituellement un paragraph, est utilisé. Par contre, vous pouvez spécifier le texte à utiliser en enveloppant une partie du contenu avec <code>&lt;span class=&quot;wb-fieldflow-label&quot;&gt;...&lt;/span&gt;</code>. Cela devrait vous permetre d'adopter une approche simpliste pour l'améliorartion progressive de votre contenu.</p>

--- a/src/plugins/fieldflow/fieldflow-doc-en.hbs
+++ b/src/plugins/fieldflow/fieldflow-doc-en.hbs
@@ -435,6 +435,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td>noreqlabel</td>
+				<td>Flag to not add the "required" red labeling during the field creation.</td>
+				<td><code>data-wb-fieldflow='{ &quot;noreqlabel&quot;: <em>true</em> }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>The labeling text "required" will be appended to the field label</dd>
+						<dt>true</dt>
+						<dd>There is no text appended to the field label</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
 				<td>ext <span class="label label-warning">Experimental</span></td>
 				<td>Specify the name of an fieldflow extension to allow to run his own initialisation.</td>
 				<td><code>data-wb-fieldflow='{&quot;ext&quot;: &quot;<em>[Extended plugin name]</em>&quot;}</code></td>

--- a/src/plugins/fieldflow/fieldflow-doc-en.hbs
+++ b/src/plugins/fieldflow/fieldflow-doc-en.hbs
@@ -422,6 +422,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td>itmselector</td>
+				<td>Specify what item to use to create fieldflow items.</td>
+				<td><code>data-wb-fieldflow='{ &quot;itmselector&quot;: &quot;<em>[jQuery selector]</em>&quot; }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Select all list items of the first unordered list. If an header block is specified, the selector will be applied after.</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> used to select the label.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
 				<td>ext <span class="label label-warning">Experimental</span></td>
 				<td>Specify the name of an fieldflow extension to allow to run his own initialisation.</td>
 				<td><code>data-wb-fieldflow='{&quot;ext&quot;: &quot;<em>[Extended plugin name]</em>&quot;}</code></td>

--- a/src/plugins/fieldflow/fieldflow-doc-fr.hbs
+++ b/src/plugins/fieldflow/fieldflow-doc-fr.hbs
@@ -425,6 +425,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td>itmselector</td>
+				<td>Specify what item to use to create fieldflow items.</td>
+				<td><code>data-wb-fieldflow='{ &quot;itmselector&quot;: &quot;<em>[jQuery selector]</em>&quot; }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Select all list items of the first unordered list. If an header block is specified, the selector will be applied after.</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> used to select the label.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
 				<td>ext <span class="label label-warning">Experimental</span></td>
 				<td>Specify the name of an fieldflow extension to allow to run his own initialisation.</td>
 				<td><code>data-wb-fieldflow='{&quot;ext&quot;: &quot;<em>[Extended plugin name]</em>&quot;}</code></td>

--- a/src/plugins/fieldflow/fieldflow-doc-fr.hbs
+++ b/src/plugins/fieldflow/fieldflow-doc-fr.hbs
@@ -438,6 +438,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td>noreqlabel</td>
+				<td>Flag to not add the "required" red labeling during the field creation.</td>
+				<td><code>data-wb-fieldflow='{ &quot;noreqlabel&quot;: <em>true</em> }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>The labeling text "required" will be appended to the field label</dd>
+						<dt>true</dt>
+						<dd>There is no text appended to the field label</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
 				<td>ext <span class="label label-warning">Experimental</span></td>
 				<td>Specify the name of an fieldflow extension to allow to run his own initialisation.</td>
 				<td><code>data-wb-fieldflow='{&quot;ext&quot;: &quot;<em>[Extended plugin name]</em>&quot;}</code></td>

--- a/src/plugins/fieldflow/fieldflow.js
+++ b/src/plugins/fieldflow/fieldflow.js
@@ -530,6 +530,7 @@ var componentName = "wb-fieldflow",
 				lblselector: labelSelector,
 				defaultselectedlabel: data.defaultselectedlabel,
 				required: !!!data.isoptional,
+				noreqlabel: data.noreqlabel,
 				items: $items,
 				inline: data.inline
 			} );
@@ -541,6 +542,7 @@ var componentName = "wb-fieldflow",
 			actions = data.actions,
 			lblselector = data.lblselector,
 			isReq = !!data.required,
+			useReqLabel = !!!data.noreqlabel,
 			items = data.items,
 			elm = event.target,
 			$elm = $( elm ),
@@ -556,7 +558,7 @@ var componentName = "wb-fieldflow",
 			i, i_len, j, j_len, cur_itm;
 
 		// Create the label
-		if ( isReq ) {
+		if ( isReq && useReqLabel ) {
 			labelPrefix += " class='required'";
 			labelSuffix += " <strong class='required'>(" + i18n.required + ")</strong>";
 		}
@@ -618,6 +620,7 @@ var componentName = "wb-fieldflow",
 			actions = data.actions,
 			lblselector = data.lblselector,
 			isReq = !!data.required,
+			useReqLabel = !!!data.noreqlabel,
 			items = data.items,
 			elm = event.target,
 			$elm = $( elm ),
@@ -646,7 +649,7 @@ var componentName = "wb-fieldflow",
 		$out = $( fieldsetHTML + "></fieldset>" );
 
 		// Create the legend
-		if ( isReq ) {
+		if ( isReq && useReqLabel ) {
 			fieldsetPrefix += " required";
 			fieldsetSuffix += " <strong class='required'>(" + i18n.required + ")</strong>";
 		}

--- a/src/plugins/fieldflow/fieldflow.js
+++ b/src/plugins/fieldflow/fieldflow.js
@@ -480,7 +480,7 @@ var componentName = "wb-fieldflow",
 				$labelExplicit, $firstChild,
 				labelSelector = data.lblselector || "." + labelClass,
 				labelTxt,
-				$items = getItemsData( $source.find( "ul:first() > li" ) ),
+				itmSelector = data.itmselector || "ul:first() > li", $items,
 				actions,
 				renderas;
 
@@ -512,7 +512,10 @@ var componentName = "wb-fieldflow",
 				labelSelector = null; // unset the label selector because it not needed for the control creation
 			} else {
 				labelTxt = $firstChild.html();
+				itmSelector = "." + headerClass + " + " + itmSelector;
 			}
+
+			$items = getItemsData( $source.find( itmSelector ) );
 
 			if ( !data.outputctnrid ) {
 				data.outputctnrid = data.provEvt.parentElement.id;


### PR DESCRIPTION
Live workinng example: http://universallabs.org/wet/labs/gcweb-PR1244/index-en.html

**Improved list items selector**
Improved list items selector to be configured and to be outside the header/labeling block.

It fix the following scenario where it's expected that the second unordered list (outside the header block) be used instead of the unordered list in the header block.

```html
<div class="wb-fieldflow">
	<div class="wb-fieldflow-header">
		<p>Some text before the label.</p>
		<p class="wb-fieldflow-label">The label</p>
		<p>Some text after the label.</p>
		<ul>
			<li data-wb-fieldflow="ajax/ajax-1.html">sss(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
			<li data-wb-fieldflow="ajax/ajax-2.html">sss(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
			<li data-wb-fieldflow="ajax/ajax-3.html">sss(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
			<li data-wb-fieldflow="ajax/ajax-4.html">sss(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
			<li data-wb-fieldflow="ajax/ajax-5.html">sss(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
		</ul>
	</div>
	<ul>
		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
	</ul>
</div>
```

**New config to prevent inserting required label**
New configuration with a working example that make the field required, but do not insert the "required" label next to it.