### PR TITLE
Site: Removed metadata comments from server message page templates.

### DIFF
--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -9,9 +9,7 @@
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>{{title}}</title>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<!-- Meta data -->
 		<meta name="robots" content="noindex, nofollow, noarchive" />
-		<!-- Meta data-->
 		{{>servermessageresources}}
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">


### PR DESCRIPTION
WET's page templates don't contain any similar comments that describe other blocks of code. Furthermore, in each template, some metadata preceded the first comment and the second comment wasn't actually followed by any metadata.

Port of wet-boew/wet-boew#8390.