### PR TITLE
Theme: Improve h1-h6 font size declarations

### DIFF
--- a/components/baseline/_base.scss
+++ b/components/baseline/_base.scss
@@ -78,7 +78,7 @@ h1.gc-thickline {
 * Panel title
 */
 .panel-title {
-	font-size: $h3-size;
+	font-size: $font-size-h3;
 }
 
 /*

--- a/components/gc-follow-us/_base.scss
+++ b/components/gc-follow-us/_base.scss
@@ -81,7 +81,7 @@ $provisional-social-media-icons-size: 38px;
 
 	&.gc-followus {
 		h2 {
-			font-size: $h4-size;
+			font-size: $font-size-h4;
 		}
 
 		ul {

--- a/misc/views/_screen-sm-max.scss
+++ b/misc/views/_screen-sm-max.scss
@@ -8,7 +8,7 @@
 h1,
 .h1 {
 	font-size: 1.7em; // expected 34px;
-	margin-top: .75em; // expected ~15px;
+	margin-top: .75em; // expected ~26px;
 }
 
 h2,

--- a/sites/_defaults.scss
+++ b/sites/_defaults.scss
@@ -106,7 +106,7 @@ h1 {
 
 	// Overwride sizing
 	h3, h4, h5, h6 {
-		font-size: $h5-size;
+		font-size: $font-size-h5;
 		margin-bottom: 5px;
 		margin-top: 23px; // same as h5
 	}
@@ -559,33 +559,7 @@ a.figcaption {
 }
 
 // Heading font-sizes
-h1,
-.h1 {
-	font-size: $h1-size;
-}
-
-h2,
-.h2 {
-	font-size: $h2-size;
-}
-
-h3,
-.h3 {
-	font-size: $h3-size;
-}
-
-h4,
-.h4 {
-	font-size: $h4-size;
-}
-
-h5,
-.h5 {
-	font-size: $h5-size;
-}
-
 h6,
 .h6 {
-	font-size: $h6-size;
 	font-weight: 400;
 }

--- a/sites/_variables.scss
+++ b/sites/_variables.scss
@@ -30,12 +30,12 @@ $padding-base-vertical: 10px;
 $padding-base-horizontal: 14px;
 
 /* Headings font-sizes */
-$h1-size: 1.9em; // expected 38px;
-$h2-size: 1.8em; // expected 36px;
-$h3-size: 1.2em; // expected 24px;
-$h4-size: 1.1em; // expected 22px;
-$h5-size: 1em; // expected 20px;
-$h6-size: .95em; // expected 19px;
+$font-size-h1: 1.9em; // expected 38px;
+$font-size-h2: 1.8em; // expected 36px;
+$font-size-h3: 1.2em; // expected 24px;
+$font-size-h4: 1.1em; // expected 22px;
+$font-size-h5: 1em; // expected 20px;
+$font-size-h6: .95em; // expected 19px;
 
 /* Small font-size */
 $small-size: 87%;


### PR DESCRIPTION
* Replaces GCWeb's heading font size variables (``$h#-size``) with overrides for Bootstrap's ones (``$font-size-h#``)
* Removes redundant SCSS selectors (Bootstrap already has them)
* Corrects estimated pixel size comment for the H1 heading's top margin in small view and under (from ~15px to ~26px)