### PR TITLE
Theme: Simplify boolean condition in default page template

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -30,9 +30,9 @@
 {{/unless}}
 			{{>contentbuttons}}
 			{{>body}}
-{{#is page.deptfeature true}}
+{{#if page.deptfeature}}
 	{{>deptfeatures}}
-{{/is}}
+{{/if}}
 {{#if page.dateModified}}
 	{{>datemodified}}
 {{/if}}


### PR DESCRIPTION
This was the only handlebars condition in the entire theme that specifically checked whether a boolean variable's value was "true". All other bool conditions use #if and only check whether they're truthy.