### PR TITLE
WET-140 Spacing Problem Fixed

### DIFF
--- a/src/components/_alert.scss
+++ b/src/components/_alert.scss
@@ -51,10 +51,6 @@
 			margin-top: auto;
 			padding-top: 15px;
 		}
-
-		:last-child {
-			padding-bottom: 25px;
-		}
 	}
 
 	&::before {


### PR DESCRIPTION
As discussed from https://github.com/wet-boew/wet-boew/pull/9018#pullrequestreview-568498021,

The last "p" tag has to have the same bottom spacing as the top spacing of the first "p".
Since the first "p" has neither margin/padding-top or margin/padding-bottom, I just got rid of the last child selector.