### PR TITLE
Renaming code name v2 for v5 along with the menu plugin and updated gcweb home page intro

### DIFF
--- a/site/includes/sitemenu.hbs
+++ b/site/includes/sitemenu.hbs
@@ -1,5 +1,5 @@
 {{#isnt language "fr"}}
-<nav class="gcweb-v2" typeof="SiteNavigationElement">
+<nav class="gcweb-menu" typeof="SiteNavigationElement">
 	<div class="container">
 		<h2 class="wb-inv">Menu</h2>
 		<button type="button" aria-haspopup="true" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
@@ -23,7 +23,7 @@
 	</div>
 </nav>
 {{else}}
-<nav class="gcweb-v2" typeof="SiteNavigationElement">
+<nav class="gcweb-menu" typeof="SiteNavigationElement">
 	<div class="container">
 		<h2 class="wb-inv">Menu</h2>
 		<button type="button" aria-haspopup="true" aria-expanded="false">Menu<span class="wb-inv"> principal</span> <span class="expicon glyphicon glyphicon-chevron-down"></span></button>

--- a/site/pages/component/list-en.hbs
+++ b/site/pages/component/list-en.hbs
@@ -1,6 +1,6 @@
 ---
 {
-	"title": "List - Additional style - GCWeb theme V2",
+	"title": "List - Additional style - GCWeb theme V5",
 	"language": "en",
 	"altLangPrefix": "list",
 	"breadcrumb": [
@@ -12,7 +12,7 @@
 }
 ---
 
-<p>The following style is an addition to list styling availble in <a href="http://wet-boew.github.io/wet-boew-styleguide/v4/design/lists-en.html">WET-BOEW Style Guide</a> and it is exclusive to GCWeb v2 theme</p>
+<p>The following style is an addition to list styling availble in <a href="http://wet-boew.github.io/wet-boew-styleguide/v4/design/lists-en.html">WET-BOEW Style Guide</a> and it is exclusive to GCWeb v5 theme</p>
 
 <h2>List double spaced <code>.lst-spcd-2</code></h2>
 

--- a/site/pages/component/list-fr.hbs
+++ b/site/pages/component/list-fr.hbs
@@ -1,6 +1,6 @@
 ---
 {
-	"title": "Liste - Style additionel - Thème de GCWeb V2",
+	"title": "Liste - Style additionel - Thème de GCWeb V5",
 	"language": "fr",
 	"altLangPrefix": "list",
 	"breadcrumb": [
@@ -12,7 +12,7 @@
 }
 ---
 
-<p>Le style suivant s'ajoute au style disponible dans le <a href="http://wet-boew.github.io/wet-boew-styleguide/v4/design/lists-en.html">guide de style de la WET-BOEW</a> et il est exclusive au thème de GCWeb V2.</p>
+<p>Le style suivant s'ajoute au style disponible dans le <a href="http://wet-boew.github.io/wet-boew-styleguide/v4/design/lists-en.html">guide de style de la WET-BOEW</a> et il est exclusive au thème de GCWeb V5.</p>
 
 <h2>Liste à double interline <code>.lst-spcd-2</code></h2>
 

--- a/site/pages/evaluation-report/1-accessibility.hbs
+++ b/site/pages/evaluation-report/1-accessibility.hbs
@@ -28,7 +28,7 @@
 	<dt>Subject</dt>
 	<dd>Evaluate the accessibility conformity of the new GCWeb look version 2.</dd>
 	<dt>Notes:</dt>
-	<dd>It was assumed that GCWeb, released with v4.0.29, was already meeting WCAG 2.0 Level AA. So a brief evaluation was done for those succes criteria. The following evaluation are mainly focus on the new GCWeb look (V2) area of changes.</dd>
+	<dd>It was assumed that GCWeb, released with v4.0.29, was already meeting WCAG 2.0 Level AA. So a brief evaluation was done for those succes criteria. The following evaluation are mainly focus on the new GCWeb look (V5) area of changes.</dd>
 </dl>
 
 <h2>Assesment summary</h2>
@@ -41,7 +41,7 @@
 	<dt>Fail Success Critiria</dt>
 	<dd>
 		<ul>
-			<li>SC 1.4.4 Resize text. Not related to the new GCWeb look (V2). See comments in the detailled report.</li>
+			<li>SC 1.4.4 Resize text. Not related to the new GCWeb look (V5). See comments in the detailled report.</li>
 		</ul>
 	</dd>
 	<dt>Level AAA</dt>

--- a/site/pages/gcweb-theme/index.hbs
+++ b/site/pages/gcweb-theme/index.hbs
@@ -7,15 +7,17 @@
 		{ "title": "GCWeb home", "link": "../index-en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2018-11-16",
+	"dateModified": "2019-01-29",
 	"share": "true"
 }
 ---
 
-<h2>GCWeb new look - V2</h2>
+<h2>GCWeb Canada.ca theme) visual update - V5</h2>
+
+<p>The GCWeb v5 (Canada.ca theme) visual update are supporting the Canada.ca Content and Information Architecture Specification 2.0.</p>
 
 <ul>
-	<li><a href="v2-migration.html">Migration instruction</a>
+	<li><a href="v5-migration.html">Migration instruction</a> (from v4.0.29 to v5)
 		<ul>
 			<li>Change: Page footer</li>
 			<li>Change: Page header Structure</li>
@@ -26,9 +28,9 @@
 	</li>
 	<li>New features (for web publisher):
 		<ul>
-			<li><a href="v2-migration.html#pg-dblspcd">Double space for list</a></li>
-			<li><a href="v2-migration.html#pg-list">Responsive list</a></li>
-			<li><a href="v2-migration.html#pg-linkfigure">Linked figure design pattern</a></li>
+			<li><a href="v5-migration.html#pg-dblspcd">Double space for list</a></li>
+			<li><a href="v5-migration.html#pg-list">Responsive list</a></li>
+			<li><a href="v5-migration.html#pg-linkfigure">Linked figure design pattern</a></li>
 			<li><a href="../content-en.html#cnt-wdth-lmtd">Content block with a limited width</a></li>
 			<li><a href="../content-en.html#call-to-action">Call to action button</a></li>
 		</ul>
@@ -47,7 +49,7 @@
 			<li><a href="../content-gcweb-4-0-29-font-style-en.html">Content page - GCWeb 4.0.29 font style</a></li>
 		</ul>
 	</li>
-	<li><a href="temp-v2issue.html">Temporary internal list of issues and todo</a></li>
+	<li><a href="temp-v5issue.html">Temporary internal list of issues and todo</a></li>
 </ul>
 
 <h3>Noticable visual difference with no markup change</h3>
@@ -114,7 +116,7 @@
 <h3 id="antialiasing">Use of font smoothing anti-aliasing</h3>
 
 <h4>Requirement</h4>
-<p>Configure the font smoothing anti-aliasing CSS for GCWeb theme v2.</p>
+<p>Configure the font smoothing anti-aliasing CSS for GCWeb theme v5.</p>
 
 <h4>Background</h4>
 <p><time datetime="2018-11-02">November 2<sup>nd</sup>, 2018</time></p>
@@ -186,7 +188,7 @@
 
 <h2>Previous version</h2>
 <ul>
-	<li>See GCWeb released with WET 4.0.29. All code change are documented in the migration instruction of GCWeb new look - V2.</li>
+	<li>See GCWeb released with WET 4.0.29. All code change are documented in the migration instruction of GCWeb new look - V5.</li>
 </ul>
 <h2>Test cases</h2>
 <ul>

--- a/site/pages/gcweb-theme/temp-v5issue.hbs
+++ b/site/pages/gcweb-theme/temp-v5issue.hbs
@@ -1,8 +1,8 @@
 ---
 {
-	"title": "Temporary issue and todo list - GCWeb theme V2",
+	"title": "Temporary issue and todo list - GCWeb theme V5",
 	"language": "en",
-	"altLangPrefix": "temp-v2issue",
+	"altLangPrefix": "temp-v5issue",
 	"breadcrumb": [
 		{ "title": "GCWeb home", "link": "../index-en.html" },
 		{ "title": "Theme meta", "link": "index.html" }

--- a/site/pages/gcweb-theme/v5-migration.hbs
+++ b/site/pages/gcweb-theme/v5-migration.hbs
@@ -1,8 +1,8 @@
 ---
 {
-	"title": "Migration instruction - GCWeb theme V2",
+	"title": "Migration instruction - GCWeb theme V5",
 	"language": "en",
-	"altLangPrefix": "v2-migration",
+	"altLangPrefix": "v5-migration",
 	"breadcrumb": [
 		{ "title": "GCWeb home", "link": "../index-en.html" },
 		{ "title": "Theme meta", "link": "index.html" }
@@ -30,6 +30,8 @@
 	<li><a href="#otherDiff">Other notable difference</a></li>
 </ul>
 
+
+<p><strong>Note for implementer that has used the GCWeb developer build on or before January 30, 2019</strong>. (This is not applicable for implemeter that has use the official GCWeb v5 release.) The top menu is now identified by using the CSS class <code>gcweb-menu</code> instead of <code>gcweb-v2</code>.</p>
 
 <h2 id="pg-footer">Page footer</h2>
 
@@ -85,7 +87,7 @@
 	<li>The color for the search button would be automated updated when the new style is applied.</li>
 	<li>Menu, see the following section for more details
 		<ul>
-			<li>The new menu style is applied when the CSS class <code>gcweb-v2</code> is applied to the navigation section of the main menu.
+			<li>The new menu style is applied when the CSS class <code>gcweb-menu</code> is applied to the navigation section of the main menu.
 				<ul>
 					<li>You will notice the "border-top" is added at the top of the menu.</li>
 					<li>You will notice the new styling for the menu button.</li>
@@ -285,7 +287,7 @@
 	<li>There is some translation string and markup variation between language for the button. It's the invisible complementary text.</li>
 </ul>
 
-<pre><code>&lt;nav class="gcweb-v2" typeof="SiteNavigationElement"&gt;
+<pre><code>&lt;nav class="gcweb-menu" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container"&gt;
 		&lt;h2 class="wb-inv"&gt;Menu&lt;/h2&gt;
 		&lt;button type="button" aria-haspopup="true" aria-expanded="false"&gt;&lt;span class="wb-inv"&gt;Main &lt;/span&gt;Menu &lt;span class="expicon glyphicon glyphicon-chevron-down"&gt;&lt;/span&gt;&lt;/button&gt;
@@ -298,7 +300,7 @@
 &lt;/nav&gt;</code></pre>
 
 <h3>French version</h3>
-<pre><code>&lt;nav class="gcweb-v2" typeof="SiteNavigationElement"&gt;
+<pre><code>&lt;nav class="gcweb-menu" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container"&gt;
 		&lt;h2 class="wb-inv"&gt;Menu&lt;/h2&gt;
 		&lt;button type="button" aria-haspopup="true" aria-expanded="false"&gt;Menu&lt;span class="wb-inv"&gt; principal&lt;/span&gt; &lt;span class="expicon glyphicon glyphicon-chevron-down"&gt;&lt;/span&gt;&lt;/button&gt;
@@ -328,7 +330,7 @@
 	<li>In the following working example, you can see a list of the top menu items which represents each theme.</li>
 </ul>
 
-<pre><code>&lt;nav class="gcweb-v2" typeof="SiteNavigationElement"&gt;
+<pre><code>&lt;nav class="gcweb-menu" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container"&gt;
 		&lt;h2 class="wb-inv"&gt;Menu&lt;/h2&gt;
 		&lt;button aria-haspopup="true" type="button"&gt;&lt;span class="wb-inv"&gt;Main &lt;/span&gt;Menu &lt;span class="expicon glyphicon glyphicon-chevron-down"&gt;&lt;/span&gt;&lt;/button&gt;
@@ -353,7 +355,7 @@
 &lt;/nav&gt;</code></pre>
 
 <h3>French version</h3>
-<pre><code>&lt;nav class="gcweb-v2" typeof="SiteNavigationElement"&gt;
+<pre><code>&lt;nav class="gcweb-menu" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container"&gt;
 		&lt;h2 class="wb-inv"&gt;Menu&lt;/h2&gt;
 		&lt;button type="button" aria-haspopup="true" aria-expanded="false"&gt;Menu&lt;span class="wb-inv"&gt; principal&lt;/span&gt; &lt;span class="expicon glyphicon glyphicon-chevron-down"&gt;&lt;/span&gt;&lt;/button&gt;
@@ -613,8 +615,8 @@
 
 <p>History:</p>
 <ul>
-	<li>Major - visual v2 - Move of the date modified after button as per the Content and IA spec.</li>
-	<li>Major - visual v2 - Include the CSS class container (only for the home page) when the CSS class container is not added to the main element.</li>
+	<li>Major - visual update v5 - Move of the date modified after button as per the Content and IA spec.</li>
+	<li>Major - visual update v5 - Include the CSS class container (only for the home page) when the CSS class container is not added to the main element.</li>
 	<li>Minor - v.4.0.28 - April 27, 2018 - Removal of the Privacy statement</li>
 	<li>Major - v.4.0.27 - December 14, 2017: Markup restructuration - Grid cell are now independant from the interactive elements to display the report a problem inline form.</li>
 	<li>Major - v.4.0.22 - August 9, 2016: Markup restructuration - Feedback link was change into an inline report a problem form.</li>
@@ -646,6 +648,6 @@
 
 <p>Some rules:</p>
 <ul>
-	<li>If the main element don't have the "container" CSS class, page details need to have that class set in order to keep it's content centered. Like for the home page with the visual v2.</li>
+	<li>If the main element don't have the "container" CSS class, page details need to have that class set in order to keep it's content centered. Like for the home page with the visual update v5.</li>
 	<li>If the page can be shared, the share button is added</li>
 </ul>

--- a/site/pages/home/index.hbs
+++ b/site/pages/home/index.hbs
@@ -15,7 +15,7 @@
 
 <dl class="horizontal">
 	<dt>Status</dt>
-	<dd>Stable for GCWeb V2</dd>
+	<dd>Stable for GCWeb V5</dd>
 
 	<dt>Type</dt>
 	<dd>Template <!-- Common design patter --></dd>
@@ -79,7 +79,7 @@
 
 <h2>Previous version</h2>
 <ul>
-	<li>See GCWeb released with WET 4.0.29. All code change are documented in the migration instruction of GCWeb new look - V2.</li>
+	<li>See GCWeb released with WET 4.0.29. All code change are documented in the migration instruction of GCWeb new look - V5.</li>
 </ul>
 
 <h2>Test cases</h2>

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -890,7 +890,7 @@
 		<li><a href="http://wet-boew.github.io/themes-dist/theme-gcwu-fegc/institution-fr.html" hreflang="fr">GCWU theme - French institution template</a></li>
 		<li><a href="tbl-floatcolumn-en.html">Float column in a data table</a></li>
 		<li><a href="redacted-en.html">Guidance on: Redacted text</a></li>
-		<li><a href="gcweb-theme/index.html">GCWeb theme meta (include migration note to the GCWeb V2 new look)</a></li>
+		<li><a href="gcweb-theme/index.html">GCWeb theme meta (include migration note to the GCWeb V5 new look)</a></li>
 	</ul>
 </section>
 <section>

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -11,9 +11,20 @@
 	"share": "true"
 }
 ---
-<p>The following are a implementation reference corresponding to the <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification/templates-detailed-specifications.html">Content and Information Architecture (C&amp;IA) Specification</a> <strong>version 1.5 released on May 2018</strong>. Government of Canada departments and agencies can add to this list by publishing their template, via <a href="https://github.com/wet-boew/GCWeb">GCWeb github repository</a>, which are out of scope or a complement the C&amp;IA specification.</p>
-<p><a href="#plugins">Plugins exclusive to this theme</a> are listed after the table.</p>
-<p>Found an C&amp;IA implementation issue or you want to contribute at their development, let us know by submiting <a href="https://github.com/wet-boew/GCWeb/issues/new?title=C&amp;IA%20implementation%20error:%20">GCweb issue</a>, sending <a href="https://github.com/wet-boew/GCWeb/pulls">pull request</a> or by participating at one of our <a href="http://wet-boew.github.io/wet-boew-documentation/index-en.html#wet-boew-code-sprint">WET-BOEW weekly Tuesday code sprint</a>.</p>
+<p>The following are an implementation reference corresponding to the <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification/templates-detailed-specifications.html">Content and Information Architecture (C&amp;IA) Specification</a>. Government of Canada departments and agencies can add to this list by publishing their template, via <a href="https://github.com/wet-boew/GCWeb">GCWeb github repository</a>, which are out of scope or a complement the C&amp;IA specification.</p>
+
+<p>This current implementation reference match the <strong>version 2.0 of the C&amp;IA Specification released on January 2019</strong>.</p>
+
+<ul class="colcount-md-2">
+	<li><a href="gcweb-theme/index.html">GCWeb v5 Summary and others technical notes</a></li>
+	<li><a href="gcweb-theme/v5-migration.html">GCWeb v5 Technial migration instruction</a></li>
+	<li><a href="#templates-common-design">Templates and common design patterns</a></li>
+	<li><a href="#plugins">Plugins exclusive to this theme</a></li>
+	<li><a href="#notes">Notes and others ressources</a></li>
+	<li><a href="#evaluation">Evaluation and report</a></li>
+</ul>
+
+<p><small>Found an C&amp;IA implementation issue or you want to contribute at their development, let us know by submiting <a href="https://github.com/wet-boew/GCWeb/issues/new?title=C&amp;IA%20implementation%20error:%20">GCweb issue</a>, sending <a href="https://github.com/wet-boew/GCWeb/pulls">pull request</a> or by participating at one of our <a href="http://wet-boew.github.io/wet-boew-documentation/index-en.html#wet-boew-code-sprint">WET-BOEW weekly Tuesday code sprint</a>.</small></p>
 <details>
 	<summary>Meaning of statuses</summary>
 	<dl class="dl-horizontal mrgn-bttm-0">
@@ -45,6 +56,8 @@
 		<dd>Do not use because it's deprecated, but listed here for your information.</dd>
 	</dl>
 </details>
+
+<h2 id="templates-common-design">Templates and common design patterns</h2>
 
 <div id="tbl-flt-ctrl" class="wb-frmvld hidden">
 	<form>
@@ -883,7 +896,7 @@
 	</ul>
 </section>
 <section>
-	<h2>Notes and other</h2>
+	<h2 id="notes">Notes and other resource</h2>
 	<ul>
 		<li><a href="deprecated-en.html">Deprecated markup</a></li>
 		<li><a href="http://wet-boew.github.io/themes-dist/theme-gcwu-fegc/institution-en.html">GCWU theme - English institution template</a></li>
@@ -894,7 +907,7 @@
 	</ul>
 </section>
 <section>
-	<h2>Evaluation and report</h2>
+	<h2 id="evaluation">Evaluation and report</h2>
 	<ul>
 		<li>November 16, 2018: <a href="evaluation-report/2-wetplugin-gcweb2.html">2 - Regression user acceptance testing of WET plugin for GCWeb theme version 2</a></li>
 		<li>November 14, 2018: <a href="evaluation-report/1-accessibility.html">1 - Accessibility assesment of GCWeb theme version 2</a></li>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -11,9 +11,20 @@
 	"share": "true"
 }
 ---
-<p>Ce site est principalement une référence d'implémentation de la <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification/templates-detailed-specifications.html">Spécifications du contenu et de l’architecture de l'information (C&amp;AI) pour Canada.ca</a> <strong>version 1.5 publié en mai 2018</strong>. Les ministères et organisme du gouvernement du Canada peuvent y contribuer, via le <a href="https://github.com/wet-boew/GCWeb">dépôt github de GCWeb</a>, en publiant leur modèle qui ne sont pas dans le champ d'application ou qui complémente la spécification C&amp;AI.</p>
-<p>Les <a href="#plugiciels">plugiciels exclusif à ce thème</a> sont énuméré après ce tableau.</p>
-<p>Vous avez trouvé des problèmes d'implémentation par rapport au C&amp;AI ou vous désirez contribué au dévelopement, faites nous le savoir en soumettant une <a href="https://github.com/wet-boew/GCWeb/issues/new?title=C&amp;IA%20implementation%20error:%20" hreflang="en">requête GCWeb</a>, en envoyant une <a href="https://github.com/wet-boew/GCWeb/pulls" hreflang="en" lang="en">pull request</a> ou en participant à un de nos <a href="http://wet-boew.github.io/wet-boew-documentation/index-en.html#wet-boew-code-sprint" hreflang="en"><span lang="en">code sprint</span> hedbomadaire à chaque mardi</a>.</p>
+<p>Ce site est principalement une référence d'implémentation de la <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/canada-content-information-architecture-specification/templates-detailed-specifications.html">Spécifications du contenu et de l’architecture de l'information (C&amp;AI) pour Canada.ca</a>. Les ministères et organisme du gouvernement du Canada peuvent y contribuer, via le <a href="https://github.com/wet-boew/GCWeb">dépôt github de GCWeb</a>, en publiant leur modèle qui ne sont pas dans le champ d'application ou qui complémente la spécification C&amp;AI.</p>
+
+<p>Cette référence d'implémentaion correspond à la <strong>version 2.0 de la spécification du C&amp;IA publié en janvier 2019</strong>.</p>
+
+<ul class="colcount-md-2">
+	<li><a href="gcweb-theme/index.html" hreflang="en" lang="en">GCWeb v5 Summary and others technical notes</a> <br />(En anglais seulement)</li>
+	<li><a href="gcweb-theme/v5-migration.html" hreflang="en" lang="en">GCWeb v5 Technial migration instruction</a> <br />(En anglais seulement)</li>
+	<li><a href="#modeles">Modèles et conception communes</a></li>
+	<li><a href="#plugiciels">Plugiciels exclusif à ce thème</a></li>
+	<li><a href="#notes">Notes et autres références</a></li>
+	<li><a href="#evaluation">Évaluation et rapport</a></li>
+</ul>
+
+<p><small>Vous avez trouvé des problèmes d'implémentation par rapport au C&amp;AI ou vous désirez contribuer au dévelopement, faites nous le savoir en soumettant une <a href="https://github.com/wet-boew/GCWeb/issues/new?title=C&amp;IA%20implementation%20error:%20" hreflang="en">requête GCWeb</a>, en envoyant une <a href="https://github.com/wet-boew/GCWeb/pulls" hreflang="en" lang="en">pull request</a> ou en participant à un de nos <a href="http://wet-boew.github.io/wet-boew-documentation/index-en.html#wet-boew-code-sprint" hreflang="en"><span lang="en">code sprint</span> hedbomadaire à chaque mardi</a>.</small></p>
 <details>
 	<summary>Définition des états</summary>
 	<dl class="dl-horizontal mrgn-bttm-0">
@@ -45,6 +56,8 @@
 		<dd>Ne pas utilisé car c'est obsolète, mais disponible pour votre information.</dd>
 	</dl>
 </details>
+
+<h2 id="modeles">Modèles et conception communes</h2>
 
 <div id="tbl-flt-ctrl" class="wb-frmvld hidden">
 	<form>
@@ -888,7 +901,7 @@
 	</ul>
 </section>
 <section>
-	<h2>Notes et autres</h2>
+	<h2 id="notes">Notes et autres références</h2>
 	<ul>
 		<li><a href="deprecated-fr.html">Balisage déconseillé</a></li>
 		<li><a href="http://wet-boew.github.io/themes-dist/theme-gcwu-fegc/institution-fr.html">Thème FEGC - Français - Gabarit de profil institutionnel</a></li>
@@ -899,7 +912,7 @@
 	</ul>
 </section>
 <section>
-	<h2>Évaluation et rapport</h2>
+	<h2 id="evaluation">Évaluation et rapport</h2>
 	<ul>
 		<li>16 november 2018: <a href="../evaluation-report/2-wetplugin-gcweb2.html" hreflang="en" lang="en">2 - Regression user acceptance testing of WET plugin for GCWeb theme version 2</a> (disponible en anglais seulement)</li>
 		<li>14 novembre 2018: <a href="evaluation-report/1-accessibility.html" hreflang="en" lang="en">1 - Accessibility assesment of GCWeb theme version 2</a> (disponible en anglais seulement)</li>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -895,7 +895,7 @@
 		<li><a href="http://wet-boew.github.io/themes-dist/theme-gcwu-fegc/institution-en.html" hreflang="en">Thème FEGC - Anglais - Gabarit de profil institutionnel</a></li>
 		<li><a href="tbl-floatcolumn-fr.html" lang="en">Float column in a data table</a></li>
 		<li><a href="redacted-fr.html">Ligne directrice sur: Texte expurgé</a></li>
-		<li><a href="gcweb-theme/index.html" hreflang="en">Méta information à propos du thème GCWeb (les notes de migration vers le nouveau look V2 sont incluses)</a> (disponible en anglais seulement)</li>
+		<li><a href="gcweb-theme/index.html" hreflang="en">Méta information à propos du thème GCWeb (les notes de migration vers le nouveau look V5 sont incluses)</a> (disponible en anglais seulement)</li>
 	</ul>
 </section>
 <section>

--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -144,7 +144,7 @@ legend {
 
 /* Force GCWeb release 4.0.29 font style
  *
- * This undo the font style introduced with gcweb v2 new look
+ * This undo the font style introduced with gcweb v5 new look
  *
  * - Rational: This is to help the adoption of the new desing by allowing adopter to use
  * a special CSS class on content like the one optimized for a desktop at 100% view port

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -25,9 +25,9 @@ $padding-base-horizontal: 14px;
 
 //Breadcrumb
 $breadcrumb-bg: transparent; // Inner background colour (Bootstrap override).
-$wb-bc-separator-content: ">"; // GCWeb v2
-$wb-bc-separator-content-rtl: "<"; // GCWeb v2
-$wb-bc-separator-font-size: .7em; // GCWeb v2
+$wb-bc-separator-content: ">"; // GCWeb v5
+$wb-bc-separator-content-rtl: "<"; // GCWeb v5
+$wb-bc-separator-font-size: .7em; // GCWeb v5
 
 //Heading links on landing pages
 $heading-link: 20px; // same as h5

--- a/src/breadcrumb/_base.scss
+++ b/src/breadcrumb/_base.scss
@@ -1,9 +1,9 @@
 /*
  WET breadcrumb overwrites
- for: GCWeb v2
+ for: GCWeb v5
  */
 
-.gcweb-v2 ~ #wb-bc {
+.gcweb-menu ~ #wb-bc {
 	ol {
 		margin-top: 15px;
 		padding-left: 0px;

--- a/src/buttons/_base.scss
+++ b/src/buttons/_base.scss
@@ -13,7 +13,7 @@ main {
 	font-family: Lato, sans-serif; // same font as %defaults-alternative-font-family
 }
 
-/* Call-to-action button style - new with GCWeb v2 */
+/* Call-to-action button style - new with GCWeb v5 */
 .btn-call-to-action {
 	@include button-variant( #fff, #318000, #458259 );
 	font-size: 1.1em;

--- a/src/menu/_base.scss
+++ b/src/menu/_base.scss
@@ -2,15 +2,15 @@
  * Site menu
  */
 
-/* Special style for the home page - GCWeb v2 */
+/* Special style for the home page - GCWeb v5 (gcweb-menu) */
 .home {
-	.gcweb-v2 {
+	.gcweb-menu {
 		border-top: 1px solid #ddd;
 		color: #284162;
 		margin-left: 0px;
 	}
 
-	.gcweb-v2 button[aria-haspopup=true] {
+	.gcweb-menu button[aria-haspopup=true] {
 		background-color: #fff;
 		border-color: #fff;
 		color: #284162;
@@ -25,11 +25,11 @@
 /*
  * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
- * GCWeb v2 (markup reviewed)
+ * GCWeb v5 (gcweb-menu)
  *
  */
 
-.gcweb-v2 {
+.gcweb-menu {
 
 	/*
 	 * Level 0 - button menu
@@ -219,7 +219,7 @@
 }
 
 // Open by default in basic HTML mode
-.wb-disable .gcweb-v2 {
+.wb-disable .gcweb-menu {
 	[role=menu] {
 		position: static;
 	}
@@ -257,7 +257,7 @@
 
 /*
  *
- * GCWeb v2 - END
+ * GCWeb v5 (gcweb-menu) - END
  *
  * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  */

--- a/src/menu/_print.scss
+++ b/src/menu/_print.scss
@@ -1,6 +1,6 @@
 /*
  Site menu (print view)
 */
-#wb-sm, .gcweb-v2 {
+#wb-sm, .gcweb-menu {
 	@extend %gcweb-print-display-none-important;
 }

--- a/src/menu/_screen-md-min-to-screen-md-max.scss
+++ b/src/menu/_screen-md-min-to-screen-md-max.scss
@@ -3,7 +3,7 @@
   @title: Medium view (screen only)
  */
 
-.gcweb-v2 {
+.gcweb-menu {
 
 	/*
 	 * Tablet mode

--- a/src/menu/_screen-md-min.scss
+++ b/src/menu/_screen-md-min.scss
@@ -3,7 +3,7 @@
   @title: Medium view and over (screen only)
  */
 
-.gcweb-v2 {
+.gcweb-menu {
 
 	/* SubSubMenu (MostRequested) keep it black
 	 *
@@ -20,7 +20,7 @@
 }
 
 // Open by default in basic HTML mode into 3 column
-.wb-disable .gcweb-v2 [role=menu] > li {
+.wb-disable .gcweb-menu [role=menu] > li {
 	float: left;
 	padding-right: 5px;
 	width: 30%;

--- a/src/menu/_screen-sm-max.scss
+++ b/src/menu/_screen-sm-max.scss
@@ -3,7 +3,7 @@
   @title: Small view and under (screen only)
  */
 
-.gcweb-v2 {
+.gcweb-menu {
 
 	/*
 	 * Mobile - first level

--- a/src/menu/_screen-xs-max.scss
+++ b/src/menu/_screen-xs-max.scss
@@ -3,7 +3,7 @@
   @title: Extra-small view and under (screen only)
  */
 
-.gcweb-v2 {
+.gcweb-menu {
 	.container {
 		padding-left: 15px;
 		padding-right: 15px;

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -1,5 +1,5 @@
 /**
- * @title Menu for GCWeb v2
+ * @title Menu for GCWeb v5
  * @overview Menu keyboard and mouse interaction with supporting responsiveness
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @duboisp
@@ -7,8 +7,8 @@
 ( function( $, wb ) {
 "use strict";
 
-var componentName = "gcweb-v2",
-	selector = ".gcweb-v2",
+var componentName = "gcweb-menu",
+	selector = ".gcweb-menu",
 	initEvent = "wb-init" + selector,
 	$document = wb.doc,
 	selectorAjaxed =  selector + " [data-ajax-replace]," + selector + " [data-ajax-append]," + selector + " [data-ajax-prepend]," + selector + " [data-wb-ajax]",
@@ -133,7 +133,7 @@ function CloseMenuWithDelay( elm ) {
 }
 
 // Open menu on mouse hovering
-$document.on( "mouseenter", ".gcweb-v2 [aria-haspopup]", function( event ) {
+$document.on( "mouseenter", selector + " [aria-haspopup]", function( event ) {
 
 	// There is no "mouseenter" in mobile
 	if ( !isMobileMode ) {
@@ -143,7 +143,7 @@ $document.on( "mouseenter", ".gcweb-v2 [aria-haspopup]", function( event ) {
 } );
 
 
-$document.on( "focusin", ".gcweb-v2 [aria-haspopup]", function( event ) {
+$document.on( "focusin", selector + " [aria-haspopup]", function( event ) {
 
 	// Don't open the submenu
 	if ( isMobileMode ) {
@@ -156,7 +156,7 @@ $document.on( "focusin", ".gcweb-v2 [aria-haspopup]", function( event ) {
 } );
 
 // The user get inside the submenu, we should cancel the "close" with delay event
-$document.on( "mouseenter focusin", ".gcweb-v2 [aria-haspopup] + [role=menu]", function( event ) {
+$document.on( "mouseenter focusin", selector + " [aria-haspopup] + [role=menu]", function( event ) {
 
 	// Prevent the menu to collapse
 	// Note: elm.id is already defined because of the mouseenter event of the parent menu element
@@ -176,7 +176,7 @@ $document.on( "mouseenter focusin", ".gcweb-v2 [aria-haspopup] + [role=menu]", f
 } );
 
 
-$document.on( "mouseleave", ".gcweb-v2 [aria-haspopup]", function( event ) {
+$document.on( "mouseleave", selector + " [aria-haspopup]", function( event ) {
 
 	// There is no "mouseenter" in mobile
 	if ( !isMobileMode ) {
@@ -185,7 +185,7 @@ $document.on( "mouseleave", ".gcweb-v2 [aria-haspopup]", function( event ) {
 	}
 } );
 
-$document.on( "focusout", ".gcweb-v2 [aria-haspopup]", function( event ) {
+$document.on( "focusout", selector + " [aria-haspopup]", function( event ) {
 
 	// Don't close the submenu
 	if ( isMobileMode ) {
@@ -196,7 +196,7 @@ $document.on( "focusout", ".gcweb-v2 [aria-haspopup]", function( event ) {
 	CloseMenuWithDelay( event.currentTarget );
 } );
 
-$document.on( "mouseleave focusout", ".gcweb-v2 [aria-haspopup] + [role=menu]", function( event ) {
+$document.on( "mouseleave focusout", selector + " [aria-haspopup] + [role=menu]", function( event ) {
 
 	// Collapse the menu
 	// Note: elm.id is already defined because of the mouseenter event
@@ -231,7 +231,7 @@ $document.on( "mouseleave focusout", ".gcweb-v2 [aria-haspopup] + [role=menu]", 
 */
 
 // Open right away the popup
-$document.on( "click", ".gcweb-v2 [aria-haspopup]", function( event ) {
+$document.on( "click", selector + " [aria-haspopup]", function( event ) {
 
 	var elm = event.currentTarget;
 
@@ -333,12 +333,12 @@ function keycode( code ) {
 // Global hook, close the menu on "ESC" when its state are open.
 $document.on( "keydown", function( event ) {
 	if ( event.keyCode === 27 ) {
-		CloseMenu( document.querySelector( ".gcweb-v2 button" ) );
+		CloseMenu( document.querySelector( selector + " button" ) );
 	}
 } );
 
 // Keyboard navigation for each menu item
-$document.on( "keydown", ".gcweb-v2 button, .gcweb-v2 [role=menuitem]", function( event ) {
+$document.on( "keydown", selector + " button, " + selector + " [role=menuitem]", function( event ) {
 
 	var elm = event.currentTarget,
 		key = keycode( event.charCode || event.keyCode );


### PR DESCRIPTION
The menu name was changed from ```gcweb-v2``` to ```gcweb-menu```. A note was added in the migration instruction.