### PR TITLE
Build: Update grunt-banner and eliminate duplicate CSS charsets

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -512,6 +512,8 @@ module.exports = (grunt) ->
 			css:
 				options:
 					banner: "@charset \"utf-8\";\n<%= banner %>"
+					position: "replace"
+					replace: "@charset \"UTF-8\";"
 				files:
 					src: "<%= themeDist %>/css/*.*"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3510,10 +3510,13 @@
       }
     },
     "grunt-banner": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/grunt-banner/-/grunt-banner-0.3.1.tgz",
-      "integrity": "sha1-xeEnMQUzSTX3qxH7dk1itPDWtx8=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/grunt-banner/-/grunt-banner-0.6.0.tgz",
+      "integrity": "sha1-P4eQIdEj+linuloLb7a+QStYhaw=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.0"
+      }
     },
     "grunt-bootlint": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "expect.js": "^0.3.1",
     "grunt": "~0.4.5",
     "grunt-assemble": "~0.6.3",
-    "grunt-banner": "^0.3.1",
+    "grunt-banner": "^0.6.0",
     "grunt-bootlint": "^0.9.1",
     "grunt-check-dependencies": "~0.6.0",
     "grunt-contrib-clean": "~1.1.0",


### PR DESCRIPTION
This is a partial port of wet-boew/wet-boew#8679.

Didn't port the CSSLint update (nor its rule adjustments) since GCWeb doesn't currently use it. I didn't feel like it'd be appropriate to introduce CSSLint into GCWeb a as a part of this PR.

@duboisp FYI