### PR TITLE
Stretched link: Propagates the clickable area around an hyperlink tag u…

### DIFF
--- a/site/pages/experimental-en.hbs
+++ b/site/pages/experimental-en.hbs
@@ -119,6 +119,12 @@
 		<td>v5.1</td>
 		<td></td>
 	</tr>
+	<tr>
+		<th>CSS <code>.stretched-link</code></th>
+		<td>Propagates the clickable area around an hyperlink tag up to a relatively positioned parent.</td>
+		<td>v5.1</td>
+		<td></td>
+	</tr>
 </tbody>
 </table>
 
@@ -216,5 +222,23 @@ if ( s.getTime() &lt; msT && msT &lt; e.getTime() ) {
 		<p>Learn how the public can participate in impact assessments.</p>
 		<h3 class="h5 mrgn-tp-sm"><a href="https://www.canada.ca/en/environmental-assessment-agency/programs/aboriginal-consultation-federal-environmental-assessment.html">Indigenous</a></h3>
 		<p>Learn about the Indigenous consultation process in impact assessments.</p>
+	</div>
+</div>
+
+<h3 id="stretched-link">Features section with stretched links</h3>
+<div class="row wb-eqht">
+	<div class="col-sm-6">
+		<div class="well well-sm brdr-rds-0 eqht-trgt">
+			<img class="img-responsive full-width" src="https://www.canada.ca/content/dam/canada/activities/20190603-1-520x200.jpg" alt="">
+			<h3 class="h5"><a class="stretched-link" href="https://www.ic.gc.ca/eic/site/062.nsf/eng/h_00108.html?open&amp;WT.mc_id=DigitalCharter_canada.ca-home_activities-initiatives_en" data-gc-analytics="promo:promotionalfeature">Learn more about Canada’s Digital Charter</a></h3>
+			<p>Learn how Canada’s Digital Charter will build a foundation of trust in a digital world.</p>
+		</div>
+	</div>
+	<div class="col-sm-6">
+		<div class="well well-sm brdr-rds-0 eqht-trgt">
+			<img class="img-responsive full-width" src="https://www.canada.ca/content/dam/canada/activities/20190604-1-520x200.jpg" alt="">
+			<h3 class="h5"><a class="stretched-link" href="https://www.rcaanc-cirnac.gc.ca/eng/1466616436543/1534874922512" data-gc-analytics="promo:promotionalfeature">National Indigenous History Month</a></h3>
+			<p>Celebrate National Indigenous History Month in June</p>
+		</div>
 	</div>
 </div>

--- a/site/pages/experimental-fr.hbs
+++ b/site/pages/experimental-fr.hbs
@@ -119,6 +119,12 @@
 		<td>v5.1</td>
 		<td></td>
 	</tr>
+	<tr lang="en">
+		<th>CSS <code>.stretched-link</code></th>
+		<td>Propagates the clickable area around an hyperlink tag up to a relatively positioned parent.</td>
+		<td>v5.1</td>
+		<td></td>
+	</tr>
 </tbody>
 </table>
 
@@ -217,6 +223,24 @@ if ( s.getTime() &lt; msT && msT &lt; e.getTime() ) {
 		<p>Learn how the public can participate in impact assessments.</p>
 		<h3 class="h5 mrgn-tp-sm"><a href="https://www.canada.ca/en/environmental-assessment-agency/programs/aboriginal-consultation-federal-environmental-assessment.html">Indigenous</a></h3>
 		<p>Learn about the Indigenous consultation process in impact assessments.</p>
+	</div>
+</div>
+
+<h3 id="stretched-link">Features section with stretched links</h3>
+<div class="row wb-eqht">
+	<div class="col-sm-6">
+		<div class="well well-sm brdr-rds-0 eqht-trgt">
+			<img class="img-responsive full-width" src="https://www.canada.ca/content/dam/canada/activities/20190603-1-520x200.jpg" alt="">
+			<h3 class="h5"><a class="stretched-link" href="https://www.ic.gc.ca/eic/site/062.nsf/eng/h_00108.html?open&amp;WT.mc_id=DigitalCharter_canada.ca-home_activities-initiatives_en" data-gc-analytics="promo:promotionalfeature">Learn more about Canada’s Digital Charter</a></h3>
+			<p>Learn how Canada’s Digital Charter will build a foundation of trust in a digital world.</p>
+		</div>
+	</div>
+	<div class="col-sm-6">
+		<div class="well well-sm brdr-rds-0 eqht-trgt">
+			<img class="img-responsive full-width" src="https://www.canada.ca/content/dam/canada/activities/20190604-1-520x200.jpg" alt="">
+			<h3 class="h5"><a class="stretched-link" href="https://www.rcaanc-cirnac.gc.ca/eng/1466616436543/1534874922512" data-gc-analytics="promo:promotionalfeature">National Indigenous History Month</a></h3>
+			<p>Celebrate National Indigenous History Month in June</p>
+		</div>
 	</div>
 </div>
 

--- a/src/_experimental.scss
+++ b/src/_experimental.scss
@@ -64,6 +64,24 @@
 		padding: 0px;
 	}
 
+	/* ------------
+	 * Stretched link
+	 *
+	 */
+
+	.stretched-link {
+		&:after {
+			background-color: rgba(0, 0, 0, 0);
+			bottom: 0;
+			content: "";
+			left: 0;
+			pointer-events: auto;
+			position: absolute;
+			right: 0;
+			top: 0;
+			z-index: 1;
+		}
+	}
 
 	/* ------------
 	 * Theme color


### PR DESCRIPTION
Propagates the clickable area around an hyperlink tag up to a relatively positioned parent.

As shown in the Bootstrap 4 documentation here: https://getbootstrap.com/docs/4.3/utilities/stretched-link/.

This new CSS class will allow us to replace `<figure>` tags on features sections.