### PR TITLE
Data-JSON: Add support to template by selecting JSON object + bug fix

### DIFF
--- a/src/plugins/data-json/data-json-doc-en.hbs
+++ b/src/plugins/data-json/data-json-doc-en.hbs
@@ -265,6 +265,158 @@
 </section>
 
 <section>
+<h2 id="jsonObjToArr">Template - Transforming JSON object into an array</h2>
+
+<p>Since WET 4.0.27 it is now possible to iterate anything that is not an array to render content through a <code>&lt;template&gt;</code>. It simply get transformed into a array. There is a low risk of lost of information, only one specific use case. It's quite similar to the JSON-LD Expanded Form. In this transformation process, it assume the array key is an IRI. Then the will result include some property from JSON-LD such as <code>@id</code> and <code>@value</code>. The <code>@id</code> wont be overwritten, in those such case the array key will be discard after the transformation.</p>
+
+<h3>When the value is a sub-object</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": {
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	"key2": {
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "key1",
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	{
+		"@id": "key2",
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+]</code></pre>
+</div></div>
+
+<h3>When the value are not an object</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": "value1",
+	"key2": "value2",
+	"key3": "value3"
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "key1",
+		"@value": "value1"
+	},
+	{
+		"@id": "key2",
+		"@value": "value2"
+	},
+	{
+		"@id": "key3",
+		"@value": "value3"
+	}
+]</code></pre>
+</div></div>
+
+<h3>When the value is a native data type</h3>
+<p>Selecting the value of <code>key1</code> to iterate.</p>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": "value1"
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>{
+	"key1": [
+		"value1"
+	]
+}</code></pre>
+</div></div>
+
+<h3>When the value is an array</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": [
+		{ "keyA": "value1" },
+		{ "keyA": "value2" }
+	],
+	"key2":  [
+		{ "keyA": "value3" },
+		{ "keyA": "value4" }
+	]
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "key1",
+		"@value": [
+			"keyA": "value1",
+			"keyA": "value2"
+		]
+	},
+	{
+		"@id": "key2",
+		"@value":
+			"keyA": "value3",
+			"keyA": "value4"
+		]
+	}
+]</code></pre>
+</div></div>
+
+<h3>When the array key information will be lost</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": {
+		"@id": "http://wet-boew.github.io/vocab/example/1",
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	"key2": {
+		"@id": "http://wet-boew.github.io/vocab/example/2",
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "http://wet-boew.github.io/vocab/example/1",
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	{
+		"@id": "http://wet-boew.github.io/vocab/example/2",
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+]</code></pre>
+</div></div>
+
+</section>
+
+<section>
 <h2>Cache busting</h2>
 <p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
 <p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
@@ -455,7 +607,10 @@
 		<td><code>mapping</code></td>
 		<td>Template only. Array of string represeting a JSON pointer or object where it specify how to bind the data with the template content. If the configuration <code>queryall</code> is used, the number of items in the mapping must match the number of returning result of the queryall. In the other hand, if <code>queryall</code> configuration is not specified, than each mapping object must define a <code>selector</code> configuration.</td>
 		<td><code>data-wb-json='{ "url": "", "mapping": [ "JSON Pointer", "JSON Pointer" ] }'</code> or <code>data-wb-json='{ "url": "", "mapping": [ {mapping object}, {mapping object} ] }'</code></td>
-		<td>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</td>
+		<td>
+			<p>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</p>
+			<p>A mapping object can contain another mapping object to support sub-template. That inner mapping can also contain it's own <code>queryall</code> configuration.</p>
+		</td>
 	</tr>
 
 	<tr>
@@ -490,7 +645,7 @@
 	</tr>
 	<tr>
 		<td><code>appendto</code></td>
-		<td>Template only. When the elements are outside the editing area, this specified the element to use to append the template. Specifying the data-json directly of the elements should remain how it is used.</td>
+		<td>Template only. When the elements are outside the editing area, this specified the element to use to append the template. Specifying the data-json directly of the elements should remain how it is used. Note: Since WET 4.0.27 a bug fix has change the behavior of one usecase depending how the mapping is configured. Since WET 4.0.27, using the data-json template is always done against an JSON array.</td>
 		<td><code>data-wb-json='{ "url": "", "appendto": "title" }'</code></td>
 		<td>A valid jQuery selector.</td>
 	</tr>

--- a/src/plugins/data-json/data-json-doc-fr.hbs
+++ b/src/plugins/data-json/data-json-doc-fr.hbs
@@ -268,6 +268,158 @@
 </section>
 
 <section>
+<h2 id="jsonObjToArr">Template - Transforming JSON object into an array</h2>
+
+<p>Since WET 4.0.27 it is now possible to iterate anything that is not an array to render content through a <code>&lt;template&gt;</code>. It simply get transformed into a array. There is a low risk of lost of information, only one specific use case. It's quite similar to the JSON-LD Expanded Form. In this transformation process, it assume the array key is an IRI. Then the will result include some property from JSON-LD such as <code>@id</code> and <code>@value</code>. The <code>@id</code> wont be overwritten, in those such case the array key will be discard after the transformation.</p>
+
+<h3>When the value is a sub-object</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": {
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	"key2": {
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "key1",
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	{
+		"@id": "key2",
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+]</code></pre>
+</div></div>
+
+<h3>When the value are not an object</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": "value1",
+	"key2": "value2",
+	"key3": "value3"
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "key1",
+		"@value": "value1"
+	},
+	{
+		"@id": "key2",
+		"@value": "value2"
+	},
+	{
+		"@id": "key3",
+		"@value": "value3"
+	}
+]</code></pre>
+</div></div>
+
+<h3>When the value is a native data type</h3>
+<p>Selecting the value of <code>key1</code> to iterate.</p>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": "value1"
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>{
+	"key1": [
+		"value1"
+	]
+}</code></pre>
+</div></div>
+
+<h3>When the value is an array</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": [
+		{ "keyA": "value1" },
+		{ "keyA": "value2" }
+	],
+	"key2":  [
+		{ "keyA": "value3" },
+		{ "keyA": "value4" }
+	]
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "key1",
+		"@value": [
+			"keyA": "value1",
+			"keyA": "value2"
+		]
+	},
+	{
+		"@id": "key2",
+		"@value":
+			"keyA": "value3",
+			"keyA": "value4"
+		]
+	}
+]</code></pre>
+</div></div>
+
+<h3>When the array key information will be lost</h3>
+<div class="row">
+<div class="col-sm-6">
+<p>Source</p>
+<pre><code>{
+	"key1": {
+		"@id": "http://wet-boew.github.io/vocab/example/1",
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	"key2": {
+		"@id": "http://wet-boew.github.io/vocab/example/2",
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+}</code></pre>
+</div>
+<div class="col-sm-6">
+<p>After</p>
+<pre><code>[
+	{
+		"@id": "http://wet-boew.github.io/vocab/example/1",
+		"keyA": "value1",
+		"keyB": "value2"
+	},
+	{
+		"@id": "http://wet-boew.github.io/vocab/example/2",
+		"keyA": "value3",
+		"keyB": "value4"
+	}
+]</code></pre>
+</div></div>
+
+</section>
+
+<section>
 <h2>Cache busting</h2>
 <p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
 <p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
@@ -458,7 +610,10 @@
 		<td><code>mapping</code></td>
 		<td>Template only. Array of string represeting a JSON pointer or object where it specify how to bind the data with the template content. If the configuration <code>queryall</code> is used, the number of items in the mapping must match the number of returning result of the queryall. In the other hand, if <code>queryall</code> configuration is not specified, than each mapping object must define a <code>selector</code> configuration.</td>
 		<td><code>data-wb-json='{ "url": "", "mapping": [ "JSON Pointer", "JSON Pointer" ] }'</code> or <code>data-wb-json='{ "url": "", "mapping": [ {mapping object}, {mapping object} ] }'</code></td>
-		<td>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</td>
+		<td>
+			<p>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</p>
+			<p>A mapping object can contain another mapping object to support sub-template. That inner mapping can also contain it's own <code>queryall</code> configuration.</p>
+		</td>
 	</tr>
 
 	<tr>
@@ -493,7 +648,7 @@
 	</tr>
 	<tr>
 		<td><code>appendto</code></td>
-		<td>Template only. When the elements are outside the editing area, this specified the element to use to append the template. Specifying the data-json directly of the elements should remain how it is used.</td>
+		<td>Template only. When the elements are outside the editing area, this specified the element to use to append the template. Specifying the data-json directly of the elements should remain how it is used. Note: Since WET 4.0.27 a bug fix has change the behavior of one usecase depending how the mapping is configured. Since WET 4.0.27, using the data-json template is always done against an JSON array.</td>
 		<td><code>data-wb-json='{ "url": "", "appendto": "title" }'</code></td>
 		<td>A valid jQuery selector.</td>
 	</tr>

--- a/src/plugins/data-json/demo/data-en.json
+++ b/src/plugins/data-json/demo/data-en.json
@@ -22,18 +22,18 @@
 		{ "name": "Jean Edmonds, North Tower", "num": 300, "street": "Slater", "city": "Ottawa", "css": "bg-success" },
 		{ "name": "Place du portage, Phase I", "num": 50, "street": "Victoria", "city": "Gatineau", "css": "bg-danger" }
 	],
-	"comments": [
-		{
+	"comments": {
+		"2017-1": {
 			"name": "Mr X",
 			"city": "Gatineau",
 			"somethingHTML": "<strong>Horay</strong> here rich HTML content",
 			"hobby": [ "Car", "Mechanic", "Race" ]
 		},
-		{
+		"2017-2": {
 			"name": "Mrs Y",
 			"city": "St-Pierre",
 			"somethingHTML": "<strong>Youpi</strong> word should be with emphasis",
 			"hobby": [ "Spa", "Nature", "Bike", "Reading" ]
 		}
-	]
+	}
 }

--- a/src/plugins/data-json/demo/data-fr.json
+++ b/src/plugins/data-json/demo/data-fr.json
@@ -22,18 +22,18 @@
 		{ "nom": "Jean Edmonds, Tour nord", "num": 300, "rue": "Slater", "ville": "Ottawa", "css": "bg-success" },
 		{ "nom": "Place du portage, Phase I", "num": 50, "rue": "Victoria", "ville": "Gatineau", "css": "bg-danger" }
 	],
-	"commentaire": [
-		{
+	"commentaire": {
+		"2017-1": {
 			"nom": "M. X",
 			"ville": "Gatineau",
 			"quelquesChoseHTML": "<strong>Horay</strong> ici du contenu HTML enrichie",
 			"passetemps": [ "Voiture", "Mécanique", "Course" ]
 		},
-		{
+		"2017-2": {
 			"nom": "Mme. Y",
 			"ville": "St-Pierre",
 			"quelquesChoseHTML": "le mot <strong>Youpi</strong> devrais avoir de la mise en évidence",
 			"passetemps": [ "Spa", "Nature", "Bicyclette", "Lecture" ]
 		}
-	]
+	}
 }

--- a/src/plugins/data-json/template-en.hbs
+++ b/src/plugins/data-json/template-en.hbs
@@ -45,20 +45,20 @@
 		{ &quot;name&quot;: &quot;Jean Edmonds, North Tower&quot;, &quot;num&quot;: 300, &quot;street&quot;: &quot;Slater&quot;, &quot;city&quot;: &quot;Ottawa&quot;, &quot;css&quot;: &quot;bg-success&quot; },
 		{ &quot;name&quot;: &quot;Place du portage, Phase I&quot;, &quot;num&quot;: 50, &quot;street&quot;: &quot;Victoria&quot;, &quot;city&quot;: &quot;Gatineau&quot;, &quot;css&quot;: &quot;bg-danger&quot; }
 	],
-	&quot;comments&quot;: [
-		{
+	&quot;comments&quot;: {
+		&quot;2017-1&quot;: {
 			&quot;name&quot;: &quot;Mr X&quot;,
 			&quot;city&quot;: &quot;Gatineau&quot;,
 			&quot;somethingHTML&quot;: &quot;&lt;strong&gt;Horay&lt;/strong&gt; here rich HTML content&quot;,
 			&quot;hobby&quot;: [ &quot;Car&quot;, &quot;Mechanic&quot;, &quot;Race&quot; ]
 		},
-		{
+		&quot;2017-2&quot;: {
 			&quot;name&quot;: &quot;Mrs Y&quot;,
 			&quot;city&quot;: &quot;St-Pierre&quot;,
 			&quot;somethingHTML&quot;: &quot;&lt;strong&gt;Youpi&lt;/strong&gt; word should be with emphasis&quot;,
 			&quot;hobby&quot;: [ &quot;Spa&quot;, &quot;Nature&quot;, &quot;Bike&quot;, &quot;Reading&quot; ]
 		}
-	]
+	}
 }</code></pre>
 </details>
 
@@ -368,6 +368,33 @@
 &lt;/div&gt;</code></pre>
 </details>
 
+<h2>Iterate from a JSON Object</h2>
+
+<p>When iterating a JSON object it get transformed into an array of objects by following a JSON-LD extended form style. You will find in the <a href="data-json-doc-en.html#jsonObjToArr">data-JSON documentation</a> sample of JSON object before and after it's transformation into an array.</p>
+
+<ul class="lst-spcd" data-wb-json='{
+		"url": "demo/data-en.json#/anArray/2",
+		"queryall": "li",
+		"mapping": "/@value"
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;ul class=&quot;lst-spcd&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray/2&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: &quot;/@value&quot;
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;</code></pre>
+</details>
+
 <h2>Table</h2>
 
 <div class="alert alert-info">
@@ -610,22 +637,22 @@
 <h2>Use <code>template</code> placeholder for appending to an element</h2>
 
 <template id="metadatacontent"  data-wb-json='{
-		"url": "demo/data-en.json",
+		"url": "demo/data-en.json#/product",
 		"appendto": "title",
 		"source": "#metadatacontent",
 		"mapping": [
-			{ "value": "/product", "placeholder": "[[great]]" }
+			{ "placeholder": "[[great]]" }
 		]
 	}'> *** [[great]] ***</template>
 
 <p>(To see this working example, take a look at the <code>title</code> element on this page)</p>
 
 <pre><code>&lt;template id=&quot;metadatacontent&quot;  data-wb-json='{
-		&quot;url&quot;: &quot;data-en.json&quot;,
+		&quot;url&quot;: &quot;data-en.json#/product&quot;,
 		&quot;appendto&quot;: &quot;title&quot;,
 		&quot;source&quot;: &quot;#metadatacontent&quot;,
 		&quot;mapping&quot;: [
-			{ &quot;value&quot;: &quot;/product&quot;, &quot;placeholder&quot;: &quot;[[great]]&quot; }
+			{ &quot;placeholder&quot;: &quot;[[great]]&quot; }
 		]
 	}'&gt; *** [[great]] ***&lt;/template&gt;</code></pre>
 

