### PR TITLE
Theme: Reset the .label class' line height

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -131,7 +131,7 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6
 /* Exclude temporary the form element from the font update, keep same style as before
  * - Rational: More testing and various adjustment need to be completed before to apply it
  */
-:not(#wb-srch) form, .checkbox, .checkbox-inline, .radio, .radio-inline, form .btn:not(.btn-call-to-action) {
+:not(#wb-srch) form, .checkbox, .checkbox-inline, .radio, .radio-inline, form .btn:not(.btn-call-to-action), .label {
 	font-size: 16px;
 	line-height: 23px;
 }


### PR DESCRIPTION
The form font resizing exclusions that were added in #1449 didn't cover the .label class. This adds it in.

As a result, this prevents the form validation plugin's field error messages from overflowing on top of labels and legends under certain circumstances. If a class was set on a label or legend to manipulate its font (such as .h1-.h6), it was causing a significant line-height mismatch between the label/legend and its associated form validation error message. That behaviour was inadvertently introduced in #1449.