### PR TITLE
alerts: fix the alert icon when applied with text-center class 

### DIFF
--- a/components/baseline/_alert.scss
+++ b/components/baseline/_alert.scss
@@ -58,6 +58,7 @@
 	}
 
 	&::before {
+		display: flex;
 		font-family: "Glyphicons Halflings";
 		font-size: 26px;
 		line-height: 2.3em;


### PR DESCRIPTION
Dans le message "Avis : Version HTML simplifiée" en haut de page lorsque l'utilisateur est en mode HTML simplifié, l'icône triangulaire relié à la nouvelle boîte d'alerte etait centré par-dessus le texte au lieu d'être à gauche comme il le devrait. Cela affectait la lisibilité du texte.
L'icône triangulaire est maintnenant à gauche dans son espace attitré.