--- a/src/plugins/data-json/template-fr.hbs
+++ b/src/plugins/data-json/template-fr.hbs
@@ -46,20 +46,20 @@
 		{ &quot;nom&quot;: &quot;Place du portage, Phase I&quot;, &quot;num&quot;: 50, &quot;rue&quot;: &quot;Victoria&quot;, &quot;ville&quot;: &quot;Gatineau&quot;, &quot;css&quot;: &quot;bg-danger&quot; }
 	],
 	&quot;auteur&quot;: &quot;&lt;a href=\&quot;https://github.com/duboisp/\&quot;&gt;Pierre Dubois&lt;/a&gt; a créé la fonctionalité data-json&quot;,
-	&quot;commentaire&quot;: [
-		{
+	&quot;commentaire&quot;: {
+		&quot;2017-1&quot;: {
 			&quot;nom&quot;: &quot;M. X&quot;,
 			&quot;ville&quot;: &quot;Gatineau&quot;,
 			&quot;quelquesChoseHTML&quot;: &quot;&lt;strong&gt;Horay&lt;/strong&gt; ici du contenu HTML enrichie&quot;,
 			&quot;passetemps&quot;: [ &quot;Voiture&quot;, &quot;Mécanique&quot;, &quot;Course&quot; ]
 		},
-		{
+		&quot;2017-2&quot;: {
 			&quot;nom&quot;: &quot;Mme. Y&quot;,
 			&quot;ville&quot;: &quot;St-Pierre&quot;,
 			&quot;quelquesChoseHTML&quot;: &quot;le mot &lt;strong&gt;Youpi&lt;/strong&gt; devrais avoir de la mise en évidence&quot;,
 			&quot;passetemps&quot;: [ &quot;Spa&quot;, &quot;Nature&quot;, &quot;Bicyclette&quot;, &quot;Lecture&quot; ]
 		}
-	]
+	}
 }</code></pre>
 </details>
 
@@ -371,6 +371,33 @@
 &lt;/div&gt;</code></pre>
 </details>
 
+<h2>Répéter à partir d'un objet JSON</h2>
+
+<p>Lorsqu'on selectionne un objet JSON à la place d'un tableau, celui va être transformé en tableau selon un style similaire au JSON-LD sous sa forme étendu. Vous trouverez dans la <a href="data-json-doc-fr.html#jsonObjToArr">documentation du data-json</a> des examples illustrant les transformations d'objet vers un tableau.</p>
+
+<ul class="lst-spcd" data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau/2",
+		"queryall": "li",
+		"mapping": "/@value"
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;ul class=&quot;lst-spcd&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau/2&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: &quot;/@value&quot;
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;</code></pre>
+</details>
+
 <h2>Tableau</h2>
 
 <div class="alert alert-info">
@@ -614,22 +641,22 @@
 <h2>Utilisé l'espace réserver avec un <code>template</code> pour ajouter à un élément</h2>
 
 <template id="metadatacontent"  data-wb-json='{
-		"url": "demo/data-fr.json",
+		"url": "demo/data-fr.json#/produit",
 		"appendto": "title",
 		"source": "#metadatacontent",
 		"mapping": [
-			{ "value": "/produit", "placeholder": "[[fantastique]]" }
+			{ "placeholder": "[[fantastique]]" }
 		]
 	}'> *** [[fantastique]] ***</template>
 
 <p>(Pour voir cet example pratique, regarder le contenu de l'élément <code>title</code> de cette page)</p>
 
 <pre><code>&lt;template id=&quot;metadatacontent&quot;  data-wb-json='{
-		&quot;url&quot;: &quot;demo/data-fr.json&quot;,
+		&quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;,
 		&quot;appendto&quot;: &quot;title&quot;,
 		&quot;source&quot;: &quot;#metadatacontent&quot;,
 		&quot;mapping&quot;: [
-			{ &quot;value&quot;: &quot;/produit&quot;, &quot;placeholder&quot;: &quot;[[fantastique]]&quot; }
+			{ &quot;placeholder&quot;: &quot;[[fantastique]]&quot; }
 		]
 	}'&gt; *** [[fantastique]] ***&lt;/template&gt;</code></pre>
 

