### PR TITLE
Search: Fixed search button layout issues.

### DIFF
--- a/src/ie8-theme.scss
+++ b/src/ie8-theme.scss
@@ -50,6 +50,7 @@
  */
 /* All screen views */
 @media screen {
+	@import "search/screen";
 	@import "views/screen";
 	@import "tabs/screen";
 	@import "priorities/screen";

--- a/src/search/_screen-sm-max.scss
+++ b/src/search/_screen-sm-max.scss
@@ -1,25 +1,11 @@
 /*
   WET-BOEW
-  @title: Search Small view and under (screen only)
+  @title: Search small view and under (screen only)
  */
 #wb-srch {
 	width: 100%;
 
 	.form-group {
 		display: inline-block;
-
-		&.submit {
-			float: right;
-		}
-	}
-}
-
-[dir=rtl] {
-	#wb-srch {
-		.form-group {
-			&.submit {
-				float: left;
-			}
-		}
 	}
 }

--- a/src/search/_screen.scss
+++ b/src/search/_screen.scss
@@ -1,0 +1,30 @@
+/*
+  WET-BOEW
+  @title: Search all screen views
+ */
+
+#wb-srch {
+	.submit {
+		float: right;
+	}
+}
+
+#wb-srch-sub {
+	height: 37px;
+	margin-left: 5px;
+}
+
+[dir=rtl] {
+	#wb-srch {
+		&.submit {
+			float: left;
+		}
+	}
+
+	#wb-srch-sub {
+		margin: {
+			left: 0;
+			right: 5px;
+		}
+	}
+}

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -56,6 +56,7 @@
  */
 /* All screen views */
 @media screen {
+	@import "search/screen";
 	@import "views/screen";
 	@import "tabs/screen";
 	@import "priorities/screen";


### PR DESCRIPTION
In medium/large views, the search field/button's layout used to rely on space/line break/tab characters being present in-between their elements in HTML markup. Their presence "filled" in the left side of the search button to make it look square-shaped. But in pages that use minified HTML, the space disappeared, which hindered the button's layout.

It turns out that the search feature's small view and under SCSS file contained selectors that eliminated the space in noscript/wbdisable mode.

This commit moves the aforementioned selectors into a screen SCSS file, adds left/right margins on the button to retain its square shape and adjusts the button's height to match the search field. Combined, these allow the button to always remain square-shaped and flush with its input field.

Related to wet-boew/wet-boew#8061.

**Screenshots:**

* **Before (minified):**
![before_minified](https://user-images.githubusercontent.com/1907279/27345052-6767e4ca-55b6-11e7-9297-c164fd2fb784.png)
* **Before (unminified):**
![before_unminified](https://user-images.githubusercontent.com/1907279/27345058-6c4c4242-55b6-11e7-93b1-fc6a84aec6bf.png)
* **After (minified and unminified):**
![after_both](https://user-images.githubusercontent.com/1907279/27345048-6591a6a4-55b6-11e7-80bd-040ca7c0490b.png)