### PR TITLE
Theme: Add hreflang attribute to language toggle links

### DIFF
--- a/site/includes/languagetoggle.hbs
+++ b/site/includes/languagetoggle.hbs
@@ -2,10 +2,10 @@
 	<h2 class="wb-inv">{{{i18n "tmpl-lang-select"}}}</h2>
 	<ul class="list-inline margin-bottom-none">
 	{{#isnt language "fr" }}
-		<li><a lang="fr" href="{{altLangPrefix}}-fr.html">{{{i18n "lang-native" language="fr"}}}</a></li>
+		<li><a lang="fr" hreflang="fr" href="{{altLangPrefix}}-fr.html">{{{i18n "lang-native" language="fr"}}}</a></li>
 	{{/isnt}}
 	{{#isnt language "en" }}
-		<li><a lang="en" href="{{altLangPrefix}}-en.html">{{{i18n "lang-native" language="en"}}}</a></li>
+		<li><a lang="en" hreflang="en" href="{{altLangPrefix}}-en.html">{{{i18n "lang-native" language="en"}}}</a></li>
 	{{/isnt}}
 	</ul>
 </section>


### PR DESCRIPTION
Brings GCWeb in line with wet-boew (which has been using ``hreflang`` since wet-boew/wet-boew#4288).