### PR TITLE
Update chatwizard.js - Reset and Minimize button labels

### DIFF
--- a/src/plugins/chatwizard/chatwizard.js
+++ b/src/plugins/chatwizard/chatwizard.js
@@ -540,10 +540,14 @@ var componentName = "wb-chtwzrd",
 			"<header class='modal-header header'><h2 class='modal-title title'>" +
 			title + "</h2><button type='button' class='reset' title='" +
 			i18nDict.reset +
-			"'> <span class='glyphicon glyphicon-refresh'></span></button>" +
+			"'> <span class='glyphicon glyphicon-refresh'></span><span class='wb-inv'>" +
+			i18nDict.reset +
+			"</span></button>" +
 			"<button type='button' class='minimize' title='" +
 			i18nDict.minimize +
-			"'><span class='glyphicon glyphicon-chevron-down'></span></button></header>" );
+			"'><span class='glyphicon glyphicon-chevron-down'></span><span class='wb-inv'>" +
+			i18nDict.minimize +
+			"</span></button></header>" );
 		$container.append( "<form class='modal-body body' method='GET'></form>" );
 
 		var $form = $( ".body", $container );


### PR DESCRIPTION
The Reset and Minimize buttons rely on the title attribute for labels. I would propose including a more substantial label for the buttons. I made a change to update the buttons to be inline with what is done for the Overlay feature, an invisible span containing the text label.