### PR TITLE
WET-BOEW Dependency Bump to v4.0.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9670,8 +9670,8 @@
       "dev": true
     },
     "wet-boew": {
-      "version": "github:wet-boew/wet-boew#9fe91ce84dd9a181fdc99811636ed6b76b4df11e",
-      "from": "github:wet-boew/wet-boew#v4.0.32",
+      "version": "github:wet-boew/wet-boew#7f8a6b51f5b7c3200993427edbae708e9f9a4857",
+      "from": "github:wet-boew/wet-boew#v4.0.33",
       "requires": {
         "bootstrap-sass": "3.4.1",
         "code-prettify": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",
     "jsonpointer.js": "^0.4.0",
-    "wet-boew": "github:wet-boew/wet-boew#v4.0.32"
+    "wet-boew": "github:wet-boew/wet-boew#v4.0.33"
   },
   "devDependencies": {
     "assemble-contrib-i18n": "0.1.*",


### PR DESCRIPTION
Is blocked by an upcoming PR that introduces a new GC Features pattern and passes the build.