### PR TITLE
GC Subway - Multiple small fixes

### DIFF
--- a/site/pages/provisional-en.hbs
+++ b/site/pages/provisional-en.hbs
@@ -543,7 +543,7 @@ if ( s.getTime() &lt; msT && msT &lt; e.getTime() ) {
 <p>In order to achieve the provisinal Service initiation template revamp with the subway map, you will need to complete the following steps:</p>
 <ol>
 	<li>First, you'll need a &lt;nav&gt; element with both the "provisional" and the "gc-subway" classes. Inside of that &lt;nav&gt;, put your first &lt;h1&gt;; it will be the smaller, gray-ish, upper one.</li>
-	<li>Add a &lt;ul&gt; with a "gc-subway-steps" class next to that &lt;h1&gt;. Put the links to your other pages related to that service initiation template in there.</li>
+	<li>Add a &lt;ul&gt; next to that &lt;h1&gt;. Put the links to your other pages related to that service initiation template in there.</li>
 	<li>The rest just needs your own main content for that page. Do not forget the navigation buttons at the bottom of the pages. If you want the left column to stop being at 2/3 of the width on desktop at some point, then you can stop the propagation by using any HTML element with a "gc-subway-section-end" class on it; that element needs to be a sibling of your ".gc-subway" &lt;nav&gt;.</li>
 	<li>If you want to use the new bold short red underline underneath your regular H1, then add both the "provisional" and "gc-thickline" classes on it.</li>
 </ol>

--- a/site/pages/provisional-fr.hbs
+++ b/site/pages/provisional-fr.hbs
@@ -545,7 +545,7 @@ if ( s.getTime() &lt; msT && msT &lt; e.getTime() ) {
 <p>In order to achieve the provisinal Service initiation template revamp with the subway map, you will need to complete the following steps:</p>
 <ol>
 	<li>First, you'll need a &lt;nav&gt; element with both the "provisional" and the "gc-subway" classes. Inside of that &lt;nav&gt;, put your first &lt;h1&gt;; it will be the smaller, gray-ish, upper one.</li>
-	<li>Add a &lt;ul&gt; with a "gc-subway-steps" class next to that &lt;h1&gt;. Put the links to your other pages related to that service initiation template in there.</li>
+	<li>Add a &lt;ul&gt; next to that &lt;h1&gt;. Put the links to your other pages related to that service initiation template in there.</li>
 	<li>The rest just needs your own main content for that page. Do not forget the navigation buttons at the bottom of the pages. If you want the left column to stop being at 2/3 of the width on desktop at some point, then you can stop the propagation by using any HTML element with a "gc-subway-section-end" class on it; that element needs to be a sibling of your ".gc-subway" &lt;nav&gt;.</li>
 	<li>If you want to use the new bold short red underline underneath your regular H1, then add both the "provisional" and "gc-thickline" classes on it.</li>
 </ol>

--- a/src/plugins/gc-subway/_base.scss
+++ b/src/plugins/gc-subway/_base.scss
@@ -16,61 +16,75 @@
 		border-top: 4px solid #26374a;
 		margin-top: 38px;
 
-		.gc-subway-steps {
+		ul {
 			clear: both;
 			list-style: none;
 			padding-left: .57em;
 			padding-top: 10px;
 			position: relative;
 
-			& > li {
+			li {
 				border-left: 4px solid #26374a;
 				padding: 0px 20px 30px 1em;
-			}
-			& > li::first-line {
-				line-height: 1 !important;
-			}
 
-			& > li > :first-child::before {
-				background-color: #fff;
-				border: 3px solid #26374a;
-				border-radius: 50%;
-				content: "";
-				height: 1.2em;
-				left: .05em;
-				position: absolute;
-				transition: width .2s, height .2s, left .2s, margin-top .2s;
-				width: 1.2em;
-			}
-			& > li.active > :first-child::before {
-				background-color: #26374a;
-			}
-			& > li > a[href]:hover::before,
-			& > li > a[href]:focus::before {
-				height: 1.4em;
-				left: -.05em;
-				margin-top: -.1em;
-				width: 1.4em;
-			}
+				&::first-line {
+					line-height: 1 !important;
+				}
 
-			& > li:last-child {
-				border-bottom: 4px solid #26374a;
-				border-bottom-left-radius: 6px;
-				border-left: 4px solid #26374a;
-			}
-		}
+				:first-child::before {
+					background-color: #fff;
+					border: 3px solid #26374a;
+					border-radius: 50%;
+					content: "";
+					height: 1.2em;
+					left: .05em;
+					position: absolute;
+					transition: width .2s, height .2s, left .2s, margin-top .2s;
+					width: 1.2em;
+				}
+				&.active > :first-child::before {
+					background-color: #26374a;
+				}
+				a[href]:hover::before,
+				a[href]:focus::before {
+					height: 1.4em;
+					left: -.05em;
+					margin-top: -.1em;
+					width: 1.4em;
+				}
+				&:last-child {
+					border-bottom: 4px solid #26374a;
+					border-bottom-left-radius: 6px;
+					border-left: 4px solid #26374a;
+				}
 
-		li .gc-subway-steps {
-			margin-top: 20px;
-			padding-left: .55em;
+				ul {
+					margin-top: 20px;
+					padding-left: .55em;
 
-			& > li:last-child {
-				padding-bottom: 0px;
+					li:last-child {
+						border-bottom-width: 0px;
+						padding-bottom: 0px;
+					}
+					&.noline li {
+						border-image: none;
+						border-left: 4px solid transparent;
+
+						&.active::before {
+							background-color: #26374a;
+							content: " ";
+							height: 4px;
+							margin-left: -2.8em;
+							margin-top: .5em;
+							position: absolute;
+							width: 1.6em;
+						}
+					}
+				}
 			}
 		}
 
 		h1 {
-			display: inline-block;
 			float: left;
 		}
 	}
@@ -84,6 +98,6 @@
 		font-size: 1.3em;
 		margin-right: 20px;
 		margin-top: -19px;
-		padding: 0px 20px 10px 12px;
+		padding: 0px 20px 10px 0px;
 	}
 }

--- a/src/plugins/gc-subway/_screen-md-min.scss
+++ b/src/plugins/gc-subway/_screen-md-min.scss
@@ -13,14 +13,18 @@
 	&.gc-subway {
 		border-right: 0px;
 		border-top: 0px;
+		display: none;
 		margin-top: 25px;
 		padding-left: 15px;
 
+		&.no-blink {
+			display: block;
+		}
 		.gc-subway-menu-nav {
 			float: right;
 			width: 33.33%;
 		}
-		.gc-subway-steps > li:last-child {
+		ul li:last-child {
 			border-bottom: 0px;
 			border-left: 4px solid transparent;
 		}
@@ -43,4 +47,8 @@
 			padding-left: 0px;
 		}
 	}
+}
+
+.wb-disable .provisional.gc-subway {
+	display: block;
 }

