### PR TITLE
Build: Update wet-boew to latest commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9432,9 +9432,9 @@
       "dev": true
     },
     "unorm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.5.0.tgz",
-      "integrity": "sha512-sMfSWoiRaXXeDZSXC+YRZ23H4xchQpwxjpw1tmfR+kgbBCaOgln4NI0LXejJIhnBuKINrB3WRn+ZI8IWssirVw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -9635,10 +9635,10 @@
       "dev": true
     },
     "wet-boew": {
-      "version": "github:wet-boew/wet-boew#4530d29338f846b42e7f32858f90ce40c92a9b0e",
-      "from": "github:wet-boew/wet-boew#v4.0.31",
+      "version": "github:wet-boew/wet-boew#21ca2eafec58421862e1ddeb27cb19721d931915",
+      "from": "github:wet-boew/wet-boew#21ca2eafec58421862e1ddeb27cb19721d931915",
       "requires": {
-        "bootstrap-sass": "^3.3.7",
+        "bootstrap-sass": "3.4.1",
         "code-prettify": "^0.1.0",
         "datatables": "1.10.13",
         "es5-shim": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",
     "jsonpointer.js": "^0.4.0",
-    "wet-boew": "github:wet-boew/wet-boew#v4.0.31"
+    "wet-boew": "github:wet-boew/wet-boew#21ca2eafec58421862e1ddeb27cb19721d931915"
   },
   "devDependencies": {
     "assemble-contrib-i18n": "0.1.*",


### PR DESCRIPTION
GCWeb's build system previously couldn't be successfully installed in node.js 12.x due to its wet-boew/wet-boew#v4.0.31 dependency lacking wet-boew/wet-boew#8687's updates.

This commit resolves it by updating the wet-boew dependency to its latest commit. I specified a specific commit hash in package.json to prevent npm install from attempting to always update to the latest wet-boew commit (which would pollute package-lock.json once future commits get added to wet-boew).