### PR TITLE
Mobile center - Prevent Close link to appear on table nav next

### DIFF
--- a/src/mobile-centre/_base.scss
+++ b/src/mobile-centre/_base.scss
@@ -86,7 +86,6 @@
 				&:hover {
 					background-color: darken(#f5f5f5, 5%);
 					border-color: darken(#e3e3e3, 5%);
-					cursor: pointer;
 				}
 
 			}
@@ -264,17 +263,19 @@
 		float: right;
 	}
 
-	:target {
-		.record-close {
-			@extend %data-visible-block;
-		}
+	table {
+		:target {
+			.record-close {
+				@extend %data-visible-block;
+			}
 
-		.product-data-compressed {
-			@extend %data-hidden;
-		}
+			.product-data-compressed {
+				@extend %data-hidden;
+			}
 
-		.product-data-expanded {
-			@extend %data-visible-block;
+			.product-data-expanded {
+				@extend %data-visible-block;
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to WET-115

Prevent the "X close" link to appear beside each individual block when a user navigate with the table multi-page navigation.

To reproduce: 
1. Go in the mobile center page,
2. Click on "Next" underneath the table (in the table navigation)
3. The "X Close" link appear beside each block.

Expected
* There is no "X Close" that appear on step 3