--- a/src/plugins/gc-subway/gc-subway-en.hbs
+++ b/src/plugins/gc-subway/gc-subway-en.hbs
@@ -16,13 +16,25 @@
 
 <nav class="provisional gc-subway">
 	<h1>Service initiation template</h1>
-	<ul class="gc-subway-steps">
-		<li class="active"><a aria-current="page">Who can apply<span class="wb-inv">: Service initiation template</span></a></li>
-		<li><a href="#">How much you can get<span class="wb-inv">: Service initiation template</span></a></li>
-		<li><a href="#">Which periods you can apply for<span class="wb-inv">: Service initiation template</span></a></li>
-		<li><a href="#">How to apply<span class="wb-inv">: Service initiation template</span></a></li>
-		<li><a href="#">Keep getting your payments<span class="wb-inv">: Service initiation template</span></a></li>
-		<li><a href="#">Return or repay a payment<span class="wb-inv">: Service initiation template</span></a></li>
+	<ul>
+		<li class="active"><a aria-current="page">Who can apply</a></li>
+		<li><a href="#">How much you can get</a>
+			<ul class="noline">
+				<li><a href="#">[Sub-Page 1]</a></li>
+				<li><a href="#">[Sub-Page 2]</a></li>
+				<li><a href="#">[Sub-Page 3]</a></li>
+			</ul>
+		</li>
+		<li><a href="#">Which periods you can apply for</a></li>
+		<li><a href="#">How to apply</a></li>
+		<li><a href="#">Keep getting your payments</a>
+			<ul>
+				<li><a href="#">[Sub-Page 1]</a></li>
+				<li><a href="#">[Sub-Page 2]</a></li>
+				<li><a href="#">[Sub-Page 3]</a></li>
+			</ul>
+		</li>
+		<li><a href="#">Return or repay a payment</a></li>
 	</ul>
 </nav>
 <h1 property="name" id="wb-cont" class="provisional gc-thickline">Who can apply</h1>

--- a/src/plugins/gc-subway/gc-subway-fr.hbs
+++ b/src/plugins/gc-subway/gc-subway-fr.hbs
@@ -17,13 +17,25 @@
 <div lang="en">
 	<nav class="provisional gc-subway">
 		<h1>Service initiation template</h1>
