### PR TITLE
Build: Made sasslint task's src globbing patterns more specific.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -401,10 +401,7 @@ module.exports = (grunt) ->
 			all:
 				expand: true
 				src: [
-						"**/*.scss"
-						"!lib/**"
-						"!node_modules/**"
-						"!dist/**"
+						"src/**/*.scss"
 					]
 
 		sass:


### PR DESCRIPTION
The "sasslint" task was previously setup to include any SCSS files as sources on a global scale. Exclusion patterns were used to omit anything within the lib, node_modules and dist folders. That resulted in really slow linting performance in Windows environments. That setup was also inconsistent with most of the other tasks. Apart from the "gh-pages" task, all other tasks' source inclusion patterns are more specific and don't rely so heavily on exclusion patterns.

This commit improves the "sasslint" task's performance (especially on Windows) by making its source inclusion patterns more specific and by reducing its reliance on exclusion patterns.

Port of wet-boew/wet-boew#8202.

@nschonni @LaurentGoderre FYI.