### PR TITLE
Fix #1634

### DIFF
--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -136,7 +136,7 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6
 	font-size: 16px;
 	line-height: 23px;
 }
-form:not(.force-style-gcweb-current) .btn:not(.btn-call-to-action), :not(.force-style-gcweb-current) .form-control {
+form:not(.force-style-gcweb-latest) .btn:not(.btn-call-to-action), :not(.force-style-gcweb-latest) .form-control {
 	padding: 6px 12px;
 }
 :not(.force-style-gcweb-current) legend {

--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -130,15 +130,16 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6
 
 /* Exclude temporary the form element from the font update, keep same style as before
  * - Rational: More testing and various adjustment need to be completed before to apply it
+ * - In the mean time, users can apply the class "force-style-gcweb-current" to the form
  */
-:not(#wb-srch) form, .checkbox, .checkbox-inline, .radio, .radio-inline, form .btn:not(.btn-call-to-action) {
+:not(#wb-srch) form:not(.force-style-gcweb-current), :not(.force-style-gcweb-current) .checkbox, :not(.force-style-gcweb-current) .checkbox-inline, :not(.force-style-gcweb-current) .radio, :not(.force-style-gcweb-current) .radio-inline, form:not(.force-style-gcweb-current) .btn:not(.btn-call-to-action) {
 	font-size: 16px;
 	line-height: 23px;
 }
-form .btn:not(.btn-call-to-action), .form-control {
+form:not(.force-style-gcweb-current) .btn:not(.btn-call-to-action), :not(.force-style-gcweb-current) .form-control {
 	padding: 6px 12px;
 }
-legend {
+:not(.force-style-gcweb-current) legend {
 	line-height: 1.65em;
 }
 

--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -132,7 +132,7 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6
  * - Rational: More testing and various adjustment need to be completed before to apply it
  * - In the mean time, users can apply the class "force-style-gcweb-current" to the form
  */
-:not(#wb-srch) form:not(.force-style-gcweb-current), :not(.force-style-gcweb-current) .checkbox, :not(.force-style-gcweb-current) .checkbox-inline, :not(.force-style-gcweb-current) .radio, :not(.force-style-gcweb-current) .radio-inline, form:not(.force-style-gcweb-current) .btn:not(.btn-call-to-action) {
+:not(#wb-srch) form:not(.force-style-gcweb-latest), :not(.force-style-gcweb-latest) .checkbox, :not(.force-style-gcweb-latest) .checkbox-inline, :not(.force-style-gcweb-latest) .radio, :not(.force-style-gcweb-latest) .radio-inline, form:not(.force-style-gcweb-latest) .btn:not(.btn-call-to-action) {
 	font-size: 16px;
 	line-height: 23px;
 }

--- a/src/_defaults.scss
+++ b/src/_defaults.scss
@@ -139,7 +139,7 @@ h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6
 form:not(.force-style-gcweb-latest) .btn:not(.btn-call-to-action), :not(.force-style-gcweb-latest) .form-control {
 	padding: 6px 12px;
 }
-:not(.force-style-gcweb-current) legend {
+:not(.force-style-gcweb-latest) legend {
 	line-height: 1.65em;
 }
 


### PR DESCRIPTION
Temporary fix, until testing is completed on the change of 2018-11-28.

This PR introduces the .force-style-gcweb-current class which content authors can apply to forms, in order to maintain compliance with the Canada.ca design system.