### PR TITLE
removed no-url-protocols rule to remove warnings from test

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -33,7 +33,6 @@ rules:
       -
           'extra-properties':
               - 'overflow-scrolling'
-  no-url-protocols: 1
   no-trailing-whitespace: 2
   placeholder-name-format: 0
   property-sort-order: 2


### PR DESCRIPTION
Please remove the sasslint rule no-url-protocols: 1 to remove the warnings on grunt test sasslint:all task. 

This is preferable over removing the HTTPS import url protocol from _defaults.scss. 

![image](https://user-images.githubusercontent.com/32347545/81455929-b520cb00-915e-11ea-9907-ca138344f6c2.png)
![image](https://user-images.githubusercontent.com/32347545/81455942-bce06f80-915e-11ea-8164-92c74106a686.png)
