### PR TITLE
Carousel: Removed media player top's margin.

### DIFF
--- a/src/carousel/_base.scss
+++ b/src/carousel/_base.scss
@@ -1,3 +1,10 @@
 /*
 Carousel
 */
+.carousel-s1,
+.carousel-s2 {
+
+	.wb-mltmd {
+		margin-top: 0;
+	}
+}


### PR DESCRIPTION
GCWeb sets 10px top and bottom margins on the multimedia player. Due to conflicts with the carousel's CSS, the top margin was appearing as a light grey border above media players situated within carousels.

This commit removes the top margin in the aforementioned context to prevent that behaviour.

**Screenshots of [GCWeb's carousel demo page](https://wet-boew.github.io/themes-dist/GCWeb/demos/tabs/tabs-carousel-en.html)...**

**Before:**
![gcweb-carousel-multimedia-before](https://user-images.githubusercontent.com/1907279/55359297-81756b00-549f-11e9-8390-75f2142bbd47.png)

**After:**
![gcweb-carousel-multimedia-after](https://user-images.githubusercontent.com/1907279/55359300-84705b80-549f-11e9-9dd0-1038e00286ec.png)
