### PR TITLE
Theme index: Revised link text to end with page languages.

### DIFF
--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -7,7 +7,7 @@
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" }
 	],
 	"tag": "GCWeb",
-	"dateModified": "2017-05-04",
+	"dateModified": "2017-05-12",
 	"share": "true"
 }
 ---
@@ -15,51 +15,51 @@
 	<h2>English</h2>
 	<div class="row"><div class="col-md-8">
 	<ul>
-		<li><a href="home-en.html">Home page</a></li>
-		<li><a href="theme-en.html">Theme landing page</a></li>
-		<li><a href="topic-en.html">Topic landing page</a></li>
-		<li><a href="institution-en.html">Institutional profile for large institutions</a></li>
-		<li><a href="institution-arms-en.html">Institutional profile for arm’s-length institutions</a></li>
-		<li><a href="institution-small-en.html">Institutional profile for small institutions</a></li>
-		<li><a href="content-en.html">Content page</a></li>
-		<li><a href="content-signedoff-en.html">Content page - Signed Off</a></li>
-		<li><a href="content-signedon-en.html">Content page - Signed On</a></li>
-		<li><a href="components-en.html">Components page</a></li>
-		<li><a href="video-en.html">Video content page</a></li>
-		<li><a href="feedback-en.html">Feedback form</a></li>
-		<li><a href="widgets-en.html">Widget page</a></li>
-		<li><a href="localnav/task1/index-en.html">Section menu examples</a></li>
-		<li><a href="splashpage.html">Splash page</a></li>
-		<li><a href="servermessage-en.html">Server message page</a></li>
-		<li><a href="servermessage-en-fr.html">Server message page (English/French)</a></li>
-		<li><a href="campaign-en.html">Campaign</a></li>
-		<li><a href="event-en.html">Event</a></li>
-		<li><a href="service-en.html">Simple service initiation landing page</a></li>
-		<li><a href="advancedservice/index-en.html">Advanced service initiation pages</a></li>
-		<li><a href="dept-en.html">Departments and agencies</a></li>
-		<li><a href="ministerial-en.html">Ministerial profile</a></li>
-		<li><a href="act-en.html">Acts</a></li>
-		<li><a href="regulations-en.html">Regulations</a></li>
-		<li><a href="topic-lowest-en.html">Lowest level topic page</a></li>
-		<li><a href="organizational-en.html">Organizational profile</a></li>
-		<li><a href="organizational-carousel-en.html">Organizational profile with carousel</a></li>
-		<li><a href="archived-en.html">Archived page</a></li>
-		<li><a href="404-en.html">404 error page</a></li>
-		<li><a href="404-en-fr.html">404 error page (English/French)</a></li>
+		<li><a href="home-en.html">Home page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="theme-en.html">Theme landing page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="topic-en.html">Topic landing page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="institution-en.html">Institutional profile for large institutions<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="institution-arms-en.html">Institutional profile for arm’s-length institutions<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="institution-small-en.html">Institutional profile for small institutions<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="content-en.html">Content page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="content-signedoff-en.html">Content page - Signed Off<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="content-signedon-en.html">Content page - Signed On<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="components-en.html">Components page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="video-en.html">Video content page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="feedback-en.html">Feedback form<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="widgets-en.html">Widget page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="localnav/task1/index-en.html">Section menu examples<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="splashpage.html">Splash page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="servermessage-en.html">Server message page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="servermessage-en-fr.html">Server message page - English/French</a></li>
+		<li><a href="campaign-en.html">Campaign<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="event-en.html">Event<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="service-en.html">Simple service initiation landing page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="advancedservice/index-en.html">Advanced service initiation pages<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="dept-en.html">Departments and agencies<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="ministerial-en.html">Ministerial profile<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="act-en.html">Acts<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="regulations-en.html">Regulations<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="topic-lowest-en.html">Lowest level topic page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="organizational-en.html">Organizational profile<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="organizational-carousel-en.html">Organizational profile with carousel<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="archived-en.html">Archived page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="404-en.html">404 error page<span class="wb-inv"> - {{i18n "lang-en"}}</span></a></li>
+		<li><a href="404-en-fr.html">404 error page - English/French</a></li>
 	</ul>
 	</div><div class="col-md-4">
 		<section>
 			<h3>Themes plugins</h3>
 			<ul>
