### PR TITLE
Fix part of #1305: remove pull right classes and update ministerial template 

### DIFF
--- a/site/pages/localnav/index-en.hbs
+++ b/site/pages/localnav/index-en.hbs
@@ -6,9 +6,9 @@
 	"pageclass": "secondary",
 	"breadcrumb": [
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Theme Name]", "link": "index-en.html" }
+		{ "title": "[Theme Name]", "link": "theme-en.html" }
 	],
-	"dateModified": "2017-12-05",
+	"dateModified": "2018-06-05",
 	"share": "true",
 	"deptfeature": true
 }
@@ -48,13 +48,12 @@
 			</section>
 		</div>
 	</section>
-	<div class="clr-rght-md clr-rght-lg"></div>
 	<div class="pull-right col-xs-12 col-md-4">
 		{{>supported-by}}
 		{{>more-info}}
 	</div>
 </div>
-<section>
+<section class="whtwedo">
 	<h2>What we are doing</h2>
 	<div class="row wb-eqht">
 		<section class="col-lg-4 col-md-6">

--- a/site/pages/localnav/index-fr.hbs
+++ b/site/pages/localnav/index-fr.hbs
@@ -6,9 +6,9 @@
 	"pageclass": "secondary",
 	"breadcrumb": [
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Theme Name]", "link": "index-en.html" }
+		{ "title": "[Thème]", "link": "theme-fr.html" }
 	],
-	"dateModified": "2017-12-05",
+	"dateModified": "2018-06-05",
 	"share": "true",
 	"deptfeature": true
 }
@@ -27,7 +27,7 @@
 	<div class="col-md-4 col-xs-12 pull-right">
 		{{>most-requested}}
 	</div>
-	<section class="col-md-8 pull-left mrgn-bttm-lg">
+	<section class="col-md-8 pull-left">
 		<h2>Services et renseignements</h2>
 		<div class="wb-eqht row">
 			<section class="col-md-6">
@@ -48,13 +48,12 @@
 			</section>
 		</div>
 	</section>
-	<div class="clr-rght-md clr-rght-lg"></div>
 	<div class="pull-right col-xs-12 col-md-4">
 		{{>supported-by}}
 		{{>more-info}}
 	</div>
 </div>
-<section>
+<section class="whtwedo">
 	<h2>Ce que nous faisons</h2>
 	<div class="row wb-eqht">
 		<section class="col-lg-4 col-md-6">

--- a/site/pages/ministerial-en.hbs
+++ b/site/pages/ministerial-en.hbs
@@ -7,64 +7,70 @@
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" },
 		{ "title": "Government of Canada Ministers", "link": "#" }
 	],
-	"dateModified": "2017-12-05",
+	"dateModified": "2018-06-05",
 	"share": "true"
 }
 ---
 <div class="row">
-    <div class="col-md-3">
-      <p class="mrgn-tp-lg"><img src="./img/265x352.png" alt="" class="img-responsive"></p>
-    </div>
-    <div class="col-md-6">
+	<div class="col-md-3">
+	  <p class="mrgn-tp-lg"><img src="./img/265x352.png" alt="" class="img-responsive"></p>
+	</div>
+	<div class="col-md-6">
 		<p class="mrgn-tp-lg"><strong>Minister of <a href="#">[Portfolio name one]</a> and <a href="#">[Portfolio name two]</a></strong><a href="#"></a></p>
