### PR TITLE
DO NOT MERGE: Splash page: Remove French meta description var

### DIFF
--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -7,8 +7,7 @@
 		<meta charset="utf-8"/>
 		<title>{{title}}</title>
 		<meta content="width=device-width, initial-scale=1" name="viewport"/>
-		<meta name="description" content="{{decription-en}}" />
-		<meta name="description" lang="fr" content="{{decription-fr}}" />
+		<meta name="description" content="{{decription}}" />
 		<meta name="dcterms.creator" content="{{creator-en}}" />
 		<meta name="dcterms.creator" lang="fr" content="{{creator-en}}" />
 		<meta name="dcterms.title" content="{{title}}" />

--- a/site/pages/splashpage.hbs
+++ b/site/pages/splashpage.hbs
@@ -2,15 +2,14 @@
 {
 	"title": "Canada.ca",
 	"pageclass": "splash",
-	"description-en": "The Government of Canada website is a single point of access to all programs, services, departments, ministries and organizations of the Government of Canada.",
-	"description-fr": "Le site Web du gouvernement du Canada fournit un point d'accès complet à tous les programmes, services, départements, ministères et organismes du gouvernement du Canada.",
+	"description": "The Government of Canada website is a single point of access to all programs, services, departments, ministries and organizations of the Government of Canada.",
 	"creator-en": "Government of Canada, Service Canada, Citizen Service Branch, Integrated Channel Management, Web Strategies and Product Management",
 	"creator-fr": "Gouvernement du Canada, Service Canada, Direction générale de service aux citoyens, Gestion intégrée des modes de service, Gestion des stratégies et produits Web",
 	"subject-en": "Government of Canada, services",
 	"subject-fr": "Gouvernement du Canada, services",
 	"language": "en",
 	"section": "message",
-	"dateModified": "2017-05-04"
+	"dateModified": "2019-09-27"
 }
 ---
 


### PR DESCRIPTION
Fixes the following error in the htmllint:all task (and official HTML validator):
"A document must not include more than one “meta” element with its “name” attribute set to the value “description”."

The WHATWG's HTML spec (which is now the W3C's canonical spec) currently disallows multiple meta descriptions on the same page:
https://html.spec.whatwg.org/multipage/semantics.html#meta-description

The W3C's archived HTML spec used to allow it (via w3c/html#1161). A similar change has yet to be proposed for the WHATWG's spec.

Related to #1598 and #1599.