### PR TITLE
GC tables: Support the "table-bordered" class

### DIFF
--- a/components/gc-table/_screen-sm-max.scss
+++ b/components/gc-table/_screen-sm-max.scss
@@ -4,6 +4,29 @@
 
 .provisional {
 	&.gc-table {
+		&.table-bordered {
+			border: 0;
+			> {
+				thead,
+				tbody,
+				tfoot {
+					> {
+						tr {
+							> {
+								th,
+								td {
+									border: {
+										bottom: 0;
+										left: 0;
+										right: 0;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 		.text-left {
 			clear: both;
 			display: block;

--- a/components/gc-table/gc-table-en.html
+++ b/components/gc-table/gc-table-en.html
@@ -5,7 +5,7 @@
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" },
 		{ "title": "Provisional functionality", "link": "https://wet-boew.github.io/themes-dist/GCWeb/provisional-en.html" }
 	],
-	"dateModified": "2020-10-16",
+	"dateModified": "2021-06-16",
 	"description": "Simple responsive gc tables",
 	"language": "en",
 	"title": "GC tables"
@@ -20,7 +20,7 @@
 	<dt>Type</dt>
 	<dd>Canada.ca design pattern</dd>
 	<dt>Last review</dt>
-	<dd>2021-02-01</dd>
+	<dd>{{ page.dateModified }}</dd>
 	<dt>Conforming to</dt>
 	<dd>Content and IA spec 2.1</dd>
 	<dt>Guidance</dt>
@@ -181,6 +181,39 @@
 			<td data-label="Strength">300 mg</td>
 			<td data-label="Lot">All lots</td>
 			<td data-label="Date added">September 25, 2019</td>
+		</tr>
+	</tbody>
+</table>
+
+<h3>Responsive cards with <code>table-bordered</code> class for table borders</h3>
+<p><span class="label label-info">Optional</span></p>
+
+<p>The class <code>table-bordered</code> can be added to the <code>&lt;table&gt;</code> to add borders to the table in medium view and over.</p>
+
+<table class="provisional gc-table table table-bordered" id="myTable4">
+	<caption>Common web browsers</caption>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Engine</th>
+			<th>Developer</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-label="Name">Chrome</td>
+			<td data-label="Engine">Blink</td>
+			<td data-label="Developer">Google</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Firefox</td>
+			<td data-label="Engine">Gecko</td>
+			<td data-label="Developer">Mozilla</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Safari</td>
+			<td data-label="Engine">WebKit</td>
+			<td data-label="Developer">Apple</td>
 		</tr>
 	</tbody>
 </table>

--- a/components/gc-table/gc-table-fr.html
+++ b/components/gc-table/gc-table-fr.html
@@ -5,7 +5,7 @@
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" },
 		{ "title": "Provisional functionality", "link": "https://wet-boew.github.io/themes-dist/GCWeb/provisional-fr.html" }
 	],
-	"dateModified": "2020-10-16",
+	"dateModified": "2021-06-16",
 	"description": "Tableau simple responsive pour le GC",
 	"language": "fr",
 	"title": "Tableaux GC"
@@ -20,7 +20,7 @@
 	<dt>Type</dt>
 	<dd>Système de conception de Canada.ca</dd>
 	<dt>Dernière revue</dt>
-	<dd>2021-02-01</dd>
+	<dd>{{ page.dateModified }}</dd>
 	<dt>Est conforme à</dt>
 	<dd>Spécifications du contenu et de l'architecture de l'information 2.1</dd>
 	<dt>Spécification</dt>
@@ -183,6 +183,39 @@
 			<td data-label="Strength">300 mg</td>
 			<td data-label="Lot">All lots</td>
 			<td data-label="Date added">September 25, 2019</td>
+		</tr>
+	</tbody>
+</table>
+
+<h3>Responsive cards with <code>table-bordered</code> class for table borders</h3>
+<p><span class="label label-info">Optional</span></p>
+
+<p>The class <code>table-bordered</code> can be added to the <code>&lt;table&gt;</code> to add borders to the table in medium view and over.</p>
+
+<table class="provisional gc-table table table-bordered" id="myTable4">
+	<caption>Common web browsers</caption>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Engine</th>
+			<th>Developer</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-label="Name">Chrome</td>
+			<td data-label="Engine">Blink</td>
+			<td data-label="Developer">Google</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Firefox</td>
+			<td data-label="Engine">Gecko</td>
+			<td data-label="Developer">Mozilla</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Safari</td>
+			<td data-label="Engine">WebKit</td>
+			<td data-label="Developer">Apple</td>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
A double-border effect used to appear in small view and under when pairing GC tables alongside Bootstrap's "table-bordered" class.

This resolves it by disabling that class' extra borders when GC tables' styles are in effect. Also adds an example of that class in use.

**Screenshots...**

**Before:**
![gc-tables-table-bordered-before](https://user-images.githubusercontent.com/1907279/120857984-1f699200-c550-11eb-81ac-9b411d268969.png)

**After:**
![gc-tables-table-bordered-after](https://user-images.githubusercontent.com/1907279/120857990-20022880-c550-11eb-86b5-545ddd469068.png)
