### PR TITLE
Form test cases: Add autocomplete attributes

### DIFF
--- a/site/pages/gcweb-theme/test-case-1.hbs
+++ b/site/pages/gcweb-theme/test-case-1.hbs
@@ -7,7 +7,7 @@
 		{ "title": "GCWeb home", "link": "../index-en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2018-12-10",
+	"dateModified": "2019-07-29",
 	"share": "true"
 }
 ---
@@ -24,11 +24,11 @@
 				<form method="get" action="#">
 					<div class="form-group">
 						<label for="exampleInputEmail1">Email address</label>
-						<input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email" />
+						<input type="email" autocomplete="username" class="form-control" id="exampleInputEmail1" placeholder="Enter email" />
 					</div>
 					<div class="form-group">
 						<label for="exampleInputPassword1">Password</label>
-						<input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password" />
+						<input type="password" autocomplete="current-password" class="form-control" id="exampleInputPassword1" placeholder="Password" />
 					</div>
 					<div class="form-group">
 						<label for="exampleInputFile">File input</label>
@@ -659,13 +659,13 @@
 					<div class="form-group">
 						<label for="inputEmail3" class="col-sm-4 control-label">Email</label>
 						<div class="col-sm-8">
-							<input type="email" class="form-control" id="inputEmail3" placeholder="Email" />
+							<input type="email" autocomplete="username" class="form-control" id="inputEmail3" placeholder="Email" />
 						</div>
 					</div>
 					<div class="form-group">
 						<label for="inputPassword3" class="col-sm-4 control-label">Password</label>
 						<div class="col-sm-8">
-							<input type="password" class="form-control" id="inputPassword3" placeholder="Password" />
+							<input type="password" autocomplete="current-password" class="form-control" id="inputPassword3" placeholder="Password" />
 						</div>
 					</div>
 					<div class="form-group">
@@ -702,11 +702,11 @@
 				<form class="form-inline" method="get" action="#">
 					<div class="form-group">
 						<label class="wb-inv" for="exampleInputEmail2">Email address</label>
-						<input type="email" class="form-control" id="exampleInputEmail2" placeholder="Enter email" />
+						<input type="email" autocomplete="username" class="form-control" id="exampleInputEmail2" placeholder="Enter email" />
 					</div>
 					<div class="form-group">
 						<label class="wb-inv" for="exampleInputPassword2">Password</label>
-						<input type="password" class="form-control" id="exampleInputPassword2" placeholder="Password" />
+						<input type="password" autocomplete="current-password" class="form-control" id="exampleInputPassword2" placeholder="Password" />
 					</div>
 					<div class="checkbox">
 						<label>
@@ -739,7 +739,7 @@
 					<div class="form-group">
 						<label for="emailReadonly" class="col-sm-4 control-label">Email</label>
 						<div class="col-sm-8">
-							<input type="email" readonly id="emailReadonly" value="email@example.com" />
+							<input type="email" autocomplete="email" readonly id="emailReadonly" value="email@example.com" />
 						</div>
 					</div>
 				</form>
@@ -868,13 +868,13 @@
 						<div class="form-group">
 							<label for="inputFullName" class="col-sm-4 control-label">Full Name</label>
 							<div class="col-sm-8">
-								<input type="text" class="form-control" id="inputFullName" placeholder="Full Name" />
+								<input type="text" autocomplete="name" class="form-control" id="inputFullName" placeholder="Full Name" />
 							</div>
 						</div>
 						<div class="form-group">
 							<label for="dob" class="col-sm-4 control-label">Date of Birth <span class="datepicker-format"> (YYYY-MM-DD)</span></label>
 							<div class="col-sm-8">
-								<input class="form-control" id="dob" name="dob" type="date" />
+								<input class="form-control" id="dob" name="dob" type="date" autocomplete="bday" />
 							</div>
 						</div>
 					</fieldset>
@@ -883,13 +883,13 @@
 						<div class="form-group">
 							<label for="tel1" class="col-sm-4 control-label">Telephone number</label>
 							<div class="col-sm-8">
-								<input class="form-control" id="tel1" name="tel1" type="tel" />
+								<input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" />
 							</div>
 						</div>
 						<div class="form-group">
 							<label for="inputEmail4" class="col-sm-4 control-label">Email</label>
 							<div class="col-sm-8">
-								<input type="email" class="form-control" id="inputEmail4" placeholder="Email" />
+								<input type="email" autocomplete="email" class="form-control" id="inputEmail4" placeholder="Email" />
 							</div>
 						</div>
 					</fieldset>
@@ -919,19 +919,19 @@
 				<div class="col-md-4">
 					<div class="form-group">
 						<label for="eaddress" class="required"><span class="field-name">Email</span> <strong class="required">(required)</strong></label>
-						<input class="form-control full-width" id="eaddress" name="eaddress" type="email" required="required" />
+						<input class="form-control full-width" id="eaddress" name="eaddress" type="email" autocomplete="email" required="required" />
 					</div>
 				</div>
 				<div class="col-md-4">
 					<div class="form-group">
 						<label for="fname" class="required"><span class="field-name">First Name</span> <strong class="required">(required)</strong></label>
-						<input class="form-control full-width" id="fname" name="fname" type="text" required="required"/>
+						<input class="form-control full-width" id="fname" name="fname" type="text" autocomplete="given-name" required="required"/>
 					</div>
 				</div>
 				<div class="col-md-4">
 					<div class="form-group">
 						<label for="lname" class="required"><span class="field-name">Last Name</span> <strong class="required">(required)</strong></label>
-						<input class="form-control full-width" id="lname" name="lname" type="text" required="required"	/>
+						<input class="form-control full-width" id="lname" name="lname" type="text" autocomplete="family-name" required="required"	/>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
**Notes:**
* Didn't add any autocomplete attributes to the "Labels"/"Inputs" sections due to lack of context.
* Some fields are now set to type="email" and autocomplete="username"... The HTML spec seems to disallow it and the validator consequently produces an error. But it might not be the spec's true intent.

Related to wet-boew/wet-boew#8692