### PR TITLE
Site: Rename .hbs links to .html

### DIFF
--- a/site/pages/gcweb-theme/index.hbs
+++ b/site/pages/gcweb-theme/index.hbs
@@ -235,5 +235,5 @@
 
 <h2 id="testCases">Test cases</h2>
 <ul>
-	<li><a href="test-case-1.hbs">From examples - test cases</a></li>
+	<li><a href="test-case-1.html">From examples - test cases</a></li>
 </ul>

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -481,7 +481,7 @@
 			<td></td>
 		</tr>
 		<tr>
-			<td><a href="search/results-en.hbs">Search results page</a></td>
+			<td><a href="search/results-en.html">Search results page</a></td>
 			<td><time>2019-02-06</time></td>
 			<td><a href="search/index.html">Templates/Search</a></td>
 			<td>For search results from across the Government of Canada.</td>
@@ -490,7 +490,7 @@
 			<td>v2.0</td>
 		</tr>
 		<tr>
-			<td><a href="search/results-contextual-en.hbs">Contextual search results page</a></td>
+			<td><a href="search/results-contextual-en.html">Contextual search results page</a></td>
 			<td><time>2019-02-06</time></td>
 			<td><a href="search/index.html">Templates/Search</a></td>
 			<td>For search results that are filtered to a search context.</td>
@@ -499,7 +499,7 @@
 			<td>v2.0</td>
 		</tr>
 		<tr>
-			<td><a href="search/results-filters-en.hbs">Search facets/filters results</a></td>
+			<td><a href="search/results-filters-en.html">Search facets/filters results</a></td>
 			<td><time>2019-02-06</time></td>
 			<td><a href="search/index.html">Templates/Search</a></td>
 			<td>For search results that are accompanied by faceted filter boxes.</td>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -482,7 +482,7 @@
 			<td></td>
 		</tr>
 		<tr>
-			<td><a href="search/results-fr.hbs">Page des résultats de recherche</a></td>
+			<td><a href="search/results-fr.html">Page des résultats de recherche</a></td>
 			<td><time>2019-02-06</time></td>
 			<td><a href="search/index.html" hreflang="en">Modèles/Recherche</a></td>
 			<td>Pour les résultats de recherche au travers du Gouvernement du Canada.</td>
@@ -491,7 +491,7 @@
 			<td>v2.0</td>
 		</tr>
 		<tr>
-			<td><a href="search/results-contextual-fr.hbs">Page des résultats de recherche contextuelle</a></td>
+			<td><a href="search/results-contextual-fr.html">Page des résultats de recherche contextuelle</a></td>
 			<td><time>2019-02-06</time></td>
 			<td><a href="search/index.html" hreflang="en">Modèles/Recherche</a></td>
 			<td>Pour les résultats de recherche filtrés avec un context de recherche.</td>
@@ -500,7 +500,7 @@
 			<td>v2.0</td>
 		</tr>
 		<tr>
-			<td><a href="search/results-filters-fr.hbs">Résultats de la recherche avec filtre</a></td>
+			<td><a href="search/results-filters-fr.html">Résultats de la recherche avec filtre</a></td>
 			<td><time>2019-02-06</time></td>
 			<td><a href="search/index.html" hreflang="en">Modèles/Recherche</a></td>
 			<td>Pour des résultats de recherche duquels des filtres sont aussi disponible.</td>


### PR DESCRIPTION
The previous behaviour didn't result in broken links (the build seems to automatically rename .hbs extensions to .html), but wasn't consistent with how the vast majority of links to built pages are coded to use .html extensions.