### PR TITLE
EditorConfig: Added .*/JSON/MD/Gemfile.lock overrides and exempted font SVG.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,14 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 4
 
-[package.json]
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
+[{.*,*.json,*.md,Gemfile.lock}]
 indent_style = space
 indent_size = 2
+
+# External font
+[!src/fonts/*.svg]
+charset = unset
+trim_trailing_whitespace = unset
+insert_final_newline = unset
+indent_style = unset
+indent_size = unset


### PR DESCRIPTION
* Added dot-prefixed/JSON/MD formats and Gemfile.lock to 2 space indentation overrides. Overall, those files already use 2 spaces more heavily than tabs.
* Removed package.json from the aforementioned override. It'll continue to be covered via the JSON override.
* Removed redundant rules from 2 space indentation overrides. They're already set in the global overrides.
* Added unset overrides for the font SVG file. Should prevent other overrides from affecting that file if it's updated in the future.
* Port of wet-boew/wet-boew#8448 and wet-boew/wet-boew#8450.