### PR TITLE
GC tables: Remove last row's bottom margin

### DIFF
--- a/components/gc-table/_screen-sm-max.scss
+++ b/components/gc-table/_screen-sm-max.scss
@@ -24,6 +24,17 @@
 			margin-bottom: .625em;
 			padding: .35em;
 		}
+		> {
+			:last-child {
+				> {
+					tr {
+						&:last-of-type {
+							margin-bottom: 0;
+						}
+					}
+				}
+			}
+		}
 		caption {
 			font-size: 1.1em;
 		}


### PR DESCRIPTION
This component's table rows use bottom margins to space-them out when they're presented like mini-tables. But that margin doesn't serve any purpose on the last row. Especially since the table itself already has its own 23px bottom margin that doesn't collapse with the row margins.

**Screenshots...**

Red is the last row's bottom margin, whereas yellow is the table's bottom margin.

**Before:**
![gc-tables-tr-last-of-type-bottom-margin-before](https://user-images.githubusercontent.com/1907279/120865432-0c5cbf00-c55c-11eb-9d0f-98348bb16365.png)

**After:**
![gc-tables-tr-last-of-type-bottom-margin-after](https://user-images.githubusercontent.com/1907279/120865434-0cf55580-c55c-11eb-9cb1-762700999f7a.png)