### PR TITLE
Build: Update grunt-html to ^11.1.1 and revise htmllint ignore rules

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -732,13 +732,6 @@ module.exports = (grunt) ->
 				options:
 					ignore: [
 						"Element “head” is missing a required instance of child element “title”."
-						"The “details” element is not supported properly by browsers yet. It would probably be better to wait for implementations."
-						"The value of attribute “title” on element “a” from namespace “http://www.w3.org/1999/xhtml” is not in Unicode Normalization Form C." #required for vietnamese translations
-						"Text run is not in Unicode Normalization Form C." #required for vietnamese translations
-						"Discarding unrecognized token “none” from value of attribute “role”. Browsers ignore any token that is not a defined ARIA non-abstract role." # menu designed as per WAI-ARIA 1.1 practice
-						"Attribute “aria-expanded” not allowed on element “a” at this point." # menu designed as per WAI-ARIA 1.1 practice
-						"Attribute “aria-orientation” not allowed on element “ul” at this point." # menu designed as per WAI-ARIA 1.1 practicee
-						"An element with “role=menuitem” must be contained in, or owned by, an element with “role=menubar” or “role=menu”." # the menu item (li) in the AJAX fragment are not contained in a UL (menu)
 						"Element “li” not allowed as child of element “body” in this context. (Suppressing further errors from this subtree.)" # the menu item (li) in the AJAX fragment are not contained in a UL (menu)
 					]
 				src: [
@@ -746,18 +739,6 @@ module.exports = (grunt) ->
 					"dist/unmin/demos/menu/demo/*.html"
 				]
 			templates:
-				options:
-					ignore: [
-						"The “details” element is not supported properly by browsers yet. It would probably be better to wait for implementations."
-						"Element “dl” is missing a required instance of child element “dd”."
-						"XHTML element “dl” is missing a required instance of child element “dd”."
-						"Element “dl” is missing a required instance of child element “dt”."
-						"XHTML element “dl” is missing a required instance of child element “dt”."
-						"Empty heading."
-						"Attribute “aria-orientation” not allowed on element “ul” at this point." # menu designed as per WAI-ARIA 1.1 practice
-						"Discarding unrecognized token “none” from value of attribute “role”. Browsers ignore any token that is not a defined ARIA non-abstract role." # menu designed as per WAI-ARIA 1.1 practice
-						"Attribute “integrity” not allowed on element “link” at this point."
-					]
 				src: [
 					"dist/unmin/demos/data-json/template-en.html"
 					"dist/unmin/demos/data-json/template-fr.html"
@@ -765,9 +746,6 @@ module.exports = (grunt) ->
 			experimental:
 				options:
 					ignore: [
-						"The “details” element is not supported properly by browsers yet. It would probably be better to wait for implementations."
-						"Attribute “integrity” not allowed on element “link” at this point."
-						"Attribute “aria-orientation” not allowed on element “ul” at this point."
 						"Consider using the “h1” element as a top-level heading only (all “h1” elements are treated as top-level headings by many screen readers and other tools)."
 					]
 				src: [
@@ -777,19 +755,11 @@ module.exports = (grunt) ->
 			all:
 				options:
 					ignore: [
-						"The “details” element is not supported properly by browsers yet. It would probably be better to wait for implementations."
-						"The “date” input type is not supported in all browsers. Please be sure to test, and consider using a polyfill."
-						"The “track” element is not supported by browsers yet. It would probably be better to wait for implementations."
-						"The “time” input type is not supported in all browsers. Please be sure to test, and consider using a polyfill."
-						"The value of attribute “title” on element “a” from namespace “http://www.w3.org/1999/xhtml” is not in Unicode Normalization Form C." #required for vietnamese translations
-						"Text run is not in Unicode Normalization Form C." #required for vietnamese translations
-						"The “longdesc” attribute on the “img” element is obsolete. Use a regular “a” element to link to the description."
-						/Bad value “\.\/\.\.\/[^”]*” for attribute “[^”]*” on XHTML element “[^”]*”: Path component contains a segment “\/\.\.\/” not at the beginning of a relative reference, or it contains a “\/\.\/”. These should be removed./
-						"Element “p” not allowed as child of element “figure” in this context. (Suppressing further errors from this subtree.)" # as per HTML 5.3 spec, figcaption just need to be a children of figure element
-						"Attribute “aria-orientation” not allowed on element “ul” at this point." # menu designed as per WAI-ARIA 1.1 practice
-						"Discarding unrecognized token “none” from value of attribute “role”. Browsers ignore any token that is not a defined ARIA non-abstract role." # menu designed as per WAI-ARIA 1.1 practice
-						"Attribute “aria-current” not allowed on element “li” at this point."
-						"Attribute “integrity” not allowed on element “link” at this point."
+						"A document must not include more than one “meta” element with its “name” attribute set to the value “description”."
+						# TODO: Should be removed and fixed now that HTML5 specs updated
+						"The “banner” role is unnecessary for element “header”."
+						"The “main” role is unnecessary for element “main”."
+						"The “navigation” role is unnecessary for element “nav”."
 					]
 				src: [
 					"dist/unmin/**/*.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4033,32 +4033,49 @@
       }
     },
     "grunt-html": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-5.0.1.tgz",
-      "integrity": "sha1-5deJDWsZ2Bm+TP0EF/z2ZvMQDTA=",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-11.1.1.tgz",
+      "integrity": "sha512-YAurPMB/GUsy8UZdNYZ38pTTGYKoXuTxi6CkIYtxSRfxKEJCCK0JSDJn5UbAvA0MK86CMhOsMeO+4qcu9KnPHw==",
       "dev": true,
       "requires": {
-        "async": "1.4.0",
-        "chalk": "1.1.0"
+        "async": "^3.1.0",
+        "chalk": "^2.4.2",
+        "vnu-jar": "19.9.4"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "async": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz",
-          "integrity": "sha1-Nfhvg8WeBCHQmc2akdgnj7V4wA0=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ==",
           "dev": true
         },
         "chalk": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "integrity": "sha1-CbRTzsSXp1Ug5KYK5IIUqHAOCSE=",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.1.0",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -9621,6 +9638,12 @@
         "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
+    },
+    "vnu-jar": {
+      "version": "19.9.4",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-19.9.4.tgz",
+      "integrity": "sha512-x91WyaNr1oPJaYZkbyMElRyV60BUaxPuhm3zXXjlFOpW3E2KavPWlyohX0LTf6gX7/tujIMgLE5UGc0jn7o4XQ==",
+      "dev": true
     },
     "void-elements": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-cssmin-ie8-clean": "0.0.1",
     "grunt-eslint": "^19.0.0",
     "grunt-gh-pages": "~2.0.0",
-    "grunt-html": "^5.0.0",
+    "grunt-html": "^11.1.1",
     "grunt-hub": "~0.7.0",
     "grunt-i18n-csv": "0.1.0",
     "grunt-lintspaces": "^0.8.3",


### PR DESCRIPTION
Updates grunt-html to ^11.1.1 and adjusts several ignore rules in its associated task (htmllint). A few new ignore rules have been added, whereas many outdated ones have been removed.

This is a port of wet-boew/wet-boew#8728.

**PS:**
I copied the following line comment from wet-boew/wet-boew#8373 for the sake of consistency:
> ``# TODO: Should be removed and fixed now that HTML5 specs updated``

Thanks @nschonni :)