### PR TITLE
fix: Update bold weight to 700

### DIFF
--- a/sites/_defaults.scss
+++ b/sites/_defaults.scss
@@ -312,7 +312,7 @@ aside {
 		li {
 			@extend %defaults-alternative-font-family;
 			font-size: 17px;
-			font-weight: 600;
+			font-weight: $bold-weight;
 			line-height: 26px;
 			margin-top: 0px;
 		}

--- a/sites/_variables.scss
+++ b/sites/_variables.scss
@@ -41,7 +41,7 @@ $h6-size: .95em; // expected 19px;
 $small-size: 87%;
 
 /* Bold weight */
-$bold-weight: 600;
+$bold-weight: 700;
 
 //Breadcrumb
 $breadcrumb-bg: transparent; // Inner background colour (Bootstrap override).

--- a/sites/gcweb-menu/_base.scss
+++ b/sites/gcweb-menu/_base.scss
@@ -170,7 +170,7 @@
 	/* First menu item (represent the home link */
 	[role=menu] [role=menu] li:first-child [role=menuitem] {
 		font-size: 32px;
-		font-weight: 600;
+		font-weight: $bold-weight;
 		text-decoration: underline;
 	}
 	/* Undo for lower level */

--- a/sites/gcweb-menu/_screen-md-min.scss
+++ b/sites/gcweb-menu/_screen-md-min.scss
@@ -13,7 +13,7 @@
 	[role=menu] [role=menu] [role=menuitem][aria-haspopup=true]:hover {
 		color: #000;
 		font-size: 20px;
-		font-weight: 600;
+		font-weight: $bold-weight;
 		text-decoration: none;
 	}
 

--- a/templates/_search.scss
+++ b/templates/_search.scss
@@ -37,7 +37,7 @@
 			background-color: #5e738b;
 			color:#fff;
 			display: inline-block;
-			font-weight: 600;
+			font-weight: $bold-weight;
 			margin-bottom: 1px;
 			padding: 0 5px;
 		}

--- a/templates/search/api.html
+++ b/templates/search/api.html
@@ -149,7 +149,7 @@
 
 <p>Notes:</p>
 <ul>
-	<li>CSS is used to put the "see result from:" label in bold. The label is after the input to use CSS like "[checked] + label { font-weight: 600 }"</li>
+	<li>CSS is used to put the "see result from:" label in bold. The label is after the input to use CSS like "[checked] + label { font-weight: 700 }"</li>
 	<li>The server would add the attribute "checked" to the proper selected radio</li>
 	<li>should only be used for contextual search results from a single institution</li>
 	<li>until radio buttons pattern works, please simply include 'All government of Canada websites' link in the well, under the search box</li>


### PR DESCRIPTION
---
name: Bold weight match
about: Update bold weight to match the font import
title: 'fix: Update _default.scss'
labels: ''
assignees: ''
---

## What does this pull request do?
This request fix an implementation issue with the bold weight. The bold weight was set to 600 but the font import only has 400 and 700 weight. Even if browsers tend to fallback to the 700 weight, we want to avoid unexpected behaviour and/or side effects.

## General checklist

- [x] [Documentation](README.md) created/updated
- [x] Changelog entry added, if necessary