### PR TITLE
Header element: Fix CSS for Geomap panel to show X button

### DIFF
--- a/src/banner/_base.scss
+++ b/src/banner/_base.scss
@@ -3,7 +3,9 @@
  */
 
 header {
-	position: relative;
+	&:not(.panel-heading) {
+		position: relative;
+	}
 
 	.brand {
 		margin-bottom: 10px;


### PR DESCRIPTION
As described in #1682 

for minimal impact, I simply removed the `.panel-heading` from the relative positioning equation.
Doesn't seem to break the layout in any way.