### PR TITLE
Promotion1 include: Removed "row" div.

### DIFF
--- a/site/includes/promotion1.hbs
+++ b/site/includes/promotion1.hbs
@@ -1,50 +1,48 @@
 <aside class="prm-flpr">
 	<div class="container">
-		<div class="row">
-			<h2 class="wb-inv">{{{i18n "tmpl-promo-title"}}}</h2>
-			<div class="wb-tabs carousel-s2 show-thumbs playing slow">
-				<ul role="tablist">
-					<li class="active">
-						<a href="#tab1"><img src="{{assets}}/img/promos/1170x347-1.png" alt="" /><span class="wb-inv">{{#startsWith "en" language }}Tab 1: Banff National Park{{else}}Languette 1 : Parc national Banff{{/startsWith}}</span></a>
-					</li>
-					<li>
-						<a href="#tab2"><img src="{{assets}}/img/promos/1170x347-2.png" alt="" /><span class="wb-inv">{{#startsWith "en" language }}Tab 2: Algonquin Provincial Park{{else}}Languette 2 : Parc Provincial Algonquin{{/startsWith}}</span></a>
-					</li>
-					<li>
-						<a href="#tab3"><img src="{{assets}}/img/promos/1170x347-3.png" alt="" /><span class="wb-inv">{{#startsWith "en" language }}Tab 3: Rideau Canal{{else}}Languette 3 : Canal Rideau{{/startsWith}}</span></a>
-					</li>
-				</ul>
-				<div class="tabpanels">
-					<div role="tabpanel" id="tab1" class="in fade">
-						<a href="#" class="learnmore">
-							<figure>
-								<img src="{{assets}}/img/promos/1170x347-1.png" alt="" />
-								<figcaption>
-									<p>{{#startsWith "en" language }}Banff National Park {{else}} Parc national Banff{{/startsWith}}</p>
-								</figcaption>
-							</figure>
-						</a>
-					</div>
-					<div role="tabpanel" id="tab2" class="out fade">
-						<a href="#" class="learnmore">
-							<figure>
-								<img src="{{assets}}/img/promos/1170x347-2.png" alt="" />
-								<figcaption>
-									<p>{{#startsWith "en" language }}Algonquin Provincial Park {{else}} Parc Provincial Algonquin{{/startsWith}}</p>
-								</figcaption>
-							</figure>
-						</a>
-					</div>
-					<div role="tabpanel" id="tab3" class="out fade">
-						<a href="#" class="learnmore">
-							<figure>
-								<img src="{{assets}}/img/promos/1170x347-3.png" alt="" />
-								<figcaption>
-									<p>{{#startsWith "en" language }}Rideau Canal {{else}} Canal Rideau{{/startsWith}}</p>
-								</figcaption>
-							</figure>
-						</a>
-					</div>
+		<h2 class="wb-inv">{{{i18n "tmpl-promo-title"}}}</h2>
+		<div class="wb-tabs carousel-s2 show-thumbs playing slow">
+			<ul role="tablist">
+				<li class="active">
+					<a href="#tab1"><img src="{{assets}}/img/promos/1170x347-1.png" alt="" /><span class="wb-inv">{{#startsWith "en" language }}Tab 1: Banff National Park{{else}}Languette 1 : Parc national Banff{{/startsWith}}</span></a>
+				</li>
+				<li>
+					<a href="#tab2"><img src="{{assets}}/img/promos/1170x347-2.png" alt="" /><span class="wb-inv">{{#startsWith "en" language }}Tab 2: Algonquin Provincial Park{{else}}Languette 2 : Parc Provincial Algonquin{{/startsWith}}</span></a>
+				</li>
+				<li>
+					<a href="#tab3"><img src="{{assets}}/img/promos/1170x347-3.png" alt="" /><span class="wb-inv">{{#startsWith "en" language }}Tab 3: Rideau Canal{{else}}Languette 3 : Canal Rideau{{/startsWith}}</span></a>
+				</li>
+			</ul>
+			<div class="tabpanels">
+				<div role="tabpanel" id="tab1" class="in fade">
+					<a href="#" class="learnmore">
+						<figure>
+							<img src="{{assets}}/img/promos/1170x347-1.png" alt="" />
+							<figcaption>
+								<p>{{#startsWith "en" language }}Banff National Park {{else}} Parc national Banff{{/startsWith}}</p>
+							</figcaption>
+						</figure>
+					</a>
+				</div>
+				<div role="tabpanel" id="tab2" class="out fade">
+					<a href="#" class="learnmore">
+						<figure>
+							<img src="{{assets}}/img/promos/1170x347-2.png" alt="" />
+							<figcaption>
+								<p>{{#startsWith "en" language }}Algonquin Provincial Park {{else}} Parc Provincial Algonquin{{/startsWith}}</p>
+							</figcaption>
+						</figure>
+					</a>
+				</div>
+				<div role="tabpanel" id="tab3" class="out fade">
+					<a href="#" class="learnmore">
+						<figure>
+							<img src="{{assets}}/img/promos/1170x347-3.png" alt="" />
+							<figcaption>
+								<p>{{#startsWith "en" language }}Rideau Canal {{else}} Canal Rideau{{/startsWith}}</p>
+							</figcaption>
+						</figure>
+					</a>
 				</div>
 			</div>
 		</div>

--- a/site/pages/campaign-en.hbs
+++ b/site/pages/campaign-en.hbs
@@ -9,7 +9,7 @@
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-22",
+	"dateModified": "2017-10-02",
 	"share": "true"
 }
 ---

--- a/site/pages/campaign-fr.hbs
+++ b/site/pages/campaign-fr.hbs
@@ -9,7 +9,7 @@
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-22",
+	"dateModified": "2017-10-02",
 	"share": "true"
 }
 ---

--- a/site/pages/event-en.hbs
+++ b/site/pages/event-en.hbs
@@ -9,7 +9,7 @@
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-22",
+	"dateModified": "2017-10-02",
 	"share": "true"
 }
 ---

--- a/site/pages/event-fr.hbs
+++ b/site/pages/event-fr.hbs
@@ -9,7 +9,7 @@
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2014-10-22",
+	"dateModified": "2017-10-02",
 	"share": "true"
 }
 ---

--- a/site/pages/home-en.hbs
+++ b/site/pages/home-en.hbs
@@ -7,7 +7,7 @@
 	"promotion": "carousel",
 	"breadcrumb": "false",
 	"toplevel": true,
-	"dateModified": "2017-09-29",
+	"dateModified": "2017-10-02",
 	"share": "true",
 	"report": "true"
 }

--- a/site/pages/home-fr.hbs
+++ b/site/pages/home-fr.hbs
@@ -7,7 +7,7 @@
 	"promotion": "carousel",
 	"breadcrumb": "false",
 	"toplevel": true,
-	"dateModified": "2017-09-29",
+	"dateModified": "2017-10-02",
 	"share": "true",
 	"report": "true"
 }

--- a/site/pages/news-en.hbs
+++ b/site/pages/news-en.hbs
@@ -6,7 +6,7 @@
 	"promotion": "carousel",
 	"breadcrumb": "false",
 	"secondlevel": false,
-	"dateModified": "2016-07-20",
+	"dateModified": "2017-10-02",
 	"share": "true",
 	"pageType": "news"
 }


### PR DESCRIPTION
The promotion1 include only contains a carousel. It doesn't use a grid layout, so the "row" class was being misused. That class was also causing the include's carousel to become wider than the content area and "touch" that area's far left/right edges. It was especially noticeable in extra-small view and under.

This commit removes the "row" div and affects the following page templates:
* Campaign (example 1)
* Event
* Home
* News (English-only)