### PR TITLE
Migration page: Disable language toggle section

### DIFF
--- a/site/pages/gcweb-theme/v5-migration.hbs
+++ b/site/pages/gcweb-theme/v5-migration.hbs
@@ -2,6 +2,7 @@
 {
 	"title": "Migration instruction - GCWeb theme V5",
 	"language": "en",
+	"languagetoggle": "false",
 	"altLangPrefix": "v5-migration",
 	"breadcrumb": [
 		{ "title": "GCWeb home", "link": "../index-en.html" },


### PR DESCRIPTION
This page was identified as unilingual in #1677's review.

I planned to add an ``isUnilingual`` variable and an extra condition for it... But it turns out that WET and GCWeb already have a built-in ``languagetoggle`` variable that does the same thing.

Things to note:
- The ``languagetoggle`` variable and its associated conditions expect its value to be a string. Several other similar variables work in the same way across WET/GCWeb.
- Without the language toggle section, GCWeb's header shifts upwards. It still looks fine, but the amount of space above the FIP and search field is reduced.