### PR TITLE
WET-BOEW dependance - Bump to v4.0.31-development+2019-05-08 build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,7 +2007,7 @@
     },
     "es5-shim": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/es5-shim/-/es5-shim-2.3.0.tgz",
       "integrity": "sha1-kCG8UK1Nmj5TkwjuvTRDcgNVUAM="
     },
     "es6-iterator": {
@@ -5779,10 +5779,6 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
-    "magnific-popup": {
-      "version": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079",
-      "from": "git+https://github.com/wet-boew/Magnific-Popup.git#1.0.0+keyboard_trap_fix"
-    },
     "make-iterator": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.3.1.tgz",
@@ -9233,8 +9229,8 @@
       "dev": true
     },
     "wet-boew": {
-      "version": "github:wet-boew/wet-boew#39e2b23140718886c4cf320627767da591da5f79",
-      "from": "github:wet-boew/wet-boew#v4.0.30",
+      "version": "github:wet-boew/wet-boew#1ddaa08930b0e91b26097c3ba314cda6bfdd2000",
+      "from": "github:wet-boew/wet-boew#master",
       "requires": {
         "bootstrap-sass": "^3.3.7",
         "code-prettify": "^0.1.0",
@@ -9243,10 +9239,15 @@
         "html5shiv": "^3.7.3",
         "jquery": "2.2.4",
         "jquery-validation": "1.17.0",
-        "magnific-popup": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079",
         "mathjax": "2.7.1",
         "proj4": "2.3.3",
         "unorm": "^1.4.1"
+      },
+      "dependencies": {
+        "magnific-popup": {
+          "version": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079",
+          "from": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079"
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",
     "jsonpointer.js": "^0.4.0",
-    "wet-boew": "github:wet-boew/wet-boew#v4.0.30"
+    "wet-boew": "github:wet-boew/wet-boew#master"
   },
   "devDependencies": {
     "assemble-contrib-i18n": "0.1.*",


### PR DESCRIPTION
After this merged, it will be possible to merge PR #1520 

Also, it includes a build script issue with: Plugin Share/Sprite: Fix build blocking condition