### PR TITLE
Multimedia player: Increase CC container's height

### DIFF
--- a/components/baseline/wet-boew-overrides.scss
+++ b/components/baseline/wet-boew-overrides.scss
@@ -9,11 +9,24 @@
 .wb-mltmd {
 	margin-bottom: 10px;
 	margin-top: 10px;
+
+	&.cc_on {
+		.wb-mm-cc {
+			height: calc(#{1.65 * $mm-cc-lines}em + #{$mm-cc-padding * 2});
+		}
+	}
 }
 
 .wb-mltmd.video:not(.playing):not(.waiting)
 .display::after {
 	line-height: 1.5em;
+}
+
+.wb-mm-cc {
+	&:before,
+	div {
+		height: #{1.65 * $mm-cc-lines}em;
+	}
 }
 
 .wb-mm-ctrls .wb-mm-txtonly p {


### PR DESCRIPTION
Prevents closed captions that contain 2 lines of text from causing the CC container's height to shift during playback (due to GCWeb's taller line height).

The shifting can be distracting when the captions update (i.e. switching between no captions, 1 line captions and 2 line captions).

Depends on wet-boew/wet-boew#9082.

**Screenshots...**

**Before** (CC container height: hardcoded 3em + 1em for padding):
![gcweb-multimedia-cc-container-before](https://user-images.githubusercontent.com/1907279/114908346-0400c700-9dea-11eb-82eb-8e358f292c8d.png)

**After** (CC container height: calculated 3.3em + 1em for padding):
![gcweb-multimedia-cc-container-after](https://user-images.githubusercontent.com/1907279/114908355-05ca8a80-9dea-11eb-8599-56df0bfc3d69.png)