### PR TITLE
Theme: Fixed layout issues with summaries styled as default buttons.

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -202,6 +202,24 @@ aside {
 	}
 }
 
+/* Summaries styled as default buttons */
+details {
+	&[open] {
+		> {
+			summary {
+				&.btn-default {
+					border: 1px outset $btn-default-border {
+						bottom: {
+							left-radius: 4px;
+							right-radius: 4px;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 /* Thumbnail Treatments */
 .thumbnail {
 	background: $profile-gray;


### PR DESCRIPTION
When expanding details elements that use summaries styled as default buttons, their borders were previously changing in an undesirable manner.

Specifically:
* Button borders were disabled. This caused the buttons, their content and their outlines to shift positions. If content was spread across multiple lines, it could even cause words to "jump" to a preceding line.
* Bottom border radiuses were disabled. This caused the bottom of the buttons to become square-shaped upon being pressed.
* A light grey bottom border was added.

This commit fixes it by adding SCSS overrides to restore the default button style's intended layout on affected summary elements.

**Screenshots (Firefox Developer Edition 57.0b6):**
* **Collapsed ``details`` element (for reference):**
![gcweb-summary-btn-default-collapsed](https://user-images.githubusercontent.com/1907279/31295892-4af32e10-aaae-11e7-9e7b-6c79402194f3.png)
* **Expanded ``details`` element (before):**
![gcweb-summary-btn-default-expanded-before](https://user-images.githubusercontent.com/1907279/31295895-4d20c792-aaae-11e7-9bba-0c1817f724d3.png)
* **Expanded ``details`` element (after):**
![gcweb-summary-btn-default-expanded-after](https://user-images.githubusercontent.com/1907279/31295898-4f10ef8c-aaae-11e7-8ee7-2c13a3a39bb7.png)
