### PR TITLE
Splash page: Fix typos in meta description vars

### DIFF
--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -7,8 +7,8 @@
 		<meta charset="utf-8"/>
 		<title>{{title}}</title>
 		<meta content="width=device-width, initial-scale=1" name="viewport"/>
-		<meta name="description" content="{{decription-en}}" />
-		<meta name="description" lang="fr" content="{{decription-fr}}" />
+		<meta name="description" content="{{description-en}}" />
+		<meta name="description" lang="fr" content="{{description-fr}}" />
 		<meta name="dcterms.creator" content="{{creator-en}}" />
 		<meta name="dcterms.creator" lang="fr" content="{{creator-en}}" />
 		<meta name="dcterms.title" content="{{title}}" />


### PR DESCRIPTION
The splash page layout file's "description-en" and "description-fr" variables previously contained typos, which prevented their values from appearing in the generated splash page's metadata.

This commit corrects the typos to allow their real values to properly appear in the generated splash page.