### PR TITLE
GC tables: Support adjacent tbodies

### DIFF
--- a/components/gc-table/_screen-sm-max.scss
+++ b/components/gc-table/_screen-sm-max.scss
@@ -2,6 +2,8 @@
  PROVISIONAL features: Responsive tables cards
 */
 
+$gc-tables-tr-margin-vertical: .625em;
+
 .provisional {
 	&.gc-table {
 		&.table-bordered {
@@ -49,7 +51,7 @@
 		tr {
 			border: 1px solid #ddd;
 			display: block;
-			margin-bottom: .625em;
+			margin-bottom: $gc-tables-tr-margin-vertical;
 			padding: .35em;
 		}
 		> {
@@ -75,6 +77,19 @@
 			padding: 0;
 			position: absolute;
 			width: 1px;
+		}
+		tbody {
+			+ {
+				tbody {
+					> {
+						tr {
+							&:first-of-type {
+								margin-top: $gc-tables-tr-margin-vertical;
+							}
+						}
+					}
+				}
+			}
 		}
 		td {
 			display: block;

--- a/components/gc-table/gc-table-en.html
+++ b/components/gc-table/gc-table-en.html
@@ -45,16 +45,16 @@
 
 <h3>Responsive cards</h3>
 <table class="provisional gc-table table" id="myTable1">
-		<caption>Population growth in Canadian cities</caption>
-		<thead>
+	<caption>Population growth in Canadian cities</caption>
+	<thead>
 		<tr>
 			<th>City</th>
 			<th>Population in 2007</th>
 			<th>Population in 2017</th>
 			<th>Percentage change</th>
 		</tr>
-		</thead>
-		<tbody>
+	</thead>
+	<tbody>
 		<tr>
 			<td data-label="City">Toronto</td>
 			<td data-label="Population in 2007">5,418,207</td>
@@ -67,6 +67,8 @@
 			<td data-label="Population in 2017">4,138,254</td>
 			<td data-label="Percentage change">11.4%</td>
 		</tr>
+	</tbody>
+	<tbody>
 		<tr>
 			<td data-label="City">Vancouver</td>
 			<td data-label="Population in 2007">2,218,134</td>
@@ -79,8 +81,8 @@
 			<td data-label="Population in 2017">1,377,016 </td>
 			<td data-label="Percentage change">15.9%</td>
 		</tr>
-		</tbody>
-	</table>
+	</tbody>
+</table>
 
 <h3>Responsive cards with text left on one item</h3>
 

--- a/components/gc-table/gc-table-fr.html
+++ b/components/gc-table/gc-table-fr.html
@@ -47,16 +47,16 @@
 
 <h3>Responsive cards</h3>
 <table class="provisional gc-table table" id="myTable1">
-		<caption>Population growth in Canadian cities</caption>
-		<thead>
+	<caption>Population growth in Canadian cities</caption>
+	<thead>
 		<tr>
 			<th>City</th>
 			<th>Population in 2007</th>
 			<th>Population in 2017</th>
 			<th>Percentage change</th>
 		</tr>
-		</thead>
-		<tbody>
+	</thead>
+	<tbody>
 		<tr>
 			<td data-label="City">Toronto</td>
 			<td data-label="Population in 2007">5,418,207</td>
@@ -69,6 +69,8 @@
 			<td data-label="Population in 2017">4,138,254</td>
 			<td data-label="Percentage change">11.4%</td>
 		</tr>
+	</tbody>
+	<tbody>
 		<tr>
 			<td data-label="City">Vancouver</td>
 			<td data-label="Population in 2007">2,218,134</td>
@@ -81,8 +83,8 @@
 			<td data-label="Population in 2017">1,377,016 </td>
 			<td data-label="Percentage change">15.9%</td>
 		</tr>
-		</tbody>
-	</table>
+	</tbody>
+</table>
 
 <h3>Responsive cards with text left on one item</h3>
 


### PR DESCRIPTION
Bootstrap's "tables" class adds a 2px border between adjacent ``tbody`` elements.

But it looked out of place in GC tables. That component adds a bottom margin to every row... which caused the adjacent ``tbody``'s top border to look like it was "sticking" to its first row.

This resolves it by adding a top margin to the adjacent ``tbody``'s first row to prevent the sticking. That allows the top border to look like a real separator. Also adds a second ``tbody`` to the first GC tables example.

Spinoff of #1843.

**Screenshots...**

**Before:**
![gc-tables-tbody-adjacent-before](https://user-images.githubusercontent.com/1907279/121228409-b7ba8c00-c85a-11eb-8a49-7381ef689461.png)

**After:**
![gc-tables-tbody-adjacent-after](https://user-images.githubusercontent.com/1907279/121228414-b8ebb900-c85a-11eb-8b09-42f2164f6239.png)

CC @jmealing @delisma @duboisp