### PR TITLE
GC subway: Add noscript support

### DIFF
--- a/src/plugins/gc-subway/_screen-md-min.scss
+++ b/src/plugins/gc-subway/_screen-md-min.scss
@@ -13,13 +13,9 @@
 	&.gc-subway {
 		border-right: 0px;
 		border-top: 0px;
-		display: none;
 		margin-top: 25px;
 		padding-left: 15px;
 
-		&.no-blink {
-			display: block;
-		}
 		.gc-subway-menu-nav {
 			float: right;
 			width: 33.33%;
@@ -49,6 +45,16 @@
 	}
 }
 
-.wb-disable .provisional.gc-subway {
-	display: block;
+.js {
+	&:not(.wb-disable) {
+		.provisional {
+			&.gc-subway {
+				display: none;
+
+				&.no-blink {
+					display: block;
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
The subway menu previously didn't appear at all when JavaScript was disabled.

This addresses it by only hiding the menu if the "js" class is detected and if the page isn't in basic HTML mode. The menu is subsequently shown once the "no-blink" class is injected.

It should be noted that this method can cause a quick flash of the pre-JS subway since it depends on a JS-injected class.

Couldn't come up with a better solution due to the following:
* Unlike WET, GCWeb lacks its own noscript file. Adding one would necessitate HTML markup changes to all page templates...
* The scripting CSS media query can be used to achieve the same purpose, but no browsers currently support it.

CC @delisma