### PR TITLE
Fix #1634

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -128,20 +128,6 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6
 }
 
 
-/* Exclude temporary the form element from the font update, keep same style as before
- * - Rational: More testing and various adjustment need to be completed before to apply it
- */
-:not(#wb-srch) form, .checkbox, .checkbox-inline, .radio, .radio-inline, form .btn:not(.btn-call-to-action) {
-	font-size: 16px;
-	line-height: 23px;
-}
-form .btn:not(.btn-call-to-action), .form-control {
-	padding: 6px 12px;
-}
-legend {
-	line-height: 1.65em;
-}
-
 /* Force GCWeb release 4.0.29 font style
  *
  * This undo the font style introduced with gcweb v5 new look


### PR DESCRIPTION
No obvious reason to format text differently just because it's inside a <form> element.