### PR TITLE
On social media (.gc-followus): Reduce line height

### DIFF
--- a/src/social-media-icons/_base.scss
+++ b/src/social-media-icons/_base.scss
@@ -64,6 +64,8 @@
 	background-image:  url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACEAAAAWCAYAAABOm/V6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gQVECMqfCsMgwAAAshJREFUSMfF1s9P02AYwPFvyxwbHRuMrYOVVgS2BRNBDfHqxXDxz/Bq4sH/QA+e/B8MR+9e/QcUMk0IMBRho4R1g7LRbmPA6mFuqLAxfj9Jk6bv276fPHnep6+QnJ3xAq+Bl0CEm41PwBsX8AJ4y+3Ec2DYBbwCCClj7O1k6Q3KRO5OXNuqlVKRjVQSr6+PXSMDMCUCIwCylkCJTWHt5smuLV4LYL9ssZFK4g9GUMYnm8/Fvyd5fX1Exx7UIetXC6mWbTLLc/gHBpG1+D9jIuDUb51jyPgklpknu750NYBKifTSVwKhKOHhGCCcQJwIry+AEptizzQw0suXByx+oS+sEFLGEQThxByx1cseyc9w/BHFnSy5zAqO41wYEAgrDERHTwW0RQB4enpRE48pbG+S13/iOLVz1UADEIqOIoitlxLP+li314eWmKaQ09nWV3FqZ0P2Sxbp5TkC4SghZawtoCMEgNsroU1Ms5vTyW+uts1IpVQkk5rHHxxsWQMXQgC4PXVIIaeT11dPrZGKXUBPJekNRpC1eEeAcyGqlRJGOoUUCFHI6+QyKWpHh81xu7CNvvKd7h4fFbuImc10XD+uzgA2RjqFRwoQUkbZL9ts/vjG4UGVbq+PWu0Qy8zROxBBVuNU7CJGJgVAf0S9fCb+B9SLVUK7/wTXHTd2cYdq2SasxpDVeHN7y2qcPdNo/B8unoljgL8JaERXlwtZS9Cuz8hqrN5jgH5ZPX8mGjXgkfwMREcv1C09kp+wGsPaaZ8R8biRH1fywX4ZI71cBwzd67jKW2ZES7BnGpgtICJQBZpN6KBaIbu+hEfyExwaObPRdBLdPT5kLYFlGqfuGhGYB9haW+Do8ICtXwt1wKCGIAg4Tu1KLrenh7AaxzKzZNcWsXZzDUNJSM7OPPtz1nPf0hHvowv4DDwF3gEPAekGFnaADPABeP8bNrJaPIc3C6EAAAAASUVORK5CYII=")
 }
 
+$provisional-social-media-li-margin-bottom: 15px;
+$provisional-social-media-icons-vertical-offset: 6px;
 $provisional-social-media-icons-size: 38px;
 
 %provisional-social-media-icons-followus-logo-properties {
@@ -72,6 +74,7 @@ $provisional-social-media-icons-size: 38px;
 	content: "";
 	height: $provisional-social-media-icons-size;
 	margin-right: 10px;
+	margin-top: -$provisional-social-media-icons-vertical-offset;
 	min-width: $provisional-social-media-icons-size;
 }
 
@@ -87,15 +90,19 @@ $provisional-social-media-icons-size: 38px;
 			font-size: $small-size;
 			font-weight: $bold-weight;
 			list-style: none;
-			margin-block-start: 1em;
+			margin-block-start: calc(1em + #{$provisional-social-media-icons-vertical-offset});
 			padding-inline-start: 1em;
 
 			li {
-				margin-bottom: 15px;
+				margin-bottom: ($provisional-social-media-li-margin-bottom + $provisional-social-media-icons-vertical-offset);
+
+				&:last-child {
+					margin-bottom: $provisional-social-media-li-margin-bottom;
+				}
 
 				a {
 					display: flex;
-					line-height: $provisional-social-media-icons-size;
+					line-height: 1.54;
 					max-width: max-content;
 					text-decoration: none;
 


### PR DESCRIPTION
Previously, when a long social media channel name was placed into one of this component's list items, it'd split across multiple lines. But its line height would create an excessive amount of space between each line.

This addresses it by reducing the line height and by using another means of making single-line text look vertically-centered compared to the social media icons.

**Screenshots...**

**Before:**
![gc-followus-before](https://user-images.githubusercontent.com/1907279/107537960-78707d00-6b91-11eb-8389-d10aec9b871a.png)

**After v1 (outdated - YouTube link's lines are noticeably closer together):**
![gc-followus-after](https://user-images.githubusercontent.com/1907279/107537972-7a3a4080-6b91-11eb-8ffb-d9fbfa32d210.png)

**After v2 (YouTube link's lines are even closer together):**
![gc-followus-after-v2](https://user-images.githubusercontent.com/1907279/107675542-306f5a00-6c66-11eb-9760-4b28cb8c5f26.png)

CC @delisma @luc-bertrand-hrsdc @GormFrank