### PR TITLE
GC Subway - Fix "active" status on a sublist item that is currently viewed

### DIFF
--- a/src/plugins/gc-subway/_base.scss
+++ b/src/plugins/gc-subway/_base.scss
@@ -30,7 +30,6 @@
 				&::first-line {
 					line-height: 1 !important;
 				}
-
 				:first-child::before {
 					background-color: #fff;
 					border: 3px solid #26374a;
@@ -57,7 +56,6 @@
 					border-bottom-left-radius: 6px;
 					border-left: 4px solid #26374a;
 				}
-
 				ul {
 					margin-top: 20px;
 					padding-left: .55em;
@@ -69,16 +67,6 @@
 					&.noline li {
 						border-image: none;
 						border-left: 4px solid transparent;
-
-						&.active::before {
-							background-color: #26374a;
-							content: " ";
-							height: 4px;
-							margin-left: -2.8em;
-							margin-top: .5em;
-							position: absolute;
-							width: 1.6em;
-						}
 					}
 				}
 			}


### PR DESCRIPTION
The `.active` class was adding a second weird blue oval shape at the left of a subitem that is active/current.