### PR TITLE
Theme: Update wordmark code and add isBilingual var

### DIFF
--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -21,7 +21,7 @@
 					<meta property="areaServed" typeOf="Country" content="Canada" />
 				</div>
 				<div class="col-sm-6">
-					<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
+					<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-blk.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />{{#if page.isBilingual}}<span class="wb-inv"> / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-wmms" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-wmms" language="en"}}}{{/is}}</span></span>{{/if}}
 				</div>
 			</div>
 		</header>

--- a/site/pages/404-en-fr.hbs
+++ b/site/pages/404-en-fr.hbs
@@ -2,6 +2,7 @@
 {
 	"title": "We couldn't find that Web page (Error 404) - Canada.ca theme / Nous ne pouvons trouver cette page Web (Erreur 404) - Thème Canada.ca",
 	"language": "en",
+	"isBilingual": true,
 	"layout": "servermessage.hbs"
 }
 ---

--- a/site/pages/404-fr-en.hbs
+++ b/site/pages/404-fr-en.hbs
@@ -2,6 +2,7 @@
 {
 	"title": "Nous ne pouvons trouver cette page Web (Erreur 404) - Thème Canada.ca / We couldn't find that Web page (Error 404) - Canada.ca theme",
 	"language": "fr",
+	"isBilingual": true,
 	"layout": "servermessage.hbs"
 }
 ---

--- a/site/pages/servermessage-en-fr.hbs
+++ b/site/pages/servermessage-en-fr.hbs
@@ -2,6 +2,7 @@
 {
 	"title": "Message title - Canada.ca theme / Titre du message - Thème Canada.ca",
 	"language": "en",
+	"isBilingual": true,
 	"layout": "servermessage.hbs"
 }
 ---

--- a/site/pages/servermessage-fr-en.hbs
+++ b/site/pages/servermessage-fr-en.hbs
@@ -2,6 +2,7 @@
 {
 	"title": "Titre du message - Thème Canada.ca / Message title - Canada.ca theme",
 	"language": "fr",
+	"isBilingual": true,
 	"layout": "servermessage.hbs"
 }
 ---

--- a/site/pages/splashpage.hbs
+++ b/site/pages/splashpage.hbs
@@ -9,8 +9,9 @@
 	"subject-en": "Government of Canada, services",
 	"subject-fr": "Gouvernement du Canada, services",
 	"language": "en",
+	"isBilingual": true,
 	"section": "message",
-	"dateModified": "2020-05-25"
+	"dateModified": "2020-06-03"
 }
 ---
 
@@ -41,7 +42,7 @@
 				<a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">{{{i18n "tmpl-terms"}}}</a> <span class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html" class="sp-lk" lang="fr">{{{i18n "tmpl-terms" language="fr"}}}</a>
 			</div>
 			<div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
-				<img src="{{assets}}/../{{site.theme}}/assets/wmms-spl.svg" width="127" alt="{{{i18n "tmpl-gc-wmms"}}} / {{{i18n "tmpl-gc-wmms" language="fr"}}}" />
+				<img src="{{assets}}/../{{site.theme}}/assets/wmms-spl.svg" width="127" alt="{{{i18n "tmpl-gc-wmms"}}}" /><span class="wb-inv"> / <span lang="{{#is page.language "en"}}fr">{{{i18n "tmpl-gc-wmms" language="fr"}}}{{else}}en">{{{i18n "tmpl-gc-wmms" language="en"}}}{{/is}}</span></span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This change updates wordmark code for consistency with #1673's FIP changes.

Specifically:
- The splash page's wordmark now uses an English alt attribute and hidden span elements for the French version's text alternative
- Bilingual server message pages now use bilingual textual equivalents for their wordmarks (they previously only used unilingual alt attributes)
- Unilingual server message pages remain as-is (unilingual alt attributes)
- All bilingual pages now contain an extra isBilingual indicator variable
  - Splash page's isBilingual variable is currently unused

CC @bsouster @duboisp 