### PR TITLE
Sample links: Moved square brackets into link text.

### DIFF
--- a/site/includes/byline.hbs
+++ b/site/includes/byline.hbs
@@ -1,2 +1,2 @@
-<p><strong>{{#is page.language "en"}}From [<a href="#">Institution name</a>]{{else}}De [<a href="#">nom de l’institution</a>]{{/is}}</strong></p>
+<p><strong>{{#is page.language "en"}}From <a href="#">[Institution name]</a>{{else}}De <a href="#">[nom de l’institution]</a>{{/is}}</strong></p>
 

--- a/site/pages/ministerial-en.hbs
+++ b/site/pages/ministerial-en.hbs
@@ -30,7 +30,7 @@
         <p>House of Commons<br>
           Ottawa, Ontario &nbsp;K1A 0A6<br>
           Telephone: 123-456-7890<br>
-          Email: [<a href="mailto:">first.last@canada.ca</a>] <span class="glyphicon glyphicon-envelope"></span></p>
+          Email: <a href="mailto:">[first.last@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
       </section>
     </div>
     <div class="col-md-3">

--- a/site/pages/ministerial-fr.hbs
+++ b/site/pages/ministerial-fr.hbs
@@ -30,7 +30,7 @@
         <p> Chambre des communes<br>
           Ottawa (Ontario)&nbsp;K1A 0A6<br>
           Téléphone : 123-456-7890<br>
-          Courriel : [<a href="mailto:">prénom.nom@canada.ca</a>] <span class="glyphicon glyphicon-envelope"></span></p>
+          Courriel : <a href="mailto:">[prénom.nom@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
       </section>
     </div>
     <div class="col-md-3">


### PR DESCRIPTION
Most of GCWeb's sample links were already doing this, but a handful weren't (their brackets were situated outside of the links).