### PR TITLE
Build: Fail on bootlint warnings

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -778,6 +778,8 @@ module.exports = (grunt) ->
 			all:
 				options:
 					stoponerror: true
+					stoponwarning: true
+					showallerrors: true
 					relaxerror: [
 						# We recommend handling this through the server headers so it never appears in the markup
 						"W002" # `<head>` is missing X-UA-Compatible `<meta>` tag that disables old IE compatibility modes
@@ -805,6 +807,8 @@ module.exports = (grunt) ->
 			bootstrap4:
 				options:
 					stoponerror: true
+					stoponwarning: true
+					showallerrors: true
 					relaxerror: [
 						# We recommend handling this through the server headers so it never appears in the markup
 						"W002" # `<head>` is missing X-UA-Compatible `<meta>` tag that disables old IE compatibility modes


### PR DESCRIPTION
This aborts the build if the bootlint task runs into any warnings (in line with how the other linters work). It'll show all issues it found before failing.

Should make it much more obvious if any future changes introduce bootlint warnings.

Partial port of wet-boew/wet-boew#8739 (GCWeb already fails on bootlint errors).