-      <p>Represents the riding of <a href="#">[Riding name]</a></p>
-      <ul>
-        <li><a href="#">Ministerial mandate letter</a></li>
-        <li><a href="#">Ministerial briefing book</a></li>
-        <li><a href="#">Ministerial appointments</a></li>
-      </ul>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique ex commodi autem laudantium aliquam id, voluptate possimus quod illo velit vero, at dolorum sequi ipsam culpa fugit, molestias quaerat vitae.</p>
-      <section>
-        <h2 class="h5">Contact information</h2>
-        <p>House of Commons<br>
-          Ottawa, Ontario &nbsp;K1A 0A6<br>
-          Telephone: 123-456-7890<br>
-          Email: <a href="mailto:">[first.last@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
-      </section>
-    </div>
-    <div class="col-md-3">
-      <h2>Twitter</h2>
-      [Twitter feed] </div>
+	  <p>Represents the riding of <a href="#">[Riding name]</a></p>
+	  <ul>
+		<li><a href="#">Ministerial mandate letter</a></li>
+		<li><a href="#">Ministerial briefing book</a></li>
+		<li><a href="#">Ministerial appointments</a></li>
+	  </ul>
+	  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+	  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique ex commodi autem laudantium aliquam id, voluptate possimus quod illo velit vero, at dolorum sequi ipsam culpa fugit, molestias quaerat vitae.</p>
+	  <section>
+		<h2>Contact information</h2>
+		<p>House of Commons<br>
+		  Ottawa, Ontario&nbsp;K1A&nbsp;0A6<br>
+		  <strong>Telephone:</strong> 123-456-7890<br>
+		  <strong>Email:</strong> <a href="mailto:">[first.last@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
+	  </section>
+	</div>
+	<div class="col-md-3">
+	  <h2>Twitter</h2>
+	  [Twitter feed] </div>
   </div>
   <div class="row">
-    <div class="col-sm-12">
-      <section>
-        <h2>Latest</h2>
-        <div class="gc-nws row">
-          <div class="col-md-8">
-            <div class="row">
-              <div class="col-md-6"> <a href="#"> <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
-                <p>[News title]</p>
-                </a> <small>YYYY-MM-DD hh:mm - Type of news product</small>
-                <p>Brief description of the news item.</p>
-              </div>
-              <div class="col-md-6"> <a href="#"> <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
-                <p>[News title]</p>
-                </a> <small>YYYY-MM-DD hh:mm - Type of news product</small>
-                <p>Brief description of the news item.</p>
-              </div>
-            </div>
-          </div>
-          <div class="wb-feeds limit-3 col-md-4">
-            <ul class="feeds-cont list-unstyled lst-spcd">
-              <li> <a href="http://news.gc.ca/web/fd-en.do?mthd=dpt&amp;ft=atom&amp;crtr.dpt1D=6675" rel="external">Government of Canada News Releases</a> </li>
-            </ul>
-            <p class="text-right"><strong><a href="#">All news</a></strong></p>
-          </div>
-        </div>
-      </section>
-    </div>
+	<div class="col-sm-12">
+	  <section>
+		<h2>Latest</h2>
+		<div class="gc-nws row">
+		  <div class="col-md-8">
+			<div class="row">
+			    <div class="col-md-6">
+                    <a href="#">
+                        <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
+                        <p>[News title]</p>
+                    </a>
+                    <p><small class="text-muted"><time>2018-06-05 19:00</time> - Type of news product</small><br />
+                    Brief description of the news item.</p>
+			    </div>
+			    <div class="col-md-6">
+                    <a href="#">
+                        <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
+                        <p>[News title]</p>
+                    </a>
+                    <p><small class="text-muted"><time>2018-06-05 20:00</time> - Type of news product</small><br />
+                    Brief description of the news item.</p>
+			    </div>
+			</div>
+		  </div>
+		  <div class="wb-feeds limit-3 col-md-4">
+			<ul class="feeds-cont list-unstyled lst-spcd">
+			  <li> <a href="http://news.gc.ca/web/fd-en.do?mthd=dpt&amp;ft=atom&amp;crtr.dpt1D=6675" rel="external">Government of Canada News Releases</a> </li>
+			</ul>
+			<p class="text-right"><strong><a href="#">All news</a></strong></p>
+		  </div>
+		</div>
+	  </section>
+	</div>
   </div>
 <section>
 	<h2>Recent activities</h2>
@@ -101,22 +107,38 @@
 <section>
 	<h2>Gallery</h2>
 	<div class="row">
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
+		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
+		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
+		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
+		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
 	</div>
 	<p><strong><a href="#">All photos and videos</a></strong></p>
 </section>

--- a/site/pages/ministerial-fr.hbs
+++ b/site/pages/ministerial-fr.hbs
@@ -7,64 +7,70 @@
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" },
 		{ "title": "Ministres du gouvernement du Canada", "link": "#" }
 	],
-	"dateModified": "2017-12-05",
+	"dateModified": "2018-06-05",
 	"share": "true"
 }
 ---
   <div class="row">