-				<li><a href="demos/data-json/data-json-en.html">Data JSON</a> (<a href="demos/data-json/data-json-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/data-json/template-en.html">Template HTML5</a> (<a href="demos/data-json/data-json-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/jsonmanager/jsonmanager-en.html">JSON Manager</a> (<a href="demos/jsonmanager/jsonmanager-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/tblfilter-en.html">URL Mapping - Table filtering</a> (<a href="demos/urlmapping/urlmapping-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/ajax-en.html">URL Mapping - Ajax</a> (<a href="demos/urlmapping/urlmapping-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/patches-en.html">URL Mapping - Patching JSON</a> (<a href="demos/urlmapping/urlmapping-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/fieldflow-en.html">Field flow</a> (<a href="demos/fieldflow/fieldflow-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/basic-en.html">Field flow basic configuration</a> (<a href="demos/fieldflow/fieldflow-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/advanced-en.html">Field flow advanced</a> (<a href="demos/fieldflow/fieldflow-doc-en.html">Documentation</a>)</li>
+				<li><a href="demos/data-json/data-json-en.html">Data JSON<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/data-json/data-json-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/data-json/template-en.html">Template HTML5<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/data-json/data-json-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/jsonmanager/jsonmanager-en.html">JSON Manager<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/jsonmanager/jsonmanager-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/tblfilter-en.html">URL Mapping - Table filtering<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/urlmapping/urlmapping-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/ajax-en.html">URL Mapping - Ajax<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/urlmapping/urlmapping-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/patches-en.html">URL Mapping - Patching JSON<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/urlmapping/urlmapping-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/fieldflow-en.html">Field flow<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/fieldflow/fieldflow-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/basic-en.html">Field flow basic configuration<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/fieldflow/fieldflow-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/advanced-en.html">Field flow advanced<span class="wb-inv"> - {{i18n "lang-en"}}</span></a> (<a href="demos/fieldflow/fieldflow-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-en"}}</span></a>)</li>
 			</ul>
 		</section>
 	</div></div>
@@ -68,49 +68,49 @@
 	<h2>French</h2>
 	<div class="row"><div class="col-md-8">
 	<ul>
-		<li><a href="home-fr.html">Home page</a></li>
-		<li><a href="theme-fr.html">Theme landing page</a></li>
-		<li><a href="topic-fr.html">Topic landing page</a></li>
-		<li><a href="institution-fr.html">Institutional profile for large institutions</a></li>
-		<li><a href="institution-arms-fr.html">Institutional profile for arm’s-length institutions</a></li>
-		<li><a href="institution-small-fr.html">Institutional profile for small institutions</a></li>
-		<li><a href="content-fr.html">Content page</a></li>
-		<li><a href="components-fr.html">Components page</a></li>
-		<li><a href="video-fr.html">Video content page</a></li>
-		<li><a href="feedback-fr.html">Feedback form</a></li>
-		<li><a href="widgets-fr.html">Widget page</a></li>
-		<li><a href="localnav/task1/index-fr.html">Section menu examples</a></li>
-		<li><a href="splashpage.html">Splash page</a></li>
-		<li><a href="servermessage-fr.html">Server message page</a></li>
-		<li><a href="servermessage-fr-en.html">Server message page (French/English)</a></li>
-		<li><a href="campaign-fr.html">Campaign</a></li>
-		<li><a href="event-fr.html">Event</a></li>
-		<li><a href="service-fr.html">Simple service initiation landing page</a></li>
-		<li><a href="advancedservice/index-fr.html">Advanced service initiation pages</a></li>
-		<li><a href="dept-fr.html">Departments and agencies</a></li>
-		<li><a href="ministerial-fr.html">Ministerial profile</a></li>
-		<li><a href="act-fr.html">Acts</a></li>
-		<li><a href="regulations-fr.html">Regulations</a></li>
-		<li><a href="topic-lowest-fr.html">Lowest level topic page</a></li>
-		<li><a href="organizational-fr.html">Organizational profile</a></li>
-		<li><a href="organizational-carousel-fr.html">Organizational profile with carousel</a></li>
-		<li><a href="archived-fr.html">Archived page</a></li>
-		<li><a href="404-fr.html">404 error page</a></li>
-		<li><a href="404-fr-en.html">404 error page (French/English)</a></li>
+		<li><a href="home-fr.html">Home page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="theme-fr.html">Theme landing page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="topic-fr.html">Topic landing page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="institution-fr.html">Institutional profile for large institutions<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="institution-arms-fr.html">Institutional profile for arm’s-length institutions<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="institution-small-fr.html">Institutional profile for small institutions<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="content-fr.html">Content page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="components-fr.html">Components page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="video-fr.html">Video content page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="feedback-fr.html">Feedback form<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="widgets-fr.html">Widget page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="localnav/task1/index-fr.html">Section menu examples<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="splashpage.html">Splash page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="servermessage-fr.html">Server message page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="servermessage-fr-en.html">Server message page - French/English</a></li>
+		<li><a href="campaign-fr.html">Campaign<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="event-fr.html">Event<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="service-fr.html">Simple service initiation landing page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="advancedservice/index-fr.html">Advanced service initiation pages<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="dept-fr.html">Departments and agencies<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="ministerial-fr.html">Ministerial profile<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="act-fr.html">Acts<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="regulations-fr.html">Regulations<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="topic-lowest-fr.html">Lowest level topic page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="organizational-fr.html">Organizational profile<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="organizational-carousel-fr.html">Organizational profile with carousel<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="archived-fr.html">Archived page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="404-fr.html">404 error page<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a></li>
+		<li><a href="404-fr-en.html">404 error page - French/English</a></li>
 	</ul>
 	</div><div class="col-md-4">
 		<section>
 			<h3>Themes plugins</h3>
 			<ul>
-				<li><a href="demos/data-json/data-json-fr.html" hreflang="fr">Data JSON</a> (<a hreflang="fr" href="demos/data-json/data-json-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/data-json/template-fr.html" hreflang="fr">Template HTML5</a> (<a hreflang="fr" href="demos/data-json/data-json-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/jsonmanager/jsonmanager-fr.html" hreflang="fr">JSON Manager</a> (<a href="demos/jsonmanager/jsonmanager-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/tblfilter-fr.html" hreflang="fr">URL Mapping - Table filtering</a> (<a hreflang="fr" href="demos/urlmapping/urlmapping-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/ajax-fr.html" hreflang="fr">URL Mapping - Ajax</a> (<a hreflang="fr" href="demos/urlmapping/urlmapping-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/patches-fr.html" hreflang="fr">URL Mapping - Patching JSON</a> (<a hreflang="fr" href="demos/urlmapping/urlmapping-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/fieldflow-fr.html" hreflang="fr">Field flow</a> (<a hreflang="fr" href="demos/fieldflow/fieldflow-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/basic-fr.html" hreflang="fr">Field flow basic configuration</a> (<a hreflang="fr" href="demos/fieldflow/fieldflow-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/advanced-fr.html" hreflang="fr">Field flow advanced</a> (<a hreflang="fr" href="demos/fieldflow/fieldflow-doc-fr.html">Documentation</a>)</li>
+				<li><a href="demos/data-json/data-json-fr.html" hreflang="fr">Data JSON<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/data-json/data-json-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/data-json/template-fr.html" hreflang="fr">Template HTML5<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/data-json/data-json-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/jsonmanager/jsonmanager-fr.html" hreflang="fr">JSON Manager<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a href="demos/jsonmanager/jsonmanager-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/tblfilter-fr.html" hreflang="fr">URL Mapping - Table filtering<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/urlmapping/urlmapping-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/ajax-fr.html" hreflang="fr">URL Mapping - Ajax<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/urlmapping/urlmapping-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/patches-fr.html" hreflang="fr">URL Mapping - Patching JSON<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/urlmapping/urlmapping-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/fieldflow-fr.html" hreflang="fr">Field flow<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/fieldflow/fieldflow-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/basic-fr.html" hreflang="fr">Field flow basic configuration<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/fieldflow/fieldflow-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/advanced-fr.html" hreflang="fr">Field flow advanced<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a> (<a hreflang="fr" href="demos/fieldflow/fieldflow-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-en" language="fr"}}</span></a>)</li>
 			</ul>
 		</section>
 	</div></div>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -7,7 +7,7 @@
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" }
 	],
 	"tag": "GCWeb",
-	"dateModified": "2017-05-04",
+	"dateModified": "2017-05-12",
 	"share": "true"
 }
 ---
@@ -15,51 +15,51 @@
 	<h2>Anglais</h2>
 	<div class="row"><div class="col-md-8">
 	<ul>
-		<li><a href="home-en.html">Page d’accueil</a></li>
-		<li><a href="theme-en.html">Page d’atterrissage du thème</a></li>
-		<li><a href="topic-en.html">Page d’atterrissage du sujet</a></li>
-		<li><a href="institution-en.html">Profil institutionnel pour les grandes organisations</a></li>
-		<li><a href="institution-en.html">Profil institutionnel pour les organisations sans lien de dépendance</a></li>
-		<li><a href="institution-small-en.html">Profil institutionnel pour les petites organisations</a></li>
-		<li><a href="content-en.html">Page de contenu</a></li>
-		<li><a href="content-signedoff-en.html">Page de contenu - Session Fermée</a></li>
-		<li><a href="content-signedon-en.html">Page de contenu - Session Ouverte</a></li>
-		<li><a href="components-en.html">Page de composants</a></li>
-		<li><a href="video-en.html">Page de contenu vidéo</a></li>
-		<li><a href="feedback-en.html">Formulaire de rétroaction</a></li>
-		<li><a href="widgets-en.html">Page de gadgets</a></li>
-		<li><a href="localnav/task1/index-en.html">Exemples avec un menu de la section</a></li>
-		<li><a href="splashpage.html">Page d’entrée</a></li>
-		<li><a href="servermessage-en.html">Page de message du serveur</a></li>
-		<li><a href="servermessage-en-fr.html">Page de message du serveur (anglais/français)</a></li>
-		<li><a href="campaign-en.html">Campagne</a></li>
-		<li><a href="event-en.html">Événement</a></li>
-		<li><a href="service-en.html">Page d’accueil d’initiation de service simple</a></li>
-		<li><a href="advancedservice/index-en.html">Page d’accueil d’initiation de service avancé</a></li>
-		<li><a href="dept-en.html">Ministères et organismes</a></li>
-		<li><a href="ministerial-en.html">Profil ministérielle</a></li>
-		<li><a href="act-en.html">Lois</a></li>
-		<li><a href="regulations-en.html">Règlements</a></li>
-		<li><a href="topic-lowest-en.html">Page de sujet au plus bas niveau</a></li>
-		<li><a href="organizational-en.html">Page profil de l’organisme</a></li>
-		<li><a href="organizational-carousel-en.html">Page profil de l’organisme avec carousel</a></li>
-		<li><a href="archived-en.html">Page archivée</a></li>
-		<li><a href="404-en.html">Page d'erreur 404</a></li>
-		<li><a href="404-en-fr.html">Page d'erreur 404 (anglais/français)</a></li>
+		<li><a href="home-en.html">Page d’accueil<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="theme-en.html">Page d’atterrissage du thème<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="topic-en.html">Page d’atterrissage du sujet<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="institution-en.html">Profil institutionnel pour les grandes organisations<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="institution-en.html">Profil institutionnel pour les organisations sans lien de dépendance<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="institution-small-en.html">Profil institutionnel pour les petites organisations<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="content-en.html">Page de contenu<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="content-signedoff-en.html">Page de contenu - Session Fermée<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="content-signedon-en.html">Page de contenu - Session Ouverte<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="components-en.html">Page de composants<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="video-en.html">Page de contenu vidéo<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="feedback-en.html">Formulaire de rétroaction<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="widgets-en.html">Page de gadgets<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="localnav/task1/index-en.html">Exemples avec un menu de la section<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="splashpage.html">Page d’entrée<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="servermessage-en.html">Page de message du serveur<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="servermessage-en-fr.html">Page de message du serveur - anglais/français</a></li>
+		<li><a href="campaign-en.html">Campagne<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="event-en.html">Événement<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="service-en.html">Page d’accueil d’initiation de service simple<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="advancedservice/index-en.html">Page d’accueil d’initiation de service avancé<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="dept-en.html">Ministères et organismes<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="ministerial-en.html">Profil ministérielle<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="act-en.html">Lois<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="regulations-en.html">Règlements<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="topic-lowest-en.html">Page de sujet au plus bas niveau<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="organizational-en.html">Page profil de l’organisme<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="organizational-carousel-en.html">Page profil de l’organisme avec carousel<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="archived-en.html">Page archivée<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="404-en.html">Page d'erreur 404<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a></li>
+		<li><a href="404-en-fr.html">Page d'erreur 404 - anglais/français</a></li>
 	</ul>
 	</div><div class="col-md-4">
 		<section>
 			<h3>Plugiciel du thème</h3>
 			<ul>
-				<li><a href="demos/data-json/data-json-en.html" hreflang="en">Data JSON</a> (<a hreflang="en" href="demos/data-json/data-json-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/data-json/template-en.html" hreflang="en">Gabarit HTML5</a> (<a hreflang="en" href="demos/data-json/data-json-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/jsonmanager/jsonmanager-en.html" hreflang="en">Gestionnaire JSON</a> (<a hreflang="en" href="demos/jsonmanager/jsonmanager-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/tblfilter-en.html" hreflang="en">Correspondance d'URL - Filtrage de tableau</a> (<a hreflang="en" href="demos/urlmapping/urlmapping-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/ajax-en.html" hreflang="en">Correspondance d'URL - Ajax</a> (<a hreflang="en" href="demos/urlmapping/urlmapping-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/patches-en.html" hreflang="en">Correspondance d'URL - Appliquer des correctifs JSON</a> (<a hreflang="en" href="demos/urlmapping/urlmapping-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/fieldflow-en.html" hreflang="en">Déroulement de champs</a> (<a hreflang="en" href="demos/fieldflow/fieldflow-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/basic-en.html" hreflang="en">Déroulement de champs avec des configurations de base</a> (<a hreflang="en" href="demos/fieldflow/fieldflow-doc-en.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/advanced-en.html" hreflang="en">Déroulement de champs avancé</a> (<a hreflang="en" href="demos/fieldflow/fieldflow-doc-en.html">Documentation</a>)</li>
+				<li><a href="demos/data-json/data-json-en.html" hreflang="en">Data JSON<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/data-json/data-json-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/data-json/template-en.html" hreflang="en">Gabarit HTML5<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/data-json/data-json-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/jsonmanager/jsonmanager-en.html" hreflang="en">Gestionnaire JSON<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/jsonmanager/jsonmanager-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/tblfilter-en.html" hreflang="en">Correspondance d'URL - Filtrage de tableau<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/urlmapping/urlmapping-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/ajax-en.html" hreflang="en">Correspondance d'URL - Ajax<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/urlmapping/urlmapping-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/patches-en.html" hreflang="en">Correspondance d'URL - Appliquer des correctifs JSON<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/urlmapping/urlmapping-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/fieldflow-en.html" hreflang="en">Déroulement de champs<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/fieldflow/fieldflow-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/basic-en.html" hreflang="en">Déroulement de champs avec des configurations de base<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/fieldflow/fieldflow-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/advanced-en.html" hreflang="en">Déroulement de champs avancé<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a> (<a hreflang="en" href="demos/fieldflow/fieldflow-doc-en.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr" language="en"}}</span></a>)</li>
 			</ul>
 		</section>
 	</div></div>
@@ -68,49 +68,49 @@
 	<h2>Français</h2>
 	<div class="row"><div class="col-md-8">
 	<ul>
-		<li><a href="home-fr.html">Page d’accueil</a></li>
-		<li><a href="theme-fr.html">Page d’atterrissage du thème</a></li>
-		<li><a href="topic-fr.html">Page d’atterrissage du sujet</a></li>
-		<li><a href="institution-fr.html">Profil institutionnel pour les grandes organisations</a></li>
-		<li><a href="institution-arms-fr.html">Profil institutionnel pour les organisations sans lien de dépendance</a></li>
-		<li><a href="institution-small-fr.html">Profil institutionnel pour les petites organisations</a></li>
-		<li><a href="content-fr.html">Page de contenu</a></li>
-		<li><a href="components-fr.html">Page de composants</a></li>
-		<li><a href="video-fr.html">Page de contenu vidéo</a></li>
-		<li><a href="feedback-fr.html">Formulaire de rétroaction</a></li>
-		<li><a href="widgets-fr.html">Page de gadgets</a></li>
-		<li><a href="localnav/task1/index-fr.html">Exemples avec un menu de la section</a></li>
-		<li><a href="splashpage.html">Page d’entrée</a></li>
-		<li><a href="servermessage-fr.html">Page de message du serveur</a></li>
-		<li><a href="servermessage-fr-en.html">Page de message du serveur (français/anglais)</a></li>
-		<li><a href="campaign-fr.html">Campagne</a></li>
-		<li><a href="event-fr.html">Événement</a></li>
-		<li><a href="service-fr.html">Page d’accueil d’initiation de service simple</a></li>
-		<li><a href="advancedservice/index-fr.html">Page d’accueil d’initiation de service avancé</a></li>
-		<li><a href="dept-fr.html">Ministères et organismes</a></li>
-		<li><a href="ministerial-fr.html">Profil ministérielle</a></li>
-		<li><a href="act-fr.html">Lois</a></li>
-		<li><a href="regulations-fr.html">Règlements</a></li>
-		<li><a href="topic-lowest-fr.html">Page de sujet au plus bas niveau</a></li>
-		<li><a href="organizational-fr.html">Page profil de l’organisme</a></li>
-		<li><a href="organizational-carousel-fr.html">Page profil de l’organisme avec carousel</a></li>
-		<li><a href="archived-fr.html">Page archivée</a></li>
-		<li><a href="404-fr.html">Page d'erreur 404</a></li>
-		<li><a href="404-fr-en.html">Page d'erreur 404 (français/anglais)</a></li>
+		<li><a href="home-fr.html">Page d’accueil<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="theme-fr.html">Page d’atterrissage du thème<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="topic-fr.html">Page d’atterrissage du sujet<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="institution-fr.html">Profil institutionnel pour les grandes organisations<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="institution-arms-fr.html">Profil institutionnel pour les organisations sans lien de dépendance<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="institution-small-fr.html">Profil institutionnel pour les petites organisations<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="content-fr.html">Page de contenu<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="components-fr.html">Page de composants<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="video-fr.html">Page de contenu vidéo<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="feedback-fr.html">Formulaire de rétroaction<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="widgets-fr.html">Page de gadgets<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="localnav/task1/index-fr.html">Exemples avec un menu de la section<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="splashpage.html">Page d’entrée<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="servermessage-fr.html">Page de message du serveur<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="servermessage-fr-en.html">Page de message du serveur - français/anglais</a></li>
+		<li><a href="campaign-fr.html">Campagne<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="event-fr.html">Événement<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="service-fr.html">Page d’accueil d’initiation de service simple<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="advancedservice/index-fr.html">Page d’accueil d’initiation de service avancé<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="dept-fr.html">Ministères et organismes<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="ministerial-fr.html">Profil ministérielle<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="act-fr.html">Lois<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="regulations-fr.html">Règlements<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="topic-lowest-fr.html">Page de sujet au plus bas niveau<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="organizational-fr.html">Page profil de l’organisme<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="organizational-carousel-fr.html">Page profil de l’organisme avec carousel<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="archived-fr.html">Page archivée<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="404-fr.html">Page d'erreur 404<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a></li>
+		<li><a href="404-fr-en.html">Page d'erreur 404 - français/anglais</a></li>
 	</ul>
 	</div><div class="col-md-4">
 		<section>
 			<h3>Plugiciel du thème</h3>
 			<ul>
-				<li><a href="demos/data-json/data-json-fr.html">Data JSON</a> (<a href="demos/data-json/data-json-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/data-json/template-fr.html">Gabarit HTML5</a> (<a href="demos/data-json/data-json-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/jsonmanager/jsonmanager-fr.html">Gestionnaire JSON</a> (<a href="demos/jsonmanager/jsonmanager-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/tblfilter-fr.html">Correspondance d'URL - Filtrage de tableau</a> (<a href="demos/urlmapping/urlmapping-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/ajax-fr.html">Correspondance d'URL - Ajax</a> (<a href="demos/urlmapping/urlmapping-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/urlmapping/patches-fr.html">Correspondance d'URL - Appliquer des correctifs JSON</a> (<a href="demos/urlmapping/urlmapping-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/fieldflow-fr.html">Déroulement de champs</a> (<a href="demos/fieldflow/fieldflow-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/basic-fr.html">Déroulement de champs avec des configurations de base</a> (<a href="demos/fieldflow/fieldflow-doc-fr.html">Documentation</a>)</li>
-				<li><a href="demos/fieldflow/advanced-fr.html">Déroulement de champs avancé</a> (<a href="demos/fieldflow/fieldflow-doc-fr.html">Documentation</a>)</li>
+				<li><a href="demos/data-json/data-json-fr.html">Data JSON<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/data-json/data-json-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/data-json/template-fr.html">Gabarit HTML5<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/data-json/data-json-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/jsonmanager/jsonmanager-fr.html">Gestionnaire JSON<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/jsonmanager/jsonmanager-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/tblfilter-fr.html">Correspondance d'URL - Filtrage de tableau<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/urlmapping/urlmapping-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/ajax-fr.html">Correspondance d'URL - Ajax<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/urlmapping/urlmapping-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/urlmapping/patches-fr.html">Correspondance d'URL - Appliquer des correctifs JSON<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/urlmapping/urlmapping-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/fieldflow-fr.html">Déroulement de champs<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/fieldflow/fieldflow-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/basic-fr.html">Déroulement de champs avec des configurations de base<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/fieldflow/fieldflow-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
+				<li><a href="demos/fieldflow/advanced-fr.html">Déroulement de champs avancé<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a> (<a href="demos/fieldflow/fieldflow-doc-fr.html">Documentation<span class="wb-inv"> - {{i18n "lang-fr"}}</span></a>)</li>
 			</ul>
 		</section>
 	</div></div>


### PR DESCRIPTION
* Added hidden link text containing " - [Language]" to the end of all page template links. This makes each link's text unique, which can benefit screen reader users that may encounter them out of context.
* Revised the bilingual 404 error and server message page's links to end with " - [Language]/[Language]" (instead of " ([Language]/[Language])") for consistency.
* Related to wet-boew/wet-boew#7990.