### PR TITLE
Build: Updated grunt-contrib-clean to version ~1.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-banner": "^0.3.1",
     "grunt-bootlint": "^0.9.1",
     "grunt-check-dependencies": "~0.6.0",
-    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-clean": "~1.1.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.8.0",
     "grunt-contrib-copy": "~0.5.0",


### PR DESCRIPTION
0.6.0 is really old and was prone to ENOTEMPTY errors in Windows. Newer versions appear to be better off.

Port of wet-boew/wet-boew#8356.

**PS:** If #1344 is merged before this, I'll rebase this PR and modify package-lock.json. Or vice versa if this is merged in first.