### PR TITLE
Home page: Have a smaller image for smaller device on the home page with bgimg-srcset

### DIFF
--- a/site/pages/home-en.hbs
+++ b/site/pages/home-en.hbs
@@ -7,14 +7,14 @@
 	"breadcrumb": [
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
 	],
-	"dateModified": "2019-07-02",
+	"dateModified": "2020-05-25",
 	"share": "true",
 	"noMainContainer": "true",
 	"noContentTitle": "true",
 	"breadcrumb": "false",
 }
 ---
-<div class="provisional bg-cover" data-bgimg="https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner.jpg">
+<div class="provisional bg-cover" data-bgimg-srcset="https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner-480w.jpg 479w, https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner.jpg 480w">
 	<div class="container p-0 p-sm-3">
 		<div class="well header-rwd brdr-0 brdr-rds-0 text-white bg-gctheme">
 			<h1 property="name" id="wb-cont">Canada.ca</h1>

--- a/site/pages/home-fr.hbs
+++ b/site/pages/home-fr.hbs
@@ -7,14 +7,14 @@
 	"breadcrumb": [
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
 	],
-	"dateModified": "2019-07-02",
+	"dateModified": "2020-05-25",
 	"share": "true",
 	"noMainContainer": "true",
 	"noContentTitle": "true",
 	"breadcrumb": "false",
 }
 ---
-<div class="provisional bg-cover" data-bgimg="https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner.jpg">
+<div class="provisional bg-cover" data-bgimg-srcset="https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner-480w.jpg 479w, https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner.jpg 480w">
 	<div class="container p-0 p-sm-3">
 		<div class="well header-rwd brdr-0 brdr-rds-0 text-white bg-gctheme">
 			<h1 property="name" id="wb-cont">Canada.ca</h1>


### PR DESCRIPTION
At 479px wide and down, you get a lighter, more vertical than horizontal image as the background on the home page. This is better adapted for mobile user and it consumes less data for them.