### PR TITLE
Doc: Remove visible markdown on home & fix grammar on provisional alert

### DIFF
--- a/_includes/alert-provisional.html
+++ b/_includes/alert-provisional.html
@@ -1,15 +1,15 @@
 {%- if page.language == "fr" -%}
 <div class="alert alert-warning">
-	<h2>Fonctionalité instable</h2>
-	<p>À être utilisé <strong>à vos propre risque</strong>. Toute les fonctionalité décris ci-dessous peut être retiré dans n'importe lequel version mineur/majeur et l'ensemble de ces fonctionalité sont exclus de l'API publique.</p>
-	<p>La documentation et/ou les examples pratique pourait être incomplete ou être non disponible.</p>
-	<p><a href="{{ include.siteroot }}provisional-fr.html">Voir l'ensemble des fonctionalités provisoires.</a></p>
+	<h2>Fonctionnalité instable</h2>
+	<p>À être utilisé <strong>à vos propres risques</strong>. Toutes les fonctionnalités décrites ci-dessous pourraient être retirées à n'importe quelle version mineur/majeur ultérieure et l'ensemble des fonctionnalités provisoires sont exclues de l'API publique de GCWeb.</p>
+	<p>La documentation et/ou les exemples pratiques pourraient être incomplets ou être non disponible.</p>
+	<p><a href="{{ include.siteroot }}provisional-fr.html">Voir l'ensemble des fonctionnalités provisoires.</a></p>
 </div>
 {%- elsif page.language == "en" -%}
 <div class="alert alert-warning">
 	<h2>Unstable feature</h2>
-	<p>To be used at <strong>your own risk</strong>. All functionality described bellow can be removed in any subsequent minor/major release and are excluded from the gcweb public API.</p>
-	<p>The documentation and/or a working example for those feature could be incomplete or not available.</p>
-	<p><a href="{{ include.siteroot }}provisional-en.html">Views all the provisional feature.</a></p>
+	<p>To be used at <strong>your own risks</strong>. All functionalities described below could be removed in any subsequent minor/major release and are excluded from the GCWeb public API.</p>
+	<p>Documentation and/or working examples for those features could be incomplete or not available.</p>
+	<p><a href="{{ include.siteroot }}provisional-en.html">See all provisional features.</a></p>
 </div>
 {%- endif -%}

--- a/accueil.md
+++ b/accueil.md
@@ -160,7 +160,7 @@ Les états suivant n'ont été transposé encore avec la réorganisation de la s
 
 <h2>Aperçu des fonctionnalités wet-boew avec le thème de Canada.ca</h2>
 <p><a href="/gcweb-compiled-demos/index.html#wet-boew">Aperçu des fonctionnalités wet-boew</a></p>
-
+{:/}
 
 ## Documentation du projet GCWeb
 

--- a/home.md
+++ b/home.md
@@ -161,6 +161,7 @@ The following status was not transposed yet with the repository structure reorg
 
 <h2>WET-BOEW feature demos styled with Canada.ca theme</h2>
 <p><a href="/gcweb-compiled-demos/index.html#wet-boew">WET-BOEW feature overview</a></p>
+{:/}
 
 ## GCWeb project documentation
 


### PR DESCRIPTION
Very minor changes. This is just content related. No impact on the API.

1. We could see `{::nomarkdown}` render on GCWeb's home page.
2. There were some grammar errors in the provisional alert banner.