### PR TITLE
Carousel: Removed link underline overrides.

### DIFF
--- a/src/carousel/_base.scss
+++ b/src/carousel/_base.scss
@@ -1,14 +1,3 @@
 /*
 Carousel
 */
-.carousel-s1,
-.carousel-s2 {
-
-	a {
-		text-decoration: none;
-
-		&:hover {
-			text-decoration: underline;
-		}
-	}
-}


### PR DESCRIPTION
wet-boew/GCWeb#917 modified GCWeb's carousels to hide link underlines by default and only show them on hover. Later on, one of wet-boew/wet-boew#7683's changes caused WET's carousel link selectors to become more specific than GCWeb's overrides. So most carousel links started appearing as underlined by default in GCWeb again.

However, GCWeb's overrides continued to affect figcaptions that contained links inside them. This caused transcript links in carousels that contain multimedia players to not appear as underlined. Without the underlines, those links looked like plain text.

This commit removes GCWeb's old overrides to prevent the aforementioned links from appearing as plain text.

**Screenshots of [GCWeb's carousel demo page](https://wet-boew.github.io/themes-dist/GCWeb/demos/tabs/tabs-carousel-en.html)...**

**Before:**
![gcweb-figure-transcript-link-before](https://user-images.githubusercontent.com/1907279/55357824-fcd51d80-549b-11e9-80ee-42e9e50d2b9e.png)

**After:**
![gcweb-figure-transcript-link-after](https://user-images.githubusercontent.com/1907279/55357828-ff377780-549b-11e9-943e-864d0d0f5364.png)
