### PR TITLE
Major - Fix broken theme link in the default menu in the template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "GCWeb",
-  "version": "5.2.0-development",
+  "version": "6.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GCWeb",
-  "version": "5.2.0-development",
+  "version": "6.0.0-development",
   "description": "Web Experience Toolkit (WET): Canada.ca Theme",
   "main": "index.html",
   "scripts": {

--- a/site/includes/sitemenu.hbs
+++ b/site/includes/sitemenu.hbs
@@ -18,7 +18,7 @@
 			<li role="presentation"><a role="menuitem" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
 			<li role="presentation"><a role="menuitem" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
 			<li role="presentation"><a role="menuitem" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
-			<li role="presentation"><a role="menuitem" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
+			<li role="presentation"><a role="menuitem" href="https://www.canada.ca/en/services/science.html">Science and innovation</a></li>
 		</ul>
 	</div>
 </nav>

--- a/site/pages/gcweb-theme/release/dev-build.hbs
+++ b/site/pages/gcweb-theme/release/dev-build.hbs
@@ -9,7 +9,7 @@
 		{ "title": "GCWeb theme", "link": "../index-en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2019-06-20",
+	"dateModified": "2019-07-11",
 	"share": "true"
 }
 ---
@@ -28,15 +28,24 @@
 
 <ul>
 	<li><strong>Planned release date:</strong> <time datetime="2019-10-14">October 14, 2019</time></li>
-	<li><strong>Going to be released under version:</strong> v5.2</li>
+	<li><strong>Going to be released under version:</strong> v6.0</li>
+	<li><strong>Canceled:</strong> (on July 11, 2019) <del>v5.2</del></li>
 </ul>
 
 <section>
 <h2>What's new?</h2>
 <ul>
-	<li>Template</li>
+	<li>Template
+		<ul>
+			<li>Major - Renamed the link of the english menu about the menu item "science" for: <code>https://www.canada.ca/en/services/science.html</code></li>
+		</ul>
+	</li>
 	<li>Styles and plugins</li>
-	<li><a href="https://wet-boew.github.io/themes-dist/GCWeb/experimental-en.html">Experimental</a></li>
+	<li><a href="https://wet-boew.github.io/themes-dist/GCWeb/experimental-en.html">Experimental</a>
+		<ul>
+			<li>Add strech link functionality</li>
+		</ul>
+	</li>
 	<li>Maintenance</li>
 </ul>
 </section>


### PR DESCRIPTION
Because this is a template change, this change will major increase the version number of GCWeb