### PR TITLE
Field flow: Use "chkbxrdio-grp" class for fieldsets

### DIFF
--- a/src/plugins/fieldflow/fieldflow.js
+++ b/src/plugins/fieldflow/fieldflow.js
@@ -632,9 +632,9 @@ var componentName = "wb-fieldflow",
 			i18n = $elm.data( configData ).i18n,
 			attributes = data.attributes,
 			ctrlID = wb.getId(),
-			fieldsetPrefix = "<legend class='h5 ",
+			fieldsetPrefix = "<legend",
 			fieldsetSuffix = "</span>",
-			fieldsetHTML = "<fieldset id='" + ctrlID + "' data-" + originData + "='" + elm.id + "' " + sourceDataAttr + "='" + source.id + "' class='" + crtlSelectClass + " mrgn-bttm-md'",
+			fieldsetHTML = "<fieldset id='" + ctrlID + "' data-" + originData + "='" + elm.id + "' " + sourceDataAttr + "='" + source.id + "' class='" + crtlSelectClass + " chkbxrdio-grp mrgn-bttm-md'",
 			$out,
 			$tmpLabel, $cloneLbl, $prevContent,
 			radCheckOut = "",
@@ -654,10 +654,10 @@ var componentName = "wb-fieldflow",
 
 		// Create the legend
 		if ( isReq && useReqLabel ) {
-			fieldsetPrefix += " required";
+			fieldsetPrefix += " class='required'";
 			fieldsetSuffix += " <strong class='required'>(" + i18n.required + ")</strong>";
 		}
-		fieldsetPrefix += "'>";
+		fieldsetPrefix += ">";
 		fieldsetSuffix += "</legend>";
 		if ( !lblselector ) {
 			$out.append( $( fieldsetPrefix + data.label + fieldsetSuffix ) );


### PR DESCRIPTION
This is how fieldsets with normal-sized legends are supposed to be coded in WET.

Field flow was previously misusing the "h5" class in its fieldset legends to get a similar visual effect. But that method has error message overlapping issues in modern versions of GCWeb and won't benefit from any solutions for #1634 (like #1654 and #1676).