### PR TITLE
Build: Added lintspaces task to check for .editorconfig compliance.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -137,6 +137,7 @@ module.exports = (grunt) ->
 		[
 			"eslint"
 			"sasslint"
+			"lintspaces"
 		]
 	)
 
@@ -399,6 +400,45 @@ module.exports = (grunt) ->
 				src: [
 						"src/**/*.scss"
 					]
+
+		lintspaces:
+			all:
+				src: [
+						# Root files
+						".editorconfig"
+						".git*"
+						".*rc"
+						".*.yml"
+						"Gemfile*"
+						"Gruntfile.coffee"
+						"Licen?e-*.txt"
+						"*.{json,md}"
+						"Rakefile"
+
+						# Folders
+						"script/**"
+						"site/**"
+						"src/**"
+
+						# Exemptions...
+
+						# Images
+						"!site/img/**/*.{jpg,png}"
+						"!src/assets/*.{ico,jpg,png}"
+
+						# External fonts
+						"!src/fonts/*.{eot,svg,ttf,woff}"
+
+						# Docker environment file
+						# File that gets created/populated in a manner that goes against .editorconfig settings during the main Travis-CI build.
+						"!script/docker/env"
+					],
+				options:
+					editorconfig: ".editorconfig",
+					ignores: [
+						"js-comments"
+					],
+					showCodes: true
 
 		sass:
 			options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
+      "dev": true,
+      "requires": {
+        "commander": "2.15.1"
+      }
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "CSSselect": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
@@ -687,11 +702,6 @@
           }
         }
       }
-    },
-    "bootstrap-sass": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.1.tgz",
-      "integrity": "sha1-NJERPWWAr/4r42dgBunXgVvpVCA="
     },
     "bower-config": {
       "version": "0.5.3",
@@ -1685,6 +1695,12 @@
       "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
       "dev": true
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1894,6 +1910,38 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.0.tgz",
+      "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
+      "dev": true,
+      "requires": {
+        "@types/commander": "2.12.2",
+        "@types/semver": "5.5.0",
+        "commander": "2.15.1",
+        "lru-cache": "4.1.3",
+        "semver": "5.5.1",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -4079,6 +4127,16 @@
         "temporary": "0.0.8"
       }
     },
+    "grunt-lintspaces": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/grunt-lintspaces/-/grunt-lintspaces-0.8.3.tgz",
+      "integrity": "sha512-D0PVIDjaPC2UZtvBeYKT1SgSEmqxgTwcYfJu/YcLl0SjV2SAf9jJWClFMqeo1Vmp3+0mALiRcyRRAYEp+WtQBQ==",
+      "dev": true,
+      "requires": {
+        "junitwriter": "0.3.1",
+        "lintspaces": "0.6.2"
+      }
+    },
     "grunt-mocha": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/grunt-mocha/-/grunt-mocha-0.4.15.tgz",
@@ -5098,14 +5156,6 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
       "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
     },
-    "jquery-validation": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.15.1.tgz",
-      "integrity": "sha1-fBZXEbYR9tzloSrj5IVcELWj4zE=",
-      "requires": {
-        "jquery": "2.1.4"
-      }
-    },
     "js-base64": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
@@ -5211,6 +5261,45 @@
         }
       }
     },
+    "junitwriter": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/junitwriter/-/junitwriter-0.3.1.tgz",
+      "integrity": "sha1-fADvwTauVmMJc7E98MAtZ5Y6r1o=",
+      "dev": true,
+      "requires": {
+        "dateformat": "1.0.11",
+        "merge": "1.2.0",
+        "mkdirp": "0.5.0",
+        "xmlbuilder": "2.6.2"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
     "kew": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
@@ -5273,6 +5362,17 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "lintspaces": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/lintspaces/-/lintspaces-0.6.2.tgz",
+      "integrity": "sha512-2WBNDTbVXtR+EFljfzMjjhbLHrlAfusQmznOigX2v+FnnnwyV03ZgwyuTkLJvba7E2Yy02vR60/hurpM6nRjJQ==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.6.0",
+        "editorconfig": "0.15.0",
+        "rc": "1.2.8"
       }
     },
     "load-grunt-tasks": {
@@ -5664,9 +5764,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
-    },
-    "magnific-popup": {
-      "version": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079"
     },
     "make-iterator": {
       "version": "0.3.1",
@@ -7203,6 +7300,26 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
@@ -9100,17 +9217,40 @@
     "wet-boew": {
       "version": "github:wet-boew/wet-boew#36642bf5d7bb8ad347670d48c18360e3b2f02d18",
       "requires": {
-        "bootstrap-sass": "3.3.1",
+        "bootstrap-sass": "3.3.7",
         "code-prettify": "0.1.0",
         "datatables": "1.10.13",
         "es5-shim": "2.3.0",
         "html5shiv": "3.7.3",
-        "jquery": "2.1.4",
-        "jquery-validation": "1.15.1",
+        "jquery": "2.2.4",
+        "jquery-validation": "1.17.0",
         "magnific-popup": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079",
         "mathjax": "2.7.1",
         "proj4": "2.3.3",
         "unorm": "1.4.1"
+      },
+      "dependencies": {
+        "bootstrap-sass": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+          "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
+        },
+        "jquery": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+          "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+        },
+        "jquery-validation": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.17.0.tgz",
+          "integrity": "sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==",
+          "requires": {
+            "jquery": "2.2.4"
+          }
+        },
+        "magnific-popup": {
+          "version": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079"
+        }
       }
     },
     "which": {
@@ -9185,6 +9325,23 @@
           "requires": {
             "minimist": "0.0.8"
           }
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+      "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
+      "dev": true,
+      "requires": {
+        "lodash": "3.5.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.5.0",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+          "integrity": "sha1-Gbs/TVEnjwuMgY7RRcdOz5/kDm0=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "grunt-html": "^5.0.0",
     "grunt-hub": "~0.7.0",
     "grunt-i18n-csv": "0.1.0",
+    "grunt-lintspaces": "^0.8.3",
     "grunt-mocha": "~0.4.12",
     "grunt-postcss": "^0.9.0",
     "grunt-sass": "^2.1.0",


### PR DESCRIPTION
* Added "lintspaces" at the end of the "test" task (which runs as part of the dist build).
* Inherits rules from the repo's .editorconfig file.
* Checks all of the repo's tracked files (minus comments, non-SVG images and external fonts).

**PS:**
This PR only introduces the linter itself. #1397 and #1398 should be merged-in beforehand, followed by a manual Travis-CI rebuild. The linter should start passing afterwards.