### PR TITLE
Footer: Made about list compatible with minified HTML.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -21,6 +21,9 @@ $wb-bc-background-color: #f5f5f5; // Outer background colour (WET override).
 //Heading links on landing pages
 $heading-link: 16px;
 
+// "About this site" footer links
+$footer-about-li-horizontal-spacing: .7em;
+
 /*
 Left menu variables
 */

--- a/src/footer/_base.scss
+++ b/src/footer/_base.scss
@@ -39,7 +39,7 @@
 		li {
 			&:before {
 				content: "\2022";
-				margin-right: .7em;
+				margin-right: $footer-about-li-horizontal-spacing;
 			}
 		}
 	}

--- a/src/footer/_screen-md-min.scss
+++ b/src/footer/_screen-md-min.scss
@@ -1,16 +1,27 @@
 /*
   WET-BOEW
-  @title: Medium view and over (screen only)
+  @title: Search medium view and over (screen only)
  */
 
 #wb-info {
 	.ftr-urlt-lnk {
 		li {
 			display: inline-block;
-			margin-right: .5em;
+			float: left;
+			margin-right: $footer-about-li-horizontal-spacing;
 
 			&:first-child:before {
 				content: none;
+			}
+		}
+	}
+}
+
+[dir=rtl] {
+	#wb-info {
+		.ftr-urlt-lnk {
+			li {
+				float: right;
 			}
 		}
 	}


### PR DESCRIPTION
The "About this site" list's layout used to rely on space/line break/tab characters being present in-between li elements in the list's HTML markup. But that didn't lend itself to pages that use minified HTML. The horizontal spacing between the list's items looked even in unminified pages, but looked off in minified ones.

This commit changes the list's SCSS to always use an even amount of spacing, regardless of whether HTML has been minified.

**Screenshots:**
* **Before (minified):** ![before_minified](https://user-images.githubusercontent.com/1907279/27187978-aae718f6-51ba-11e7-9bc5-c4d25c705043.png)
* **Before (unminified):**  ![before_unminified](https://user-images.githubusercontent.com/1907279/27187971-a94b1fba-51ba-11e7-8244-6f4422df5059.png)
* **After (minified and unminified):**
![after_both](https://user-images.githubusercontent.com/1907279/27187981-ac711140-51ba-11e7-9fb2-2ccdb5d5b10a.png)

**PS:**
PR #1259 should be merged in before this one. Once that happens, this PR will most likely run into merge conflicts, so I'll rebase it afterwards.