### PR TITLE
fix background-color for menu overlay close button

### DIFF
--- a/src/menu/_base.scss
+++ b/src/menu/_base.scss
@@ -172,6 +172,10 @@
 		}
 	}
 
+	.modal-footer {
+		background: #0e4164;
+	}
+
 	.mfp-close {
 		top: .55em;
 	}

--- a/src/overlay/_base.scss
+++ b/src/overlay/_base.scss
@@ -5,8 +5,4 @@
 	header {
 		background: $accent-blue;
 	}
-
-	.overlay-close {
-		background: transparent;
-	}
 }


### PR DESCRIPTION
See close button in the mobile menu and in the overlay working example

http://universallabs.org/wet/labs/fix-overlay-close/gcweb/unmin/index-en.html
http://universallabs.org/wet/labs/fix-overlay-close/gcweb/unmin/demos/overlay/overlay-en.html