### PR TITLE
Theme: Hid expanded report a problem dropdowns when printing.

### DIFF
--- a/src/share/_print.scss
+++ b/src/share/_print.scss
@@ -2,8 +2,11 @@
  * Share/feedback-specific overrides (print view)
  */
 .pagedetails {
+	details	{
+		@extend %gcweb-print-display-none-important;
+	}
+
 	.btn {
 		@extend %gcweb-print-display-none-important;
 	}
 }
-


### PR DESCRIPTION
Previously, if a user expanded the "Report a problem on this page" dropdown in a browser and subsequently printed the page they were on, the dropdown's expanded content would appear in the printout. However, the expanded content served no purpose in that context. Furthermore, since the "Report a problem on this page" button is hidden when printing, the purpose of the expanded content wasn't clear.

This change prevents the expanded content from ever appearing in printouts.