-    <div class="col-md-3">
-      <p class="mrgn-tp-lg"><img src="./img/265x352.png" alt="" class="img-responsive"></p>
-    </div>
-    <div class="col-md-6">
-      <p class="mrgn-tp-lg"><strong>Ministre de <a href="#">[nom du portefeuille no1]</a> et <a href="#">[nom du portefeuille no2]</a></strong></p>
-      <p>Représente la circonscription de <a href="#">[nom de la circonscription]</a></p>
-      <ul>
-        <li><a href="#">Lettre de mandat adressées aux ministres</a></li>
-        <li><a href="#">Cahier de breffage ministériel</a></li>
-        <li><a href="#">Nomination ministérielle</a></li>
-      </ul>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-      <section>
-        <h2 class="h5">Coordonnées</h2>
-        <p> Chambre des communes<br>
-          Ottawa (Ontario)&nbsp;K1A 0A6<br>
-          Téléphone : 123-456-7890<br>
-          Courriel : <a href="mailto:">[prénom.nom@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
-      </section>
-    </div>
-    <div class="col-md-3">
-      <h2>Twitter</h2>
-      [Twitter feed] </div>
+	<div class="col-md-3">
+	  <p class="mrgn-tp-lg"><img src="./img/265x352.png" alt="" class="img-responsive"></p>
+	</div>
+	<div class="col-md-6">
+	  <p class="mrgn-tp-lg"><strong>Ministre de <a href="#">[nom du portefeuille no1]</a> et <a href="#">[nom du portefeuille no2]</a></strong></p>
+	  <p>Représente la circonscription de <a href="#">[nom de la circonscription]</a></p>
+	  <ul>
+		<li><a href="#">Lettre de mandat adressées aux ministres</a></li>
+		<li><a href="#">Cahier de breffage ministériel</a></li>
+		<li><a href="#">Nomination ministérielle</a></li>
+	  </ul>
+	  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+	  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+	  <section>
+		<h2>Coordonnées</h2>
+		<p> Chambre des communes<br>
+		  Ottawa (Ontario)&nbsp;K1A&nbsp;0A6<br>
+		  <strong>Téléphone&nbsp;:</strong> 123-456-7890<br>
+		  <strong>Courriel&nbsp;:</strong> <a href="mailto:">[prénom.nom@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
+	  </section>
+	</div>
+	<div class="col-md-3">
+	  <h2>Twitter</h2>
+	  [Twitter feed] </div>
   </div>
   <div class="row">
-    <div class="col-sm-12">
-      <section>
-        <h2>Nouveautés</h2>
-        <div class="gc-nws row">
-          <div class="col-md-8">
-            <div class="row">
-              <div class="col-md-6"> <a href="#"> <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
-                <p>[Titre de l’article]</p>
-                </a> <small>AAAA-MM-JJ hh:mm - Type de produit médiatique</small>
-                <p>Brève description de la nouvelle.</p>
-              </div>
-              <div class="col-md-6"> <a href="#"> <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
-                <p>[Titre de l’article]</p>
-                </a> <small>AAAA-MM-JJ hh:mm - Type de produit médiatique</small>
-                <p>Brève description de la nouvelle.</p>
-              </div>
-            </div>
-          </div>
-          <div class="wb-feeds limit-3 col-md-4">
-            <ul class="feeds-cont list-unstyled lst-spcd">
-              <li> <a href="http://news.gc.ca/web/fd-fr.do?mthd=dpt&amp;ft=atom&amp;crtr.dpt1D=6675" rel="external">Nouvelles du Gouvernement du Canada </a> </li>
-            </ul>
-            <p class="text-right"><strong><a href="#">Toutes les nouvelles</a></strong></p>
-          </div>
-        </div>
-      </section>
-    </div>
+	<div class="col-sm-12">
+	  <section>
+		<h2>Nouveautés</h2>
+		<div class="gc-nws row">
+		  <div class="col-md-8">
+			<div class="row">
+			    <div class="col-md-6">
+                    <a href="#">
+                        <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
+                        <p>[Titre de l’article]</p>
+                    </a>
+                    <p><small class="text-muted"><time>2018-06-05 19:00</time> - Type de produit médiatique</small><br />
+                    Brève description de la nouvelle.</p>
+			    </div>
+			    <div class="col-md-6">
+                    <a href="#">
+                        <img src="./img/360x203.png" alt="" class="img-responsive thumbnail">
+                        <p>[Titre de l’article]</p>
+                    </a>
+                    <p><small class="text-muted"><time>2018-06-05 19:00</time> - Type de produit médiatique</small><br />
+                    Brève description de la nouvelle.</p>
+			    </div>
+			</div>
+		  </div>
+		  <div class="wb-feeds limit-3 col-md-4">
+			<ul class="feeds-cont list-unstyled lst-spcd">
+			  <li> <a href="http://news.gc.ca/web/fd-fr.do?mthd=dpt&amp;ft=atom&amp;crtr.dpt1D=6675" rel="external">Nouvelles du Gouvernement du Canada </a> </li>
+			</ul>
+			<p class="text-right"><strong><a href="#">Toutes les nouvelles</a></strong></p>
+		  </div>
+		</div>
+	  </section>
+	</div>
   </div>
 <section>
 	<h2>Activités récentes</h2>
@@ -101,22 +107,38 @@
 <section>
 	<h2>Galerie</h2>
 	<div class="row">
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
-		<a href="#"><figure class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-		</figure></a>
+        <div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
+        <div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
+        <div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
+        <div class="col-lg-3 col-md-6 mrgn-bttm-lg">
+			<a href="#">
+				<figure>
+					<img src="{{assets}}/img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
+				</figure>
+			</a>
+		</div>
 	</div>
 	<p><strong><a href="#">Toutes les photos et vidéos</a></strong></p>
 </section>


### PR DESCRIPTION
This pull request when added addresses two items identified in Issue #1305 : 

1. Remove the remaining `clr-rght-md` and `clr-rght-lg`
2. Fixing this content block: where column is not child of a row

In addition: 

3. The Ministerial profile page templates were brought more in line with how they appear in the [Content and IA Spec version 1.5](https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification/templates-detailed-specifications/ministerial-profile-pages.html).

Notes: 

1. I had to change the pattern of the Date and Time text in the News section (line 52 of the English Ministerial hbs file) to be an actual time `2018-06-05 19:00` because the html linter did not like the pattern `YYYY-MM-DD hh:mm` inside a `time` tag.