### PR TITLE
Fix potential build breaker in hbs markup

### DIFF
--- a/site/pages/gcweb-theme/release/v6.0-en.hbs
+++ b/site/pages/gcweb-theme/release/v6.0-en.hbs
@@ -162,7 +162,7 @@
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/cd96aed">Form test cases: Add autocomplete attributes</a> - Eric Dunsworth, 2019-07-29 15:13:39 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/f22e096">Megamenu: Health Most requested links changes</a> - GormFrank, 2019-07-29 15:36:16 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/8794e45">Site: Rename .hbs links to .html</a> - Eric Dunsworth, 2019-07-30 12:05:37 -0400</li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/588f942">Form test cases: Remove stray </div> tag</a> - Eric Dunsworth, 2019-07-31 13:55:45 -0400</li>
+		<li><a href="https://github.com/wet-boew/GCWeb/commit/588f942">Form test cases: Remove stray &lt;/div&gt; tag</a> - Eric Dunsworth, 2019-07-31 13:55:45 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/40554fc">Site: Fix image misplacement issues</a> - Eric Dunsworth, 2019-07-31 15:59:15 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/492e8c2">Video example: Fix poster image links</a> - Eric Dunsworth, 2019-08-15 11:42:59 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/a81878d">404 english page changed the heading to be more descriptive</a> - NoahGresser, 2019-08-20 14:05:55 -0400</li>

--- a/site/pages/gcweb-theme/release/v6.0-fr.hbs
+++ b/site/pages/gcweb-theme/release/v6.0-fr.hbs
@@ -157,7 +157,7 @@
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/cd96aed">Form test cases: Add autocomplete attributes</a> - Eric Dunsworth, 2019-07-29 15:13:39 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/f22e096">Megamenu: Health Most requested links changes</a> - GormFrank, 2019-07-29 15:36:16 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/8794e45">Site: Rename .hbs links to .html</a> - Eric Dunsworth, 2019-07-30 12:05:37 -0400</li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/588f942">Form test cases: Remove stray </div> tag</a> - Eric Dunsworth, 2019-07-31 13:55:45 -0400</li>
+		<li><a href="https://github.com/wet-boew/GCWeb/commit/588f942">Form test cases: Remove stray &lt;/div&gt; tag</a> - Eric Dunsworth, 2019-07-31 13:55:45 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/40554fc">Site: Fix image misplacement issues</a> - Eric Dunsworth, 2019-07-31 15:59:15 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/492e8c2">Video example: Fix poster image links</a> - Eric Dunsworth, 2019-08-15 11:42:59 -0400</li>
 		<li><a href="https://github.com/wet-boew/GCWeb/commit/a81878d">404 english page changed the heading to be more descriptive</a> - NoahGresser, 2019-08-20 14:05:55 -0400</li>


### PR DESCRIPTION
Found non-escaped HTML markup in the commits list of v6.0 release notes.