### PR TITLE
Add BOM to UTF-8 file

### DIFF
--- a/src/plugins/actionmng/actionmng.js
+++ b/src/plugins/actionmng/actionmng.js
@@ -268,7 +268,7 @@ var $document = wb.doc,
 			csvText = csvText + "\n";
 		}
 
-		wb.download( new Blob( [ csvText ], { type: "text/plain;charset=utf-8" } ), fileName );
+		wb.download( new Blob( [ "\ufeff" + csvText ], { type: "text/plain;charset=utf-8" } ), fileName );
 
 	},
 


### PR DESCRIPTION
This fixes the reported Excel issue with opening the downloaded csv