### PR TITLE
8.1.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "GCWeb",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9688,7 +9688,7 @@
     },
     "wet-boew": {
       "version": "github:wet-boew/wet-boew#1a9e3707e9dcfdbeb507f1ca784900f169e2ea3c",
-      "from": "github:wet-boew/wet-boew#v4.0.38",
+      "from": "github:wet-boew/wet-boew#v4.0.39",
       "requires": {
         "bootstrap-sass": "3.4.1",
         "code-prettify": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GCWeb",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "Web Experience Toolkit (WET): Canada.ca Theme",
   "main": "index.html",
   "scripts": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",
     "jsonpointer.js": "^0.4.0",
-    "wet-boew": "github:wet-boew/wet-boew#v4.0.38"
+    "wet-boew": "github:wet-boew/wet-boew#v4.0.39"
   },
   "devDependencies": {
     "assemble-contrib-i18n": "0.1.*",

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -7,7 +7,7 @@
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
 	],
 	"tag": "GCWeb",
-	"dateModified": "2020-09-18",
+	"dateModified": "2020-11-04",
 	"share": "true"
 }
 ---
@@ -16,8 +16,8 @@
 		<p>The page templates and design patterns below comprise a reference implementation of the <a href="https://design.canada.ca">Canada.ca design system</a>, including the mandatory requirement of the Content and Information Architecture (C&amp;IA) Specification. Government of Canada departments and agencies can contribute additional patterns and templates via <a href="https://github.com/wet-boew/GCWeb">GCWeb github repository</a>.</p>
 	</div>
 	<div class="col-xs-12 col-md-auto pull-right">
-		<p><a href="https://github.com/wet-boew/GCWeb/archive/v8.0.2.zip" class="btn btn-primary">Download GCWeb theme <strong>v8.0.2 (STR)</strong></a><br />
-			<small>(<time>2020-09-18</time> - <a href="https://github.com/wet-boew/gcweb/releases/tag/v8.0.2">Release notes</a>)</small></p>
+		<p><a href="https://github.com/wet-boew/GCWeb/archive/v8.1.0.zip" class="btn btn-primary">Download GCWeb theme <strong>v8.1.0</strong></a><br />
+			<small>(<time>2020-10-28</time> - <a href="https://github.com/wet-boew/gcweb/releases/tag/v8.1.0">Release notes</a>)</small></p>
 	</div>
 </div>
 <p>This current implementation reference match the <strong>version 2.0 of the C&amp;IA Specification released on January 2019</strong>.</p>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -7,7 +7,7 @@
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
 	],
 	"tag": "GCWeb",
-	"dateModified": "2020-09-18",
+	"dateModified": "2020-11-04",
 	"share": "true"
 }
 ---
@@ -16,8 +16,8 @@
 		<p>Les gabarits et les conceptions communes si dessous sont une référence d'implémentation du <a href="https://conception.canada.ca">Système de conception de Canada.ca</a>, incluant les exigences obligatoire de la spécifications du contenu et de l’architecture de l'information (C&amp;AI) pour Canada.ca. Les ministères et organisme du gouvernement du Canada peuvent y contribuer en publiant leur modèle et leur conception commune via le <a href="https://github.com/wet-boew/GCWeb">dépôt github de GCWeb</a>.</p>
 	</div>
 	<div class="col-xs-12 col-md-auto pull-right">
-		<p><a href="https://github.com/wet-boew/GCWeb/archive/v8.0.2.zip" class="btn btn-primary">Télécharger le thème <strong>GCWeb v8.0.2 (DCT)</strong></a><br />
-			<small>(<time>2020-09-18</time> - <a href="https://github.com/wet-boew/gcweb/releases/tag/v8.0.2">Note de version</a>)</small></p>
+		<p><a href="https://github.com/wet-boew/GCWeb/archive/v8.1.0.zip" class="btn btn-primary">Télécharger le thème <strong>GCWeb v8.1.0</strong></a><br />
+			<small>(<time>2020-10-28</time> - <a href="https://github.com/wet-boew/gcweb/releases/tag/v8.1.0">Note de version</a>)</small></p>
 	</div>
 </div>
 


### PR DESCRIPTION
This is a **MINOR release** (without breaking changes):

