### PR TITLE
Theme: Darkened light grey colour SCSS variable.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -10,6 +10,7 @@ $border-red: #af3c43;
 $active-blue: #243850;
 $search-gray: #e0e0e0;
 $profile-gray: #eaebed;
+$gray-light: #6f6f6f; // Light grey colour (Bootstrap override).
 
 // Body
 $body-bg: #f9f9f9; // Body element's background colour (Bootstrap override).


### PR DESCRIPTION
Bootstrap 3.3.1 contains an SCSS colour variable called $gray-dark. It's sometimes used as a text colour against white backgrounds or as a background colour against white text.

Bootstrap's default value for $gray-dark fails WCAG 2.0 AA's contrast ratio requirements when used against white text/backgrounds. To meet those requirements, wet-boew/wet-boew#5600 darkened that variable's value in WET's core SCSS.

wet-boew/wet-boew#5600's fix achieved a 4.5:1 contrast ratio in WET themes that use white background colours. But in GCWeb, the fix only produced a 4.3:1 contrast ratio, since that theme uses a light grey background colour.

This commit further darkens $gray-dark in GCWeb to meet WCAG 2.0 AA's contrast ratio requirements. It depends on wet-boew/wet-boew#8198.

Credit goes to @donmcdill for initially noticing this issue.