--- a/src/plugins/deps/template.js
+++ b/src/plugins/deps/template.js
@@ -10,11 +10,36 @@
 /*
  * Variable and function definitions.
  * These are global to the polyfill - meaning that they will be initialized once per page.
+ * This polyfill is mostly used to support <template> element in IE11
  */
 var componentName = "wb-template",
 	selector = "template",
 	initEvent = "wb-init." + componentName,
 	$document = wb.doc,
+
+	/**
+	 * @method polyfill
+	 * @param {DOM element} element that we need to apply the polyfill
+	 */
+	polyfill = function( elm ) {
+
+		if ( elm.content ) {
+			return;
+		}
+		var elPlate = elm,
+			qContent,
+			docContent;
+
+		qContent = elPlate.childNodes;
+		docContent = document.createDocumentFragment();
+
+		while ( qContent[ 0 ] ) {
+			docContent.appendChild( qContent[ 0 ] );
+		}
+
+		elPlate.content = docContent;
+
+	},
 
 	/**
 	 * @method init
@@ -29,26 +54,15 @@ var componentName = "wb-template",
 
 		if ( elm ) {
 
-			if ( !elm.content ) {
-
-				var elPlate = elm,
-					qContent,
-					docContent;
-
-				qContent = elPlate.childNodes;
-				docContent = document.createDocumentFragment();
-
-				while ( qContent[ 0 ] ) {
-					docContent.appendChild( qContent[ 0 ] );
-				}
-
-				elPlate.content = docContent;
-			}
+			polyfill( elm );
 
 			// Identify that initialization has completed
 			wb.ready( $( elm ), componentName );
 		}
 	};
+
+// Make it available of when template element is needed on the fly, like subtemplate support in IE11
+wb.tmplPolyfill = polyfill;
 
 // Bind the events of the polyfill
 $document.on( "timerpoke.wb " + initEvent, selector, init );


### PR DESCRIPTION
Data-JSON: Add support to template by selecting a JSON object instead of an array and IE11 bug fix with sub-template.

Working example: 
* http://universallabs.org/wet/labs/gcweb-2017-11-21/unmin/demos/data-json/template-en.html