### PR TITLE
Report a problem: Fixed dropdown box's width.

### DIFF
--- a/site/includes/datemodified.hbs
+++ b/site/includes/datemodified.hbs
@@ -3,7 +3,7 @@
 	<details class="brdr-0 col-sm-6 col-lg-4 mrgn-tp-sm">
 		<summary class="btn btn-default text-center">{{{i18n "tmpl-feedback"}}}</summary>
 		<div class="clearfix"></div>
-		<div class="well row">
+		<div class="well">
 		{{>report-problem}}
 		</div>
 	</details>

--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -233,6 +233,13 @@ aside {
 			margin-top: 0;
 		}
 	}
+
+	.well {
+		margin: {
+			left: -$details-identation;
+			right: -$details-identation;
+		}
+	}
 }
 
 /* IE */


### PR DESCRIPTION
The report a problem dropdown box's width was previously thinner than the summary button that directly precedes it. Bootstrap's "row" class was being misused to increase its width, but it still wasn't enough. The "row" class' negative left/right margins differ from the summary's margins.

This commit makes the dropdown box's width consistent with the preceding summary. It removes the unnecessary "row" class and overrides the "well" class' margins to rely on the same SCSS variable that's used to generate the summary element's left/right margins. These changes are backwards-compatible with GCWeb 4.0.26 and under.

**Screenshots:**
* **Before:**
![gcweb-report-problem-well-width-before](https://user-images.githubusercontent.com/1907279/31029523-01073bb8-a520-11e7-8ad0-edad43d387bd.png)
* **After:**
![gcweb-report-problem-well-width-after](https://user-images.githubusercontent.com/1907279/31029533-0bc5f1de-a520-11e7-9827-84af5d2f7ee1.png)

**PS:**
PR #1290 should be merged in before this one. Once that's merged, merge conflicts will appear in this PR and it'll need to be rebased.