### PR TITLE
Footer: Simplified about list's SCSS selectors.

### DIFF
--- a/src/footer/_base.scss
+++ b/src/footer/_base.scss
@@ -32,23 +32,14 @@
 
 	.ftr-urlt-lnk {
 		ul {
-
 			margin: 0;
 			padding: 0;
+		}
 
-			li {
-				display: inline-block;
-				margin-right: .5em;
-				padding: 0;
-
-				&:before {
-					content: "\2022";
-					margin-right: .7em;
-				}
-
-				&:first-child:before {
-					content: none;
-				}
+		li {
+			&:before {
+				content: "\2022";
+				margin-right: .7em;
 			}
 		}
 	}

--- a/src/footer/_screen-md-min.scss
+++ b/src/footer/_screen-md-min.scss
@@ -1,0 +1,17 @@
+/*
+  WET-BOEW
+  @title: Medium view and over (screen only)
+ */
+
+#wb-info {
+	.ftr-urlt-lnk {
+		li {
+			display: inline-block;
+			margin-right: .5em;
+
+			&:first-child:before {
+				content: none;
+			}
+		}
+	}
+}

--- a/src/footer/_screen-sm-max.scss
+++ b/src/footer/_screen-sm-max.scss
@@ -4,20 +4,14 @@
  */
 
 #wb-info {
-
 	.ftr-urlt-lnk {
 		ul {
 			column-count: 2;
+		}
 
-			li {
-				display: block;
-				margin-bottom: .2em;
-
-				&:first-child:before {
-					content: "\2022";
-					margin-right: .7em;
-				}
-			}
+		li {
+			display: block;
+			margin-bottom: .2em;
 		}
 	}
 }

--- a/src/footer/_screen-xxs-max.scss
+++ b/src/footer/_screen-xxs-max.scss
@@ -2,14 +2,9 @@
  * Site information (extra-extra-small view)
  */
 #wb-info {
-
 	.ftr-urlt-lnk {
 		ul {
 			column-count: 1;
-
-			li {
-				margin-bottom: .2em;
-			}
 		}
 	}
 

--- a/src/ie8-theme.scss
+++ b/src/ie8-theme.scss
@@ -94,6 +94,7 @@
 @media screen and (min-width: $screen-md-min) {
 	@import "views/screen-md-min";
 	@import "social-media-icons/screen-md-min";
+	@import "footer/screen-md-min";
 }
 
 /* Large view and over */

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -104,6 +104,7 @@
 @media screen and (min-width: $screen-md-min) {
 	@import "views/screen-md-min";
 	@import "social-media-icons/screen-md-min";
+	@import "footer/screen-md-min";
 }
 
 /* Large view and over */


### PR DESCRIPTION
* Stopped nesting li selectors inside ul selectors.
* Moved certain selectors into a medium view and over file.
* Removed small view and under file's li:first-child:before selector.
* Removed extra-extra small view file's redundant li margin-bottom selector.
* Removed empty lines in-between certain nested parent selectors.