### PR TITLE
JIRA ticket WET-143 (Panel headings are smaller than actual content inside its body)

### DIFF
--- a/src/components/_base.scss
+++ b/src/components/_base.scss
@@ -62,3 +62,10 @@ button {
 .well.header-rwd {
 	width: 100%;
 }
+
+/*
+* Panel title
+*/
+.panel-title {
+	font-size: 1.2em;
+}


### PR DESCRIPTION
Panel headings are smaller than actual content inside its body

Closes https://github.com/wet-boew/GCWeb/issues/1726