### PR TITLE
Video example: Use repo's copies of poster images

### DIFF
--- a/site/pages/video-en.hbs
+++ b/site/pages/video-en.hbs
@@ -6,7 +6,7 @@
 	"breadcrumb": [
 		{ "title": "Home", "link": "https://www.canada.ca/en.html" }
 	],
-	"dateModified": "2019-08-15",
+	"dateModified": "2019-09-06",
 	"share": "true"
 }
 ---
@@ -15,7 +15,7 @@
 		<h2>MPEG4 (H264 + AAC) source with inline HTML captions</h2>
 		<p>This example illustrates the use of an inline transcript to provide captions. This example can also demonstrate the fallback mechanism in Web browsers that don't support HTML5 videos.</p>
 		<figure class="wb-mltmd">
-			<video poster="https://wet-boew.github.io/v4.0-ci/demos/multimedia/demo/video1-en.jpg" title="Looking for a Job">
+			<video poster="demos/multimedia/demo/video1-en.jpg" title="Looking for a Job">
 				<source type="video/mp4" src="https://video2.servicecanada.gc.ca/video/boew-wet/te-lj-eng.mp4" />
 				<track src="#inline-captions" kind="captions" data-type="text/html" srclang="en" label="English" />
 			</video>
@@ -83,7 +83,7 @@
 		<details class="mrgn-tp-md">
 			<summary>View code</summary>
 			<pre><code>&lt;figure class=&quot;wb-mltmd&quot;&gt;
-&lt;video poster=&quot;https://wet-boew.github.io/v4.0-ci/demos/multimedia/demo/video1-en.jpg&quot; title=&quot;Looking for a Job&quot;&gt;
+&lt;video poster=&quot;demos/multimedia/demo/video1-en.jpg&quot; title=&quot;Looking for a Job&quot;&gt;
 	&lt;source type=&quot;video/mp4&quot; src=&quot;https://video2.servicecanada.gc.ca/video/boew-wet/te-lj-eng.mp4&quot; /&gt;
 	&lt;track src=&quot;#inline-captions&quot; kind=&quot;captions&quot; data-type=&quot;text/html&quot; srclang=&quot;en&quot; label=&quot;English&quot; /&gt;
 &lt;/video&gt;

--- a/site/pages/video-fr.hbs
+++ b/site/pages/video-fr.hbs
@@ -6,7 +6,7 @@
 	"breadcrumb": [
 		{ "title": "Accueil", "link": "https://www.canada.ca/fr.html" }
 	],
-	"dateModified": "2019-08-15",
+	"dateModified": "2019-09-06",
 	"share": "true"
 }
 ---
@@ -15,7 +15,7 @@
 		<h2>MPEG4 (H264 + AAC) Source avec sous-titre intégré au HTML</h2>
 		<p>Cet exemple illustre l’utilisation d’un relevé de notes en ligne pour fournir des légendes. Cet exemple peut également démontrer le mécanisme de secours dans les navigateurs Web qui ne supporte pas les vidéos HTML5.</p>
 		<figure class="wb-mltmd">
-			<video poster="https://wet-boew.github.io/v4.0-ci/demos/multimedia/demo/video1-fr.jpg" title="Trouver un emploi">
+			<video poster="demos/multimedia/demo/video1-fr.jpg" title="Trouver un emploi">
 				<source type="video/mp4" src="https://video2.servicecanada.gc.ca/video/boew-wet/te-lj-fra.mp4" />
 				<track src="#inline-captions" kind="captions" data-type="text/html" srclang="en" label="Français" />
 			</video>
@@ -89,7 +89,7 @@
 		<details class="mrgn-tp-md">
 			<summary>Visualiser le code</summary>
 			<pre><code>&lt;figure class=&quot;wb-mltmd&quot;&gt;
-&lt;video poster=&quot;https://wet-boew.github.io/v4.0-ci/demos/multimedia/demo/video1-fr.jpg&quot; title=&quot;Trouver un emploi&quot;&gt;
+&lt;video poster=&quot;demos/multimedia/demo/video1-fr.jpg&quot; title=&quot;Trouver un emploi&quot;&gt;
 	&lt;source type=&quot;video/mp4&quot; src=&quot;https://video2.servicecanada.gc.ca/video/boew-wet/te-lj-fra.mp4&quot; /&gt;
 	&lt;track src=&quot;#inline-captions&quot; kind=&quot;captions&quot; data-type=&quot;text/html&quot; srclang=&quot;en&quot; label=&quot;Français&quot; /&gt;
 &lt;/video&gt;


### PR DESCRIPTION
This is another take on what was done in #1576.

GCWeb contains copies of most (all?) of the WET repo's plugin demo pages, documentation and supporting files. So it makes more sense for the video example page's poster image references to be relative to GCWeb instead of referencing an external repo (wet-boew).