### PR TITLE
Splash page: Fixed H1 heading's content.

### DIFF
--- a/site/pages/splashpage.hbs
+++ b/site/pages/splashpage.hbs
@@ -17,7 +17,7 @@
 
 <div class="sp-hb">
 	<div class="sp-bx col-xs-12">
-		<h1 property="name" class="wb-inv">{title}}</h1>
+		<h1 property="name" class="wb-inv">{{title}}</h1>
 		<div class="row">
 			<div class="col-xs-11 col-md-8">
 				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" aria-label="Government of Canada / Gouvernement du Canada"></object>


### PR DESCRIPTION
The H1 heading in question previously contained a broken handlebars expression, which caused "{title}}" to appear in generated splash pages.

This commit adds an extra opening bracket to allow the aforementioned expression to resolve to "Canada.ca".