### PR TITLE
menu - Added colour to menubar css in Basic HTML mode

### DIFF
--- a/src/menu/_base.scss
+++ b/src/menu/_base.scss
@@ -5,6 +5,7 @@
 	background: $accent-blue;
 
 	.menu {
+        background: $accent-blue;
 		display: table;
 		margin-bottom: 0;
 		text-shadow: 1px 1px 1px #222;

--- a/src/menu/_base.scss
+++ b/src/menu/_base.scss
@@ -5,7 +5,6 @@
 	background: $accent-blue;
 
 	.menu {
-		background: $accent-blue;
 		display: table;
 		margin-bottom: 0;
 		text-shadow: 1px 1px 1px #222;
@@ -89,6 +88,15 @@
 		}
 	}
 }
+
+.wb-disable {
+	#wb-sm {
+		.menu {
+			background: $accent-blue;
+		}
+	}
+}
+
 
 
 /*

--- a/src/menu/_base.scss
+++ b/src/menu/_base.scss
@@ -5,7 +5,7 @@
 	background: $accent-blue;
 
 	.menu {
-        background: $accent-blue;
+		background: $accent-blue;
 		display: table;
 		margin-bottom: 0;
 		text-shadow: 1px 1px 1px #222;

--- a/src/menu/_base.scss
+++ b/src/menu/_base.scss
@@ -97,8 +97,6 @@
 	}
 }
 
-
-
 /*
  * Mobile panel
  */


### PR DESCRIPTION
Fixes #1021

Issue caused by menubar overflowing when page was too small or too zoomed in.
Only occurs when WET is not loaded.
Added background colour to menubar to preserve readability.