-		<ul class="gc-subway-steps">
-			<li class="active"><a aria-current="page">Who can apply<span class="wb-inv">: Service initiation template</span></a></li>
-			<li><a href="#">How much you can get<span class="wb-inv">: Service initiation template</span></a></li>
-			<li><a href="#">Which periods you can apply for<span class="wb-inv">: Service initiation template</span></a></li>
-			<li><a href="#">How to apply<span class="wb-inv">: Service initiation template</span></a></li>
-			<li><a href="#">Keep getting your payments<span class="wb-inv">: Service initiation template</span></a></li>
-			<li><a href="#">Return or repay a payment<span class="wb-inv">: Service initiation template</span></a></li>
+		<ul>
+			<li class="active"><a aria-current="page">Who can apply</a></li>
+			<li><a href="#">How much you can get</a>
+				<ul class="noline">
+					<li><a href="#">[Sub-Page 1]</a></li>
+					<li><a href="#">[Sub-Page 2]</a></li>
+					<li><a href="#">[Sub-Page 3]</a></li>
+				</ul>
+			</li>
+			<li><a href="#">Which periods you can apply for</a></li>
+			<li><a href="#">How to apply</a></li>
+			<li><a href="#">Keep getting your payments</a>
+				<ul>
+					<li><a href="#">[Sub-Page 1]</a></li>
+					<li><a href="#">[Sub-Page 2]</a></li>
+					<li><a href="#">[Sub-Page 3]</a></li>
+				</ul>
+			</li>
+			<li><a href="#">Return or repay a payment</a></li>
 		</ul>
 	</nav>
 	<h1 property="name" id="wb-cont" class="provisional gc-thickline">Who can apply</h1>

--- a/src/plugins/gc-subway/gc-subway.js
+++ b/src/plugins/gc-subway/gc-subway.js
@@ -12,6 +12,8 @@ var $document = wb.doc,
 	selector = ".provisional." + componentName,
 	initEvent = "wb-init ." + componentName,
 	views = {
+		xxs: "xxsmallview",
+		xs: "xsmallview",
 		sm: "smallview",
 		md: "mediumview",
 		lg: "largeview",
@@ -58,8 +60,8 @@ var $document = wb.doc,
 		}
 
 		// Desktop view, setup and mutate H1s
-		if ( ( $html.hasClass( views.md ) || $html.hasClass( views.lg ) ||
-			$html.hasClass( views.xl ) ) ) {
+		if ( $html.hasClass( views.md ) || $html.hasClass( views.lg ) ||
+			$html.hasClass( views.xl ) ) {
 
 			// Initiate desktop mode only once
 			if ( !desktopInited ) {
@@ -68,7 +70,7 @@ var $document = wb.doc,
 			$h1.addClass( toggleClass );
 			$h1Copy.prependTo( $main );
 			$h2.prependTo( $menu );
-		} else if ( $html.hasClass( views.sm ) && desktopInited ) {
+		} else if ( ( $html.hasClass( views.sm ) || $html.hasClass( views.xs ) || $html.hasClass( views.xxs ) ) && desktopInited ) {
 
 			// Mobile view, mutate back to mobile first if needed
 			$h1.removeClass( toggleClass );
@@ -86,10 +88,14 @@ var $document = wb.doc,
 		$h1 = $( "h1", $elm );
 		$h2 = $( "<h2 class='h3 hidden-xs visible-md visible-lg mrgn-tp-0'>Sections</h2>" );
 		$h1Copy = $( "<p class='gc-subway-h1' aria-hidden='true'>" + $h1.text() + "</p>" );
-		$( ".gc-subway-steps" ).wrap( "<div class='gc-subway-menu-nav'></div>" );
+		$( "ul", $elm ).first().wrap( "<div class='gc-subway-menu-nav'></div>" );
 		$menu = $( ".gc-subway-menu-nav", $elm );
 		$elm.nextUntil( ".pagedetails, .gc-subway-section-end" ).wrapAll( "<section class='provisional " + mainClass + "'>" );
 		$main = $elm.next();
+
+		// Prevent on-load blinking on desktop
+		$elm.addClass( "no-blink" );
+
 		desktopInited = true;
 	};
 


### PR DESCRIPTION
**Changes include:**

- Prevent most of the on-load blinking with the addition of a "no-blink" shows the plugin after it is initialized, but the plugin does show in Basic HTML mode no matter what. Also, this only affects desktop mode;
- Add breakpoints to the resize event triggers, in order to make DOM shift smoother;
- Make sublists work and look right (also with .noline), plus add one to the working example;
- Clean inline-block on a float left element and some spacing.

Closes #1715