### PR TITLE
Skip links: Changed "About this site" to "About government".

### DIFF
--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -2,6 +2,7 @@
 	"gnl-close": "Close",
 	"gnl-main-page": "Main Page",
 	"tmpl-settings": "Settings",
+	"tmpl-skip-about-government": "Skip to \"About government\"",
 	"tmpl-search-placeholder": "Search Canada.ca",
 	"tmpl-promo-title": "Promotions",
 	"tmpl-feedback": "Report a problem or mistake on this page",

--- a/site/data/i18n/fr.json
+++ b/site/data/i18n/fr.json
@@ -2,6 +2,7 @@
 	"gnl-close": "Fermer",
 	"gnl-main-page": "Page principale",
 	"tmpl-settings": "Paramètres",
+	"tmpl-skip-about-government": "Passer à «&#160;Au sujet du gouvernement&#160;»",
 	"tmpl-search-placeholder": "Rechercher dans Canada.ca",
 	"tmpl-promo-title": "Promotions",
 	"tmpl-feedback": "Signaler un problème ou une erreur sur cette page",

--- a/site/includes/skiplinks.hbs
+++ b/site/includes/skiplinks.hbs
@@ -4,7 +4,7 @@
 	</li>
 {{#isnt footer "false"}}
 	<li class="wb-slc visible-sm visible-md visible-lg">
-		<a class="wb-sl" href="#wb-info">{{{i18n "tmpl-skip-about-site"}}}</a>
+		<a class="wb-sl" href="#wb-info">{{{i18n "tmpl-skip-about-government"}}}</a>
 	</li>
 {{/isnt}}
 {{#if page.secondarymenu}}


### PR DESCRIPTION
Prior to #1132, the first heading within the wb-info ID's container was called "About this site". As a part of #1132's changes, the footer was restructured into two sections of links ("About government" and "About this site"). As a result of those changes, wb-info's first heading changed to "About government"... but its skip link was never updated. Ever since then, the "Skip to 'About this site'" skip link has technically been pointing to the "About government" heading.

This commit fixes that inconsistency by renaming the "Skip to 'About this site'" link to "Skip to 'About government'".