### PR TITLE
Build: Depend on a specific version of WET (4.0.29).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9234,7 +9234,7 @@
     },
     "wet-boew": {
       "version": "github:wet-boew/wet-boew#36642bf5d7bb8ad347670d48c18360e3b2f02d18",
-      "from": "github:wet-boew/wet-boew",
+      "from": "github:wet-boew/wet-boew#v4.0.29",
       "requires": {
         "bootstrap-sass": "^3.3.7",
         "code-prettify": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",
     "jsonpointer.js": "^0.4.0",
-    "wet-boew": "wet-boew/wet-boew"
+    "wet-boew": "github:wet-boew/wet-boew#v4.0.29"
   },
   "devDependencies": {
     "assemble-contrib-i18n": "0.1.*",


### PR DESCRIPTION
GCWeb's package.json file previously specified "wet-boew/wet-boew" as a dependency, without a tag or commit hash. As a result, running npm install would cause package.json's wet-boew dependency to resolve to that project's latest commit and modify the working tree's version of package-lock.json to specify wet-boew's latest commit hash.

This commit modifies GCWeb's package files to specify WET 4.0.29's tag. That way, the version of WET that'll be used will be predictable and prevent package-lock.json's wet-boew entries from getting modified when a user installs the build system.