### PR TITLE
Topic template - Test case 1 - Alternative template when right column is higher

### DIFF
--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -130,6 +130,15 @@
 			<td>v1.4</td>
 		</tr>
 		<tr>
+			<td><a href="topic-testcase-1-en.html">Topic page, test case 1</a></td>
+			<td><time>2021-01-22</time></td>
+			<td>Templates</td>
+			<td>Special test case of a topic pages where the service and information section take less heigh space compared to most request and contributor section on the right column.</td>
+			<td><span class="label label-info">Need to revalidate</span></td>
+			<td><a href="https://design.canada.ca/mandatory-templates/topic-pages.html">C&amp;IA</a></td>
+			<td>v2.0</td>
+		</tr>
+		<tr>
 			<td><a href="dept-en.html">Departments and agencies page</a></td>
 			<td><time>2017-11-30</time></td>
 			<td>Templates</td>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -122,13 +122,22 @@
 			<td>v1.4</td>
 		</tr>
 		<tr>
-			<td><a href="">Page de sujet</a></td>
+			<td><a href=""topic-fr.html>Page de sujet</a></td>
 			<td><time>2017-12-05</time></td>
 			<td>Modèles</td>
 			<td>Aident une personne à savoir tout ce que fait le gouvernement du Canada dans un domaine précis lié au sujet</td>
 			<td><span class="label label-info">Revalidation requise</span></td>
 			<td><a href="https://conception.canada.ca/modeles-obligatoire/page-sujet.html">C&amp;AI</a></td>
 			<td>v1.4</td>
+		</tr>
+		<tr>
+			<td><a href="topic-testcase-1-fr.html">Page de sujet, cas d'essaie 1</a></td>
+			<td><time>2021-01-22</time></td>
+			<td>Modèles</td>
+			<td>Cas d'essaie spécial de la page de sujet lorsque la hauteur du contenu pour la section service et renseignements est plus petite que la section en demande et collaborateurs dans la colonne de droite.</td>
+			<td><span class="label label-info">Revalidation requise</span></td>
+			<td><a href="https://conception.canada.ca/modeles-obligatoire/page-sujet.html">C&amp;AI</a></td>
+			<td>v2.0</td>
 		</tr>
 		<tr>
 			<td><a href="">Page des ministères et organismes</a></td>

--- a/site/pages/topic-testcase-1-en.hbs
+++ b/site/pages/topic-testcase-1-en.hbs
@@ -1,0 +1,60 @@
+---
+{
+	"title": "[Topic title, test case 1]",
+	"language": "en",
+	"altLangPrefix": "topic-testcase-1",
+	"pageType": "topic",
+	"pageclass": "page-type-nav",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+		{ "title": "[Theme Name]", "link": "theme-testcase-1-en.html" }
+	],
+	"dateModified": "2021-01-22",
+	"share": "true",
+	"deptfeature": true
+}
+---
+<div class="row profile">
+	<div class="col-md-6">
+		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<p>1-2 sentences that describe the topics and top tasks that can be accessed on this page.</p>
+		{{>follow}}
+	</div>
+	<div class="col-md-6 mrgn-tp-sm hidden-sm hidden-xs">
+		<img src="{{assets}}/img/520x200.png" alt="" class="pull-right img-responsive thumbnail"/>
+	</div>
+</div>
+<div class="row">
+	<section class="gc-srvinfo col-md-8">
+		<h2>Services and information</h2>
+		<div class="wb-eqht row">
+			<div class="col-md-6">
+				<h3><a href="#">[Subtopic hyperlink text]</a></h3>
+				<p>Summary of the information or tasks that can be accomplished on the sub-topic page. Remove prose or promotional messaging. Use action verbs.</p>
+			</div>
+			<div class="col-md-6">
+				<h3><a href="#">[Subtopic hyperlink text]</a></h3>
+				<p>Summary of the information or tasks that can be accomplished on the sub-topic page. Remove prose or promotional messaging. Use action verbs.</p>
+			</div>
+		</div>
+	</section>
+	<div class="col-xs-12 col-md-4">
+		{{>most-requested}}
+		{{>supported-by}}
+		{{>more-info}}
+	</div>
+</div>
+<section class="whtwedo">
+	<h2>What we are doing</h2>
+	<div class="row wb-eqht">
+		<section class="col-lg-4 col-md-6">
+			{{>research}}
+		</section>
+		<section class="col-lg-4 col-md-6">
+			{{>surveys}}
+		</section>
+		<section class="col-lg-4 col-md-6">
+			{{>consultations}}
+		</section>
+	</div>
+</section>

--- a/site/pages/topic-testcase-1-fr.hbs
+++ b/site/pages/topic-testcase-1-fr.hbs
@@ -1,0 +1,60 @@
+---
+{
+	"title": "[Titre du sujet, cas d'essaie 1]",
+	"language": "fr",
+	"altLangPrefix": "topic-testcase-1",
+	"pageType": "topic",
+	"pageclass": "page-type-nav",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+		{ "title": "[Thème]", "link": "theme-testcase-1-fr.html" }
+	],
+	"dateModified": "2021-01-22",
+	"share": "true",
+	"deptfeature": true
+}
+---
+<div class="row profile">
+	<div class="col-md-6">
+		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<p>1 ou 2 phrases d’introduction qui définissent les sous-sujets et les tâches principales qui peuvent être consultés sur cette page.</p>
+		{{>follow}}
+	</div>
+	<div class="col-md-6 mrgn-tp-sm hidden-sm hidden-xs">
+		<img src="{{assets}}/img/520x200.png" alt="" class="pull-right img-responsive thumbnail"/>
+	</div>
+</div>
+<div class="row">
+	<section class="gc-srvinfo col-md-8">
+		<h2>Services et renseignements</h2>
+		<div class="wb-eqht row">
+			<div class="col-md-6">
+				<h3><a href="#">[Lien à un sous-sujet]</a></h3>
+				<p>Résumé des renseignements disponibles ou des tâches pouvant être accomplies sur la page. Supprimez les longs libellés et les messages promotionnels. Utilisez une formulation basée sur l'action.</p>
+			</div>
+			<div class="col-md-6">
+				<h3><a href="#">[Lien à un sous-sujet]</a></h3>
+				<p>Résumé des renseignements disponibles ou des tâches pouvant être accomplies sur la page. Supprimez les longs libellés et les messages promotionnels. Utilisez une formulation basée sur l'action.</p>
+			</div>
+		</div>
+	</section>
+	<div class="col-xs-12 col-md-4">
+		{{>most-requested}}
+		{{>supported-by}}
+		{{>more-info}}
+	</div>
+</div>
+<section class="whtwedo">
+	<h2>Ce que nous faisons</h2>
+	<div class="row wb-eqht">
+		<section class="col-lg-4 col-md-6">
+			{{>research}}
+		</section>
+		<section class="col-lg-4 col-md-6">
+			{{>surveys}}
+		</section>
+		<section class="col-lg-4 col-md-6">
+			{{>consultations}}
+		</section>
+	</div>
+</section>


### PR DESCRIPTION
This alternative template avoid to have the "contributor" section to float in the middle of the page when there is not a lot of doormat link in the service and information section.

The fix is to remove the floating CSS class (pull-right, pull-left) and to move the "Most requested" section after the "Service and information" section. 

PP reference number: WET-155

@delisma can you ask if DTO are ok with that change for this special edge case?