### PR TITLE
Moving GC brand text to img alt

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,6 +1,7 @@
 {{#unless provisional}}
 	<div class="brand col-xs-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
 		<a href="https://www.canada.ca/{{language}}.html" property="url"><img src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}}" property="logo" /></a>
+		<meta property="name" content="{{{i18n "tmpl-gc-sig"}}}" />
 		<meta property="areaServed" typeOf="Country" content="Canada" />
 		<link property="logo" href="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" />
 	</div>

--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,6 +1,6 @@
 {{#unless provisional}}
 	<div class="brand col-xs-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
-		<a href="https://www.canada.ca/{{language}}.html" property="url"><img src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}}" property="logo" /></a>
+		<a href="https://www.canada.ca/{{language}}.html" property="url"><img src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}}" property="logo" /><span class="wb-inv"> / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span></a>
 		<meta property="name" content="{{{i18n "tmpl-gc-sig"}}}" />
 		<meta property="areaServed" typeOf="Country" content="Canada" />
 		<link property="logo" href="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" />

--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,6 +1,6 @@
 {{#unless provisional}}
 	<div class="brand col-xs-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
-		<a href="https://www.canada.ca/{{language}}.html" property="url"><img src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="" property="logo" /><span class="wb-inv" property="name"> {{{i18n "tmpl-gc-sig"}}} / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span></a>
+		<a href="https://www.canada.ca/{{language}}.html" property="url"><img src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}}" property="logo" /></a>
 		<meta property="areaServed" typeOf="Country" content="Canada" />
 		<link property="logo" href="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" />
 	</div>

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -15,8 +15,10 @@
 	<body vocab="http://schema.org/" typeof="WebPage">
 		<header role="banner" id="wb-bnr" class="container">
 			<div class="row">
-				<div class="col-sm-6">
-					<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}} / {{#is page.language "en"}}{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}" />
+				<div class="col-sm-6" property="publisher" typeof="GovernmentOrganization">
+					<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{language}}.svg" alt="{{{i18n "tmpl-gc-sig"}}}" property="logo" /><span class="wb-inv"> / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span>
+					<meta property="name" content="{{{i18n "tmpl-gc-sig"}}}" />
+					<meta property="areaServed" typeOf="Country" content="Canada" />
 				</div>
 				<div class="col-sm-6">
 					<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />

--- a/site/pages/splashpage.hbs
+++ b/site/pages/splashpage.hbs
@@ -18,8 +18,10 @@
 	<div class="sp-bx col-xs-12">
 		<h1 property="name" class="wb-inv">{{title}}</h1>
 		<div class="row">
-			<div class="col-xs-11 col-md-8">
-				<img src="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" alt="{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}" />
+			<div class="col-xs-11 col-md-8" property="publisher" typeof="GovernmentOrganization">
+				<img src="{{assets}}/../{{site.theme}}/assets/sig-spl.svg" width="283" alt="{{{i18n "tmpl-gc-sig"}}}" property="logo" /><span class="wb-inv"> / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-sig" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-sig" language="en"}}}{{/is}}</span></span>
+				<meta property="name" content="{{{i18n "tmpl-gc-sig"}}}" />
+				<meta property="areaServed" typeOf="Country" content="Canada" />
 			</div>
 		</div>
 		<div class="row">


### PR DESCRIPTION
- removed the span with GC text and RDFa name
- placed GC text in logo img alt
- supplemented RDFa name with a meta tag

Note: the img alt text is reflecting the brand text of the chosen language of page only. Logos are exempt from verbosity.

Related: https://github.com/wet-boew/GCWeb/issues/1670