### PR TITLE
GC tables: Add partial DataTables support

### DIFF
--- a/components/gc-table/_screen-sm-max.scss
+++ b/components/gc-table/_screen-sm-max.scss
@@ -27,6 +27,11 @@
 				}
 			}
 		}
+		&.dataTable {
+			&.no-footer {
+				border-bottom: 0;
+			}
+		}
 		.text-left {
 			clear: both;
 			display: block;

--- a/components/gc-table/gc-table-en.html
+++ b/components/gc-table/gc-table-en.html
@@ -217,3 +217,36 @@
 		</tr>
 	</tbody>
 </table>
+
+<h3>Responsive cards with ``wb-tables`` class for filterable tables</h3>
+<p><span class="label label-info">Optional</span></p>
+
+<p>The class <code>wb-tables</code> can be added to the <code>&lt;table&gt;</code> to make it use <a href="https://wet-boew.github.io/v4.0-ci/demos/tables/tables-en.html">WET's tables plugin</a>. Please note that scrollable and responsive WET tables are unsupported.</p>
+
+<table class="provisional gc-table table wb-tables" id="myTable5">
+	<caption>Immunization clinics</caption>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>City</th>
+			<th>Province</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-label="Name">Clinic 1</td>
+			<td data-label="City">Edmonton</td>
+			<td data-label="Province">Alberta</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Clinic 2</td>
+			<td data-label="City">Toronto</td>
+			<td data-label="Province">Ontario</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Clinic 3</td>
+			<td data-label="City">Montréal</td>
+			<td data-label="Province">Québec</td>
+		</tr>
+	</tbody>
+</table>

--- a/components/gc-table/gc-table-fr.html
+++ b/components/gc-table/gc-table-fr.html
@@ -219,4 +219,37 @@
 		</tr>
 	</tbody>
 </table>
+
+<h3>Responsive cards with ``wb-tables`` class for filterable tables</h3>
+<p><span class="label label-info">Optional</span></p>
+
+<p>The class <code>wb-tables</code> can be added to the <code>&lt;table&gt;</code> to make it use <a href="https://wet-boew.github.io/v4.0-ci/demos/tables/tables-en.html">WET's tables plugin</a>. Please note that scrollable and responsive WET tables are unsupported.</p>
+
+<table class="provisional gc-table table wb-tables" id="myTable5">
+	<caption>Immunization clinics</caption>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>City</th>
+			<th>Province</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-label="Name">Clinic 1</td>
+			<td data-label="City">Edmonton</td>
+			<td data-label="Province">Alberta</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Clinic 2</td>
+			<td data-label="City">Toronto</td>
+			<td data-label="Province">Ontario</td>
+		</tr>
+		<tr>
+			<td data-label="Name">Clinic 3</td>
+			<td data-label="City">Montréal</td>
+			<td data-label="Province">Québec</td>
+		</tr>
+	</tbody>
+</table>
 </div>


### PR DESCRIPTION
A bottom table border used to appear in small view and under when pairing GC tables alongside WET's tables (DataTables) plugin.

This removes that border when GC tables' styles are in effect. Also adds an DataTables example.

**Note:**
I also wanted to make GC tables disable datatables' optional scrolling features, but was unable to since its scrolling container is situated outside the table.

**Screenshots...**

**Before:**
![gc-tables-datatables-before](https://user-images.githubusercontent.com/1907279/120863824-42e50a80-c559-11eb-9277-7c798f8141f0.png)

**After:**
![gc-tables-datatables-after](https://user-images.githubusercontent.com/1907279/120863827-44aece00-c559-11eb-8588-08e867f55a34.png)


**PS:**
This will need to be rebased after #1841 gets merged.