### PR TITLE
Campaign example 2: Fixed equal heights implementation.

### DIFF
--- a/site/pages/campaign2-en.hbs
+++ b/site/pages/campaign2-en.hbs
@@ -16,41 +16,41 @@
 <div class="row">
 	<div class="col-sm-10 col-sm-offset-1 cmpgn-sctns">
 		<ul class="list-unstyled row text-center wb-eqht">
-			<li class="col-sm-4 hght-inhrt">
-				<a href="#s1" class="btn btn-default btn-block well">
+			<li class="col-sm-4">
+				<a href="#s1" class="btn btn-default btn-block well hght-inhrt">
 					<div class="row">
 						<div class="col-sm-12 col-xs-3">
 							<img src="{{assets}}/img/promos/140x140-circle.png" class="img-responsive center-block" alt="" />
 						</div>
 						<div class="col-sm-12 col-xs-9">
 							<p class="mrgn-bttm-0"><strong class="h4">[Heading 1]</strong></p>
-							<p class="mrgn-bttm-lg sctn-desc">[Brief description]</p>
+							<p class="sctn-desc">[Brief description]</p>
 						</div>
 					</div>
 				</a>
 			</li>
-			<li class="col-sm-4 hght-inhrt">
-				<a href="#s2" class="btn btn-default btn-block well">
+			<li class="col-sm-4">
+				<a href="#s2" class="btn btn-default btn-block well hght-inhrt">
 					<div class="row">
 						<div class="col-sm-12 col-xs-3">
 							<img src="{{assets}}/img/promos/140x140-circle.png" class="img-responsive center-block" alt="" />
 						</div>
 						<div class="col-sm-12 col-xs-9">
 							<p class="mrgn-bttm-0"><strong class="h4">[Heading 2]</strong></p>
-							<p class="mrgn-bttm-lg sctn-desc">[Brief description]</p>
+							<p class="sctn-desc">[Brief description]</p>
 						</div>
 					</div>
 				</a>
 			</li>
-			<li class="col-sm-4 hght-inhrt">
-				<a href="#s3" class="btn btn-default btn-block well">
+			<li class="col-sm-4">
+				<a href="#s3" class="btn btn-default btn-block well hght-inhrt">
 					<div class="row">
 						<div class="col-sm-12 col-xs-3">
 							<img src="{{assets}}/img/promos/140x140-circle.png" class="img-responsive center-block" alt="" />
 						</div>
 						<div class="col-sm-12 col-xs-9">
 							<p class="mrgn-bttm-0"><strong class="h4">[Heading 3]</strong></p>
-							<p class="mrgn-bttm-lg sctn-desc">[Brief description]</p>
+							<p class="sctn-desc">[Brief description]</p>
 						</div>
 					</div>
 				</a>

--- a/site/pages/campaign2-fr.hbs
+++ b/site/pages/campaign2-fr.hbs
@@ -16,41 +16,41 @@
 <div class="row">
 	<div class="col-sm-10 col-sm-offset-1 cmpgn-sctns">
 		<ul class="list-unstyled row text-center wb-eqht">
-			<li class="col-sm-4 hght-inhrt">
-				<a href="#s1" class="btn btn-default btn-block well">
+			<li class="col-sm-4">
+				<a href="#s1" class="btn btn-default btn-block well hght-inhrt">
 					<div class="row">
 						<div class="col-sm-12 col-xs-3">
 							<img src="{{assets}}/img/promos/140x140-circle.png" class="img-responsive center-block" alt="" />
 						</div>
 						<div class="col-sm-12 col-xs-9">
 							<p class="mrgn-bttm-0"><strong class="h4">[Titre 1]</strong></p>
-							<p class="mrgn-bttm-lg sctn-desc">[Courte description]</p>
+							<p class="sctn-desc">[Courte description]</p>
 						</div>
 					</div>
 				</a>
 			</li>
-			<li class="col-sm-4 hght-inhrt">
-				<a href="#s2" class="btn btn-default btn-block well">
+			<li class="col-sm-4">
+				<a href="#s2" class="btn btn-default btn-block well hght-inhrt">
 					<div class="row">
 						<div class="col-sm-12 col-xs-3">
 							<img src="{{assets}}/img/promos/140x140-circle.png" class="img-responsive center-block" alt="" />
 						</div>
 						<div class="col-sm-12 col-xs-9">
 							<p class="mrgn-bttm-0"><strong class="h4">[Titre 2]</strong></p>
-							<p class="mrgn-bttm-lg sctn-desc">[Courte description]</p>
+							<p class="sctn-desc">[Courte description]</p>
 						</div>
 					</div>
 				</a>
 			</li>
-			<li class="col-sm-4 hght-inhrt">
-				<a href="#s3" class="btn btn-default btn-block well">
+			<li class="col-sm-4">
+				<a href="#s3" class="btn btn-default btn-block well hght-inhrt">
 					<div class="row">
 						<div class="col-sm-12 col-xs-3">
 							<img src="{{assets}}/img/promos/140x140-circle.png" class="img-responsive center-block" alt="" />
 						</div>
 						<div class="col-sm-12 col-xs-9">
 							<p class="mrgn-bttm-0"><strong class="h4">[Titre 3]</strong></p>
-							<p class="mrgn-bttm-lg sctn-desc">[Courte description]</p>
+							<p class="sctn-desc">[Courte description]</p>
 						</div>
 					</div>
 				</a>


### PR DESCRIPTION
* Moved "hght-inhrt" class from list items to the links within them.
* Removed "mrgn-bttm-lg" class from the brief description paragraphs. That class no longer serves any purpose since the inherited heights make the link boxes taller.
* Fixes wet-boew/wet-boew#8483.