### PR TITLE
Theme: Fixed incorrect FIP alt text in arm's length institution pages.

### DIFF
--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -231,7 +231,6 @@
 	"service-right-panel-contact-heading": "Contact us",
 	"service-right-panel-contact-listitem": "Contact [Institution name] for help",
 	"arms-description": "We are a federal institution that is part of the [portfolio name] portfolio. We operate at arm’s length from the Government of Canada.",
-	"arms-image-alt": "Department name",
 	"comp-dwnld-title": "Document title",
 	"comp-dwnld-size-type": "MB",
 	"comp-dwnld-size-abbr": "Megabyte",

--- a/site/data/i18n/fr.json
+++ b/site/data/i18n/fr.json
@@ -232,7 +232,6 @@
 	"service-right-panel-contact-heading": "Contactez-nous",
 	"service-right-panel-contact-listitem": "Contact [nom de l'institution] pour l'aide",
 	"arms-description": "Nous sommes une institution fédérale qui fait partie du portefeuille de [nom du portefeuille]. Nous fonctionnons sans lien de dépendance avec le gouvernement du Canada.",
-	"arms-image-alt": "Nom du département",
 	"comp-dwnld-title": "Titre du document",
 	"comp-dwnld-size-type": "Mo",
 	"comp-dwnld-size-abbr": "mégaoctet",

--- a/site/includes/features.hbs
+++ b/site/includes/features.hbs
@@ -2,7 +2,7 @@
 {{#is page.armslength true}}
 	<div class="row mrgn-tp-lg">
 		<div class="col-sm-4 col-xs-10 col-sm-push-8 mrgn-bttm-lg">
-			<img class="img-responsive" alt="{{{i18n "arms-image-alt"}}}" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.png" />
+			<img class="img-responsive" alt="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.png" />
 		</div>
 		<div class="col-sm-8 col-sm-pull-4">
 			<p>{{{i18n "arms-description"}}}</p>

--- a/site/pages/institution-arms-en.hbs
+++ b/site/pages/institution-arms-en.hbs
@@ -8,7 +8,7 @@
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" },
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
-	"dateModified": "2014-10-24",
+	"dateModified": "2017-05-04",
 	"share": "true",
 	"armslength": true
 }
@@ -16,7 +16,7 @@
 
 <div class="row">
 	<div class="col-sm-5 col-xs-8 pull-right gc-rms-lngth">
-		<img class="img-responsive" alt="{{{i18n "arms-image-alt"}}}" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.png" />
+		<img class="img-responsive" alt="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.png" />
 	</div>
 	<div class="col-sm-7 pull-left">
 		<p>We are a federal institution that is part of the <a href="#">[portfolio name] portfolio</a>. We operate at arm’s length from the Government of Canada.</p>

--- a/site/pages/institution-arms-fr.hbs
+++ b/site/pages/institution-arms-fr.hbs
@@ -8,14 +8,14 @@
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" },
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
-	"dateModified": "2014-10-24",
+	"dateModified": "2017-05-04",
 	"share": "true",
 	"armslength": true
 }
 ---
 <div class="row">
 	<div class="col-sm-5 col-xs-8 pull-right gc-rms-lngth">
-		<img class="img-responsive" alt="{{{i18n "arms-image-alt"}}}" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.png" />
+		<img class="img-responsive" alt="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.png" />
 	</div>
 	<div class="col-sm-7 pull-left">
 		<p>Nous sommes une institution fédérale qui fait partie du portefeuille du <a href="#">[nom du portfolio]</a>. Nous fonctionnons sans lien de dépendance avec le gouvernement du Canada.</p>


### PR DESCRIPTION
The Government of Canada FIP is used as a sample image throughout arm's-length institution page templates. Until now, it was using "Department name"/"Nom du département" as alt text, which is incorrect.

This commit fixes it by removing the "arms-image-alt" i18n variable, replacing all references to it with "tmpl-gc-sig" and adding extra is/else logic to account for the fact that the FIP is bilingual.