### PR TITLE
Skip links: Made footer link visible in all views.

### DIFF
--- a/site/includes/skiplinks.hbs
+++ b/site/includes/skiplinks.hbs
@@ -3,7 +3,7 @@
 		<a class="wb-sl" href="#wb-cont">{{{i18n "tmpl-skip-cont"}}}</a>
 	</li>
 {{#isnt footer "false"}}
-	<li class="wb-slc visible-sm visible-md visible-lg">
+	<li class="wb-slc">
 		<a class="wb-sl" href="#wb-info">{{{i18n "tmpl-skip-about-government"}}}</a>
 	</li>
 {{/isnt}}


### PR DESCRIPTION
In WET's other themes, the footer and its associated skip link are hidden in extra-small view and under. #1132 made GCWeb's entire footer visible in the aforementioned view. But the footer's skip link wasn't updated accordingly. So it remained hidden in smaller views ever since.

This commit makes the footer's skip link visible in all views.