### PR TITLE
Changes to colouring of placeholder text

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -28,9 +28,7 @@ a {
 }
 
 // scss-lint:disable QualifyingElement
-input[placeholder],
-[placeholder],
-*[placeholder] {
+*[placeholder]::placeholder {
 	color: $input-color-placeholder;
 }
 

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -32,6 +32,6 @@ Left menu variables
 $menu-background: #fff;
 $menu-colour: #555;
 
-$input-color-placeholder: #646564 !important;
+$input-color-placeholder: #636463 !important;
 
 @import "wet-boew/src/variables";

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -32,6 +32,6 @@ Left menu variables
 $menu-background: #fff;
 $menu-colour: #555;
 
-$input-color-placeholder: #767676 !important;
+$input-color-placeholder: #646564 !important;
 
 @import "wet-boew/src/variables";

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -32,6 +32,6 @@ Left menu variables
 $menu-background: #fff;
 $menu-colour: #555;
 
-$input-color-placeholder: #5c5c5c !important;
+$input-color-placeholder: #767676 !important;
 
 @import "wet-boew/src/variables";


### PR DESCRIPTION
Normally, a text field's placeholder text is a different, usually paler color than the user input. Currently, we are setting both of these to the same color: #5c5c5c

The first part of this PR makes it so only the placeholder text is being set to #5c5c5c. User input will be colored as #555555 by the theming for form-control elements.

The second part of this PR changes the placeholder colour to #636463. This is the palest value that satisfies the WCAG requirement 1.4.3 on contrast. (contrasting against the color of the search bar, #e0e0e0)

It should be noted that the difference between placeholder text and normal text is still quite minimal, but this is what is needed to satisfy WCAG.

Possible issues:
The changes to default.scss may cause unwanted changes to styling, although I cannot think of any situation where it would. If this is a concern, there is another fix.

Fixes #1285.