### PR TITLE
GC tables: Left-align column labels

### DIFF
--- a/components/gc-table/_screen-sm-max.scss
+++ b/components/gc-table/_screen-sm-max.scss
@@ -45,6 +45,7 @@
 				content: attr(data-label);
 				float: left;
 				font-weight: bold;
+				text-align: left;
 			}
 			&:last-child {
 				border-bottom: 0;


### PR DESCRIPTION
This component normally right-aligns data cells and floats their column labels to the left. That's fine for column labels that can fit on a single line. But ones that span across multiple lines end up becoming right-aligned - which looks really strange.

This resolves it by explicitly aligning column label text to the left.

**Screenshots...**

**Before:**
![gc-tables-label-alignment-before](https://user-images.githubusercontent.com/1907279/120814000-705f9300-c51c-11eb-88fa-a78b359a1a82.png)

**After:**
![gc-tables-label-alignment-after](https://user-images.githubusercontent.com/1907279/120814010-72295680-c51c-11eb-8f1b-17ca144145db.png)
