### PR TITLE
Theme: Reference SVG logos with img element instead of object.

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,6 +1,6 @@
 {{#unless experimental}}
 	<div class="brand col-xs-8 col-sm-9 col-md-6">
-		<a href="https://www.canada.ca/{{language}}.html"><object type="image/svg+xml" tabindex="-1" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg"></object><span class="wb-inv"> {{{i18n "tmpl-gc-sig"}}} / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span></a>
+		<a href="https://www.canada.ca/{{language}}.html"><img src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="" /><span class="wb-inv"> {{{i18n "tmpl-gc-sig"}}} / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span></a>
 	</div>
 {{else}}
 	<div class="brand col-xs-6">

--- a/site/includes/footerbrand.hbs
+++ b/site/includes/footerbrand.hbs
@@ -15,7 +15,7 @@
 				<a href="#wb-cont">{{{i18n "tmpl-toppage"}}} <span class="glyphicon glyphicon-chevron-up"></span></a>
 			</div>
 			<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+				<img src="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
 			</div>
 		</div>
 	</div>

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -18,10 +18,10 @@
 		<header role="banner" id="wb-bnr" class="container">
 			<div class="row">
 				<div class="col-sm-6">
-					<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" aria-label="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}"></object>
+					<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}" />
 				</div>
 				<div class="col-sm-6">
-					<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+					<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
 				</div>
 			</div>
 		</header>

--- a/site/pages/splashpage.hbs
+++ b/site/pages/splashpage.hbs
@@ -20,7 +20,7 @@
 		<h1 property="name" class="wb-inv">{{title}}</h1>
 		<div class="row">
 			<div class="col-xs-11 col-md-8">
-				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" aria-label="{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}"></object>
+				<img src="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" alt="{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}" />
 			</div>
 		</div>
 		<div class="row">
@@ -40,7 +40,7 @@
 				<a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">{{{i18n "tmpl-terms"}}}</a> <span class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html" class="sp-lk" lang="fr">{{{i18n "tmpl-terms" language="fr"}}}</a>
 			</div>
 			<div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
-				<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-spl.svg" width="127" aria-label="{{{i18n "tmpl-gc-wmms"}}} / {{{i18n "tmpl-gc-wmms" language="fr"}}}"></object>
+				<img src="{{assets}}/../{{site.theme}}/assets/wmms-spl.svg" width="127" alt="{{{i18n "tmpl-gc-wmms"}}} / {{{i18n "tmpl-gc-wmms" language="fr"}}}" />
 			</div>
 		</div>
 	</div>

--- a/src/banner/_base.scss
+++ b/src/banner/_base.scss
@@ -27,10 +27,16 @@ header {
 			}
 		}
 
-		object,
-		img {
+		// Needed for backwards compatibility with GCWeb 4.0.27 and below's HTML markup.
+		// Remove object references from all of this theme's logo selectors in GCWeb 4.1+.
+		img,
+		object {
 			height: auto;
 			max-height: 40px;
+		}
+
+		img {
+			margin-bottom: .375em;
 		}
 	}
 }

--- a/src/messages.scss
+++ b/src/messages.scss
@@ -4,9 +4,15 @@
 @import "variables";
 
 .splash {
-	object {
+
+	object,
+	img {
 		height: auto;
 		max-width: 100%;
+	}
+
+	img {
+		margin-bottom: .375em;
 	}
 
 	#bg {


### PR DESCRIPTION
* Port of wet-boew/wet-boew#8282.
* Related to wet-boew/wet-boew#8276.
* Modifies SCSS to increase the bottom margins on the FIP images to replicate the empty space that was previously appearing below their object element containers.