### PR TITLE
Adding pull-right to language toggle instructions

### DIFF
--- a/site/pages/gcweb-theme/release/v8.0-en.hbs
+++ b/site/pages/gcweb-theme/release/v8.0-en.hbs
@@ -59,7 +59,7 @@
 &lt;header&gt;
 	&lt;div id="wb-bnr" class="container"&gt;
 		<strong>&lt;div class="row"&gt;</strong>
-			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 </strong>text-right"&gt;
+			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 pull-right </strong>text-right"&gt;
 				&lt;h2 class="wb-inv"&gt;Language selection&lt;/h2&gt;
 				&lt;ul class="list-inline <strong>mrgn-bttm-0</strong>"&gt;
 					&lt;li&gt;

--- a/site/pages/gcweb-theme/release/v8.0-en.hbs
+++ b/site/pages/gcweb-theme/release/v8.0-en.hbs
@@ -208,7 +208,7 @@
 &lt;header&gt;
 	&lt;div id="wb-bnr" class="container"&gt;
 		<strong>&lt;div class="row"&gt;</strong>
-			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 </strong>text-right"&gt;
+			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 pull-right </strong>text-right"&gt;
 				&lt;h2 class="wb-inv"&gt;Language selection&lt;/h2&gt;
 				&lt;ul class="list-inline <strong>mrgn-bttm-0</strong>"&gt;
 					&lt;li&gt;

--- a/site/pages/gcweb-theme/release/v8.0-fr.hbs
+++ b/site/pages/gcweb-theme/release/v8.0-fr.hbs
@@ -208,7 +208,7 @@
 &lt;header&gt;
 	&lt;div id="wb-bnr" class="container"&gt;
 		<strong>&lt;div class="row"&gt;</strong>
-			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 </strong>text-right"&gt;
+			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 pull-right </strong>text-right"&gt;
 				&lt;h2 class="wb-inv"&gt;Sélection de la langue&lt;/h2&gt;
 				&lt;ul class="list-inline <strong>mrgn-bttm-0</strong>"&gt;
 					&lt;li&gt;

--- a/site/pages/gcweb-theme/release/v8.0-fr.hbs
+++ b/site/pages/gcweb-theme/release/v8.0-fr.hbs
@@ -59,7 +59,7 @@
 &lt;header&gt;
 	&lt;div id="wb-bnr" class="container"&gt;
 		<strong>&lt;div class="row"&gt;</strong>
-			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 </strong>text-right"&gt;
+			&lt;section id="wb-lng" class="<strong>col-xs-3 col-sm-12 pull-right </strong>text-right"&gt;
 				&lt;h2 class="wb-inv"&gt;Sélection de la langue&lt;/h2&gt;
 				&lt;ul class="list-inline <strong>mrgn-bttm-0</strong>"&gt;
 					&lt;li&gt;


### PR DESCRIPTION
I had issues with the language flip link being on the left of the Government of Canada logo when following the migration instructions for GCWeb v8.0. I found that the Canada.ca wb-lng has the pull-right class to help make the wb-lng stay to the right of the Government of Canada logo, while the instructions don't have this class.