### PR TITLE
Footer: Increased the Canada wordmark's grid width in medium view.

### DIFF
--- a/site/includes/footerbrand.hbs
+++ b/site/includes/footerbrand.hbs
@@ -1,7 +1,7 @@
 <div class="brand">
 	<div class="container">
 		<div class="row ">
-			<nav class="col-md-10 ftr-urlt-lnk">
+			<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
 				<h2 class="wb-inv">{{{i18n "tmpl-about-site"}}}</h2>
 				<ul>
 					<li><a href="{{{i18n "menu-footer-communications-social-link"}}}">{{{i18n "menu-footer-communications-social-text"}}}</a></li>
@@ -14,7 +14,7 @@
 			<div class="col-xs-6 visible-sm visible-xs tofpg">
 				<a href="#wb-cont">{{{i18n "tmpl-toppage"}}} <span class="glyphicon glyphicon-chevron-up"></span></a>
 			</div>
-			<div class="col-xs-6 col-md-2 text-right">
+			<div class="col-xs-6 col-md-3 col-lg-2 text-right">
 				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
 			</div>
 		</div>


### PR DESCRIPTION
When the footer was revised as a part of #1132, the width of the wordmark's grid was reduced to "col-md-2". But that caused the wordmark to significantly overflow beyond its container in medium view's minimum widths (992-1011 pixels), which introduced an horizontal scrollbar.

This commit eliminates the scrollbar by increasing the wordmark's grid width to "col-md-3" and adjusts the rest of the grid layout accordingly. It also keeps the original 10/2 grid layout in large view to maximize the "About this site" list's available width.

On a side note, in large view, the wordmark slightly overflows its "col-lg-2" grid, but not enough to go past the far right edge of the grid's right padding. So it's not significant-enough to cause an horizontal scrollbar to appear.