### PR TITLE
Theme: Removed all references to the "gc-drmt" class.

### DIFF
--- a/site/includes/focuson.hbs
+++ b/site/includes/focuson.hbs
@@ -5,16 +5,16 @@
 		</div>
 	</div>
 	<div class="wb-eqht row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">{{{i18n "home-focuson-audience"}}}</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis architecto repellendus hic iure laboriosam.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">{{{i18n "home-focuson-audience"}}}</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis architecto repellendus hic iure laboriosam.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">{{{i18n "home-focuson-audience"}}}</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis architecto repellendus hic iure laboriosam.</p>
 		</section>

--- a/site/includes/task.hbs
+++ b/site/includes/task.hbs
@@ -1,4 +1,4 @@
-<section class="gc-drmt">
+<section>
 	<h3 class="h5"><a href="#">{{{i18n "doormat-task-link-text"}}}</a></h3>
 	<p>{{{i18n "doormat-task-description"}}}</p>
 </section>

--- a/site/includes/theme-topic.hbs
+++ b/site/includes/theme-topic.hbs
@@ -1,4 +1,4 @@
-<section class="col-md-6 gc-drmt">
+<section class="col-md-6">
 	<h3 class="h5"><a href="#">{{#is page.language "fr"}}[Lien à un sujet]{{else}}[Topic hyperlink text]{{/is}}</a></h3>
 	<p>{{#is page.language "fr"}}Résumé des renseignements disponibles ou des tâches pouvant être accomplies sur la page. Supprimez les longs libellés et les messages promotionnels. Utilisez une formulation basée sur l'action.{{else}}Summary of the information or tasks that can be accomplished on the topic page. Remove prose or promotional messaging. Use action verbs.{{/is}}</p>
 </section>

--- a/site/includes/topic-subtopic.hbs
+++ b/site/includes/topic-subtopic.hbs
@@ -1,5 +1,5 @@
 <div class="col-md-6">
-	<section class="gc-drmt">
+	<section>
 		<h3 class="h5"><a href="#">
 		{{#is page.language "fr"}}
 		[Lien à un sous-sujet]

--- a/site/pages/campaign2-en.hbs
+++ b/site/pages/campaign2-en.hbs
@@ -63,15 +63,15 @@
 	<h2 id="s1">[Heading 1]</h2>
 	<p>Short sentence describing topic.</p>
 	<div class="row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 1]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 2]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 3]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
@@ -81,15 +81,15 @@
 	<h2 id="s2">[Heading 2]</h2>
 	<p>Short sentence describing topic.</p>
 	<div class="row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 1]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 2]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 3]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
@@ -99,15 +99,15 @@
 	<h2 id="s3">[Heading 3]</h2>
 	<p>Short sentence describing topic.</p>
 	<div class="row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 1]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 2]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Hyperlink text 3]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>

--- a/site/pages/campaign2-fr.hbs
+++ b/site/pages/campaign2-fr.hbs
@@ -63,15 +63,15 @@
 	<h2 id="s1">[Titre 1]</h2>
 	<p>Phrase courte décrivant le thème.</p>
 	<div class="row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 1]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 2]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 3]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
@@ -81,15 +81,15 @@
 	<h2 id="s2">[Titre 2]</h2>
 	<p>Phrase courte décrivant le thème.</p>
 	<div class="row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 1]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 2]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 3]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
@@ -99,15 +99,15 @@
 	<h2 id="s3">[Titre 3]</h2>
 	<p>Phrase courte décrivant le thème.</p>
 	<div class="row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 1]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 2]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="#">[Lien hypertexte 3]</a></h3>
 			<p>Lorem ipsum dolor sit  amet, consectetur adipisicing elit. Eaque praesentium, nulla ab nobis.</p>
 		</section>

--- a/site/pages/home-en.hbs
+++ b/site/pages/home-en.hbs
@@ -20,44 +20,44 @@
 		</div>
 	</div>
 	<div class="wb-eqht row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.esdc.gc.ca/en/jobs/opportunities/index.page" rel="external">Find a Job</a></h3>
 			<p>Find public and private sector job opportunities and hiring programs, apply or extend a work permit, get a Social Insurance Number, a criminal record check or a security clearance.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="https://www.canada.ca/en/services/benefits/ei.html">Employment Insurance</a></h3>
 			<p>Information about Employment Insurance (<abbr>EI</abbr>) temporary benefits for workers, sickness, fishing and family-related benefits as well as how to apply online and submit a report.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.cra-arc.gc.ca/esrvc-srvce/tx/ndvdls/myccnt/menu-eng.html" rel="external">My Account for individuals &ndash; Canada Revenue Agency</a></h3>
 			<p>Information on how the service works, how to register for it, and what you can do online.</p>
 		</section>
 		<div class="clearfix visible-lg"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.servicecanada.gc.ca/eng/services/pensions/cpp/retirement/index.shtml" rel="external">Canada Pension Plan retirement pension</a></h3>
 			<p>Information on eligibility criteria, deciding when to take your pension, how to apply online and amounts.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.servicecanada.gc.ca/eng/services/pensions/oas/pension/index.shtml" rel="external">Old Age Security pension</a></h3>
 			<p>Information on a pension you can receive if you are 65 years of age or older and have lived in Canada for at least 10 years - even if you have never worked.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.cic.gc.ca/english/residents/passport.asp" rel="external">Get a passport</a></h3>
 			<p>Includes passport applications, passport offices and processing times for renewals and new applications.</p>
 		</section>
 		<div class="clearfix visible-md visible-lg"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://weather.gc.ca/?&amp;wb48617274=F4EE897A" rel="external">Weather</a></h3>
 			<p>Information on current conditions, short and long-term forecasts and public weather alerts, access marine forecasts, the Air Quality Health Index and historical climate data.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.forces.ca/en/home/" rel="external">Join the Armed Forces</a></h3>
 			<p>Information about jobs with the Canadian Armed Forces, wages, benefits and recruitment centre locations.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="https://www.canada.ca/en/services/business/start.html">Business Planning</a></h3>
 			<p>Includes checklists and guides for starting a business, business planning tips, and templates and sample business plans.</p>
 		</section>

--- a/site/pages/home-fr.hbs
+++ b/site/pages/home-fr.hbs
@@ -20,44 +20,44 @@
 		</div>
 	</div>
 	<div class="wb-eqht row">
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.edsc.gc.ca/fr/emplois/opportunites/index.page?" rel="external">Trouver un emploi</a></h3>
 			<p>Trouvez des possibilités d’emploi et des programmes d’embauche dans les secteurs public et privé, demandez ou prolongez un permis de travail, obtenez un numéro d’assurance sociale, une vérification du casier judiciaire ou une vérification de sécurité.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="https://www.canada.ca/fr/services/prestations/ae.html">Assurance-emploi</a></h3>
 			<p>Renseignements sur les prestations temporaires d’assurance-emploi pour les travailleurs, les prestations de maladie, les prestations de pêcheur, les prestations en lien avec la situation familiale, ainsi que la marche à suivre pour présenter une demande en ligne et faire une déclaration.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.cra-arc.gc.ca/esrvc-srvce/tx/ndvdls/myccnt/menu-fra.html" rel="external">Mon dossier pour les particuliers &ndash; Agence du revenu du Canada</a></h3>
 			<p>Renseignements sur le fonctionnement du service, la façon de vous inscrire et ce que vous pouvez faire en ligne.</p>
 		</section>
 		<div class="clearfix visible-lg"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.servicecanada.gc.ca/fra/services/pensions/rpc/retraite/index.shtml" rel="external">Régime de pensions du Canada</a></h3>
 			<p>Renseignements sur les critères d’admissibilité, sur le choix du moment où vous commencerez à recevoir votre pension, sur la façon de présenter une demande en ligne et sur les montants auxquels vous aurez droit.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.servicecanada.gc.ca/fra/services/pensions/sv/pension/index.shtml" rel="external">Pension de la Sécurité de la vieillesse</a></h3>
 			<p>Renseignements sur une pension que vous pouvez recevoir si vous avez 65 ans ou plus et que vous avez habité au Canada pendant au moins 10&nbsp;ans (même si vous n’y avez jamais travaillé).</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.cic.gc.ca/francais/residents/passeport.asp" rel="external">Obtenir un passeport</a></h3>
 			<p>Demandes de passeport, bureaux des passeports et délais de traitement pour les renouvellements et les nouvelles demandes.</p>
 		</section>
 		<div class="clearfix visible-md visible-lg"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://meteo.gc.ca/?&amp;wb48617274=AAB6929C" rel="external">Renseignements météorologiques</a></h3>
 			<p>Renseignements sur les conditions actuelles, les prévisions à court et long terme et les alertes météo publiques, accès aux prévisions maritimes, à la Cote air santé et aux données climatiques historiques.</p>
 		</section>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.forces.ca/fr/home" rel="external">S'enrôler dans les Forces armées canadiennes</a></h3>
 			<p>Renseignements sur les emplois dans les Forces armées canadiennes, la rémunération, les avantages sociaux et l’emplacement des centres de recrutement.</p>
 		</section>
 		<div class="clearfix visible-md"></div>
-		<section class="col-lg-4 col-md-6 gc-drmt">
+		<section class="col-lg-4 col-md-6">
 			<h3 class="h5"><a href="http://www.entreprisescanada.ca/fra/page/2865/" rel="external">Planification d’entreprise</a></h3>
 			<p>Des listes de contrôle et des guides sur le démarrage d’entreprise, des conseils utiles ainsi que des modèles et des exemples de plans d’affaires.</p>
 		</section>


### PR DESCRIPTION
That class wasn't associated to any SCSS styles. It also wasn't used consistently across either GCWeb nor real-world implementations of that theme (including the MWS).

If it solely existed as a placeholder class to make it possible to easily modify the layout of all doormat links in the future, it was unable to fully achieve that objective since it was missing from many pages that use those kinds of links.

@lucas-hay @masterbee @shawnthompson Thoughts?