## What’s new?
The following lists all the "What's new?" items since the last regular release (non-STR), which was v8.0.

* **template:**
	* Patch - Follow - google plus removed from follow template
	* Head - Remove no longer supported Internet Explorer conditionals

* **Styles and plugins:**
	* Minor - JSON Manager - Make it usable without fetching a JSON file applied in each files
	* Action Manager - Add BOM to UTF-8 file to fix character encoding on CSV export

* **[Provisional](https://wet-boew.github.io/themes-dist/GCWeb/provisional-en.html):**
	* Fix - GC Subway - Fix "active" status on a sublist item that is currently viewed
	* Chat wizard - Fix special characters in French invisible text
	* GC Subway - Multiple small fixes (e.g.prevent blinking)
	* Checkbox & Radio - Offer larger checkboxes and radio-buttons
	* Subway map menu - Have a subway map navigation menu for service initiation template, along with double H1s
	* H1 bold underline - H1 underlined by a short bold red line
	* Chat wizard - Improve "Reset" and "Minimize" button invisible text for screen readers

### Modified files for implementation
* GCWeb/js/theme.js
* GCWeb/js/theme.min.js
* GCWeb/css/theme.css
* GCWeb/css/theme.min.css

## Details
Compiles with: [WET-BOEW v4.0.39](https://github.com/wet-boew/wet-boew/releases/tag/v4.0.39)

[List of commits](https://github.com/wet-boew/gcweb/commits/v8.1.0)

### Browsers supported (as described in [Design decision 2](https://wet-boew.github.io/wet-boew-documentation/decision/2.html))
* Chrome 85
* Chrome 84
* Firefox 80
* Firefox 79
* Firefox ESR - 68.12
* Safari 13.1.2
* Edge 85.0.564.51

## Subresource integrity ([SRI](https://www.w3.org/TR/SRI/))
GCWeb/js/theme.min.js: `Coming soon...`

------------

Ceci est un **déploiement MINEUR** (sans changement non rétrocompatible) :

## Quoi de neuf?
Les items suivants liste tous les "Quoi de neuf?" depuis le dernier déploiement régulier (non-DCT) qui était v8.0.

* **Gabarit :**
	* En-tête - Retirer les conditionnels d'Internet Explorer qui ne sont plus supportés
* **Styles et plugiciels :**
	* Mineur - JSON Manager - Rendre le plugiciel utilisable sans extraire un fichier JSON
	* Action Manager - Ajoujer BOM au fichier UTF-8 pour corriger l'encodage des caractères lors de l'exportation au CSV
* **[Provisoire](https://wet-boew.github.io/themes-dist/GCWeb/provisional-fr.html) :**
	* Assistant par discussion - Corriger caractères spéciaux dans le texte invisible en français
	* GC Subway - Multiples petits changements (ex:enlever le clignotement)
	* Assistant par discussion - Améliorer le texte invisible des boutons "Recommencer" et "Réduire" pour les lecteurs d'écrans
	* Case à cocher et radio - Offrir des cases à cocher et boutons radios plus gros
	* Menu carte métro - Avoir un menu de navigation en carte de métro pour les Gabarit de services avancés, avec deux titres H1
	* Souligné H1 en gras - H1 souligné par une courte ligne rouge en gras

### Fichiers modifiés pour implémentation
* GCWeb/js/theme.js
* GCWeb/js/theme.min.js
* GCWeb/css/theme.css
* GCWeb/css/theme.min.css

## Détails
Compile avec : [WET-BOEW v4.0.39](https://github.com/wet-boew/wet-boew/releases/tag/v4.0.39)

[Liste des contributions](https://github.com/wet-boew/gcweb/commits/v8.1.0)

### Fureteurs supportés (Tel que défini par la [Décision de conception 2](https://wet-boew.github.io/wet-boew-documentation/decision/2.html))
* Chrome 85
* Chrome 84
* Firefox 80
* Firefox 79
* Firefox ESR - 68.12
* Safari 13.1.2
* Edge 85.0.564.51

## Intégrité des sous-ressources ([SRI](https://www.w3.org/TR/SRI/))
GCWeb/js/theme.min.js: `À venir...`