### PR TITLE
Theme: Removed leftover references to to the "pagetag" class/property.

### DIFF
--- a/site/pages/dept-en.hbs
+++ b/site/pages/dept-en.hbs
@@ -6,13 +6,13 @@
 	"breadcrumb": [
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" }
 	],
-	"dateModified": "2017-11-30",
+	"dateModified": "2018-07-12",
 	"share": "true"
 }
 ---
  <div class="row profile">
   <div class="col-xs-12">
-    <p class="pagetag">Enter a department name or abbreviation to find current Government of Canada departments, agencies, crown corporations and special operating agencies.</p>
+    <p>Enter a department name or abbreviation to find current Government of Canada departments, agencies, crown corporations and special operating agencies.</p>
   </div>
 </div>
 <table class="wb-tables table" data-wb-tables="{ &quot;paging&quot;: false }">

--- a/site/pages/dept-fr.hbs
+++ b/site/pages/dept-fr.hbs
@@ -6,13 +6,13 @@
 	"breadcrumb": [
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" }
 	],
-	"dateModified": "2017-11-30",
+	"dateModified": "2018-07-12",
 	"share": "true"
 }
 ---
 <div class="row profile">
   <div class="col-xs-12">
-    <p class="pagetag">Taper le nom ou l’abréviation d’un ministère pour trouver les ministères, les organismes gouvernementaux et de service spécial et les sociétés d'État actuels du gouvernement du Canada.</p>
+    <p>Taper le nom ou l’abréviation d’un ministère pour trouver les ministères, les organismes gouvernementaux et de service spécial et les sociétés d'État actuels du gouvernement du Canada.</p>
   </div>
 </div>
 <table class="wb-tables table" data-wb-tables="{ &quot;paging&quot;: false }">

--- a/site/pages/index/longindex-en.hbs
+++ b/site/pages/index/longindex-en.hbs
@@ -7,11 +7,11 @@
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2018-06-27",
+	"dateModified": "2018-07-12",
 	"share": "true"
 }
 ---
-<p class="pagetag">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>
 <p>Enter a word, or part of a word, that might match in what you are looking for into the text area below. We will narrow down the list to show only items that contain the term you have entered.</p>
 <div class="form-inline">
 <label for="longIdxFltr">What are you looking for?:</label>

--- a/site/pages/index/longindex-fr.hbs
+++ b/site/pages/index/longindex-fr.hbs
@@ -7,11 +7,11 @@
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2018-06-27",
+	"dateModified": "2018-07-12",
 	"share": "true"
 }
 ---
-<p class="pagetag">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>
 <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 <div class="form-inline">
 <label for="longIdxFltr">Que recherchez-vous?:</label>

--- a/site/pages/topic-fr.hbs
+++ b/site/pages/topic-fr.hbs
@@ -11,8 +11,7 @@
 	],
 	"dateModified": "2017-12-05",
 	"share": "true",
-	"deptfeature": true,
-	"pagetag": ""
+	"deptfeature": true
 }
 ---
 <div class="row profile">


### PR DESCRIPTION
References to the "pagetag" class, property and include were removed from all pages in #1155.

However, #1155 didn't remove the property from the French topic page template. Furthermore, #1297 inadvertently re-introduced the class into the departments and agencies page. The class was also present in #1372's long index pages.