### PR TITLE
wet-195 Ministerial-profile GCWeb template updates

### DIFF
--- a/_data/templates.json
+++ b/_data/templates.json
@@ -751,13 +751,26 @@
 		"fr": "Profile ministriel"
 	},
 	"description": {
-		"en": "Ministerial profile templates samples",
-		"fr": "Exemple de page Profile ministriel."
+		"en": "Ministerial profile templates documentation and example",
+		"fr": "Documentation et exemple de page Profile ministriel."
 	},
-	"modified": "2018-06-05",
+	"modified": "2021-09-16",
 	"componentName": "ministerial",
 	"status": "stable",
 	"pages": {
+		"docs": [
+
+			{
+				"title": "Ministerial profile page",
+				"language": "en",
+				"path": "ministerial-doc-en.html"
+			},
+			{
+				"title": "Page de Profile ministriel",
+				"language": "fr",
+				"path": "ministerial-doc-fr.html"
+			}
+		],
 		"examples": [
 
 			{

--- a/templates/ministerial/index.json-ld
+++ b/templates/ministerial/index.json-ld
@@ -11,13 +11,26 @@
 		"fr": "Profile ministriel"
 	},
 	"description": {
-		"en": "Ministerial profile templates samples",
-		"fr": "Exemple de page Profile ministriel."
+		"en": "Ministerial profile templates documentation and example",
+		"fr": "Documentation et exemple de page Profile ministriel."
 	},
-	"modified": "2018-06-05",
+	"modified": "2021-09-16",
 	"componentName": "ministerial",
 	"status": "stable",
 	"pages": {
+		"docs": [
+
+			{
+				"title": "Ministerial profile page",
+				"language": "en",
+				"path": "ministerial-doc-en.html"
+			},
+			{
+				"title": "Page de Profile ministriel",
+				"language": "fr",
+				"path": "ministerial-doc-fr.html"
+			}
+		],
 		"examples": [
 
 			{

--- a/templates/ministerial/ministerial-doc-en.html
+++ b/templates/ministerial/ministerial-doc-en.html
@@ -1,0 +1,57 @@
+---
+title: Documentation about Ministerial profile page template
+description: Documentation and working examples for the Ministerial profile tempalte.
+language: en
+altLangPage: ministerial-doc-fr.html
+dateModified: 2021-09-16
+share: true
+---
+
+<div class="wb-prettify all-pre hide"></div>
+
+<dl class="horizontal">
+	<dt>Status</dt>
+	<dd>Stable</dd>
+
+	<dt>Type</dt>
+	<dd>Canada.ca template</dd>
+
+	<dt>Last review</dt>
+	<dd>2021-09-15</dd>
+
+	<dt>Conforming to</dt>
+	<dd>Content and IA spec 2.1</dd>
+
+	<dt>Specification</dt>
+	<dd><a href="https://design.canada.ca/mandatory-templates/ministerial-profile-pages-draft.html">Ministerial profile pages - Canada.ca mandatory template</a></dd>
+
+	<dt>Template version</dt>
+	<dd>Version 2.0</dd>
+</dl>
+
+<h2>Working example</h2>
+
+<ul>
+	<li><a href="ministerial-en.html">Working example</a></li>
+	<li><a href="ministerial-fr.html" lang="fr">Exemple pratique</a></li>
+</ul>
+
+<h2>Change history</h2>
+
+<h3>Version 2.0</h3>
+
+<ul>
+	<li>replaced Latest, Recent announcements, and Gallery with a flexible Features section </li>
+	<li>removed the social media feed and added an optional Follow me section instead</li>
+	<li>simplified and streamlined the guidance </li>
+	<li>clarified how to display ministers, parliamentary secretaries and heads of organizations</li>
+</ul>
+
+<h3>Version 1.0</h3>
+
+<ul>
+	<li>Initial template</li>
+</ul>
+
+<h2>Evaluation and report</h2>
+<p>There is no evaluation and report available for this component.</p>

--- a/templates/ministerial/ministerial-doc-fr.html
+++ b/templates/ministerial/ministerial-doc-fr.html
@@ -1,0 +1,57 @@
+---
+title: Documentation au sujet de la page de profil des ministres
+description: Documentation et exemple pratique des pages de profil des ministres.
+language: fr
+altLangPage: ministerial-doc-en.html
+dateModified: 2021-09-16
+share: true
+---
+
+<div class="wb-prettify all-pre hide"></div>
+
+<dl class="horizontal">
+	<dt>Statut</dt>
+	<dd>Stable</dd>
+
+	<dt>Type</dt>
+	<dd>Gabarit de Canada.ca</dd>
+
+	<dt>Dernière revue</dt>
+	<dd>2021-09-15</dd>
+
+	<dt>Est conforme à</dt>
+	<dd>Spécifications du contenu et de l'architecture de l'information 2.1</dd>
+
+	<dt>Spécification</dt>
+	<dd><a href="https://conception.canada.ca/modeles-obligatoire/pages-profil-ministres-draft.html">Pages de profil des ministres - Modèle obligatoire de Canada.ca</a></dd>
+
+	<dt>Version du gabarit</dt>
+	<dd>Version 2.0</dd>
+</dl>
+
+<h2>Exemple pratique</h2>
+
+<ul>
+	<li><a href="ministerial-fr.html">Exemple pratique</a></li>
+	<li><a href="ministerial-en.html" lang="en">working example</a></li>
+</ul>
+
+<h2>Historique des changements</h2>
+
+<h3>Version 2.0</h3>
+
+<ul>
+	<li>remplacement des sections Nouveautés, Activités récentes et Galerie par une section En vedette flexible</li>
+	<li>suppression du widget de médias sociaux et ajout d'une section facultative "Suivez" à la place</li>
+	<li>simplification et amélioration des directives</li>
+	<li>clarification de la manière d'afficher les ministres, les secrétaires parlementaires et les chefs d'organisation</li>
+</ul>
+
+<h3>Version 1.0</h3>
+
+<ul>
+	<li>Gabarit initial</li>
+</ul>
+
+<h2>Raport et évaluation</h2>
+<p>Il n'y aucun raport ou évaluation disponible pour ce gabarit.</p>

--- a/templates/ministerial/ministerial-en.html
+++ b/templates/ministerial/ministerial-en.html
@@ -1,22 +1,18 @@
 ---
-{
-	"title": "The Honourable [Minister name], MP",
-	"language": "en",
-	"altLangPrefix": "ministerial",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "Government of Canada Ministers", "link": "#" }
-	],
-	"dateModified": "2018-06-05",
-	"share": "true"
-}
+title: The Honourable [Minister name], MP | [Parliamentary secretary’s name] | [Head of institution or organization's name]
+description: Working example for the Ministerial profile page template
+language: en
+altLangPage: ministerial-fr.html
+dateModified: 2021-09-16
+share: true
 ---
+
 <div class="row">
 	<div class="col-md-3">
 		<p class="mrgn-tp-lg"><img src="img/265x352.png" alt="" class="img-responsive"></p>
 	</div>
-	<div class="col-md-6">
-		<p class="mrgn-tp-lg"><strong>Minister of <a href="#">[Portfolio name one]</a> and <a href="#">[Portfolio name two]</a></strong><a href="#"></a></p>
+	<div class="col-md-9">
+		<p class="mrgn-tp-lg"><strong>Minister of <a href="#">[Portfolio name one]</a> and <a href="#">[Portfolio name two]</a> | Parliamentary secretary to the <a href="#">[Minister of portfolio name]</a> | [Official title of the head]</strong></p>
 		<p>Represents the riding of <a href="#">[Riding name]</a></p>
 		<ul>
 			<li><a href="#">Ministerial mandate letter</a></li>
@@ -33,113 +29,24 @@
 				<strong>Email:</strong> <a href="mailto:">[first.last@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
 		</section>
 	</div>
-	<div class="col-md-3">
-		<h2>Twitter</h2>
-		[Twitter feed]
-	</div>
 </div>
-<div class="row">
-	<div class="col-sm-12">
-		<section>
-			<h2>Latest</h2>
-			<div class="gc-nws row">
-				<div class="col-md-8">
-					<div class="row">
-						<div class="col-md-6">
-							<a href="#">
-								<img src="../img/news-360x203.png" alt="" class="img-responsive thumbnail">
-								<p>[News title]</p>
-							</a>
-							<p><small class="text-muted"><time>2018-06-05 19:00</time> - Type of news product</small><br />
-							Brief description of the news item.</p>
-						</div>
-						<div class="col-md-6">
-							<a href="#">
-								<img src="../img/news-360x203.png" alt="" class="img-responsive thumbnail">
-								<p>[News title]</p>
-							</a>
-							<p><small class="text-muted"><time>2018-06-05 20:00</time> - Type of news product</small><br />
-							Brief description of the news item.</p>
-						</div>
-					</div>
-				</div>
-				<div class="wb-feeds limit-3 col-md-4">
-					<ul class="feeds-cont list-unstyled lst-spcd">
-						<li> <a href="http://news.gc.ca/web/fd-en.do?mthd=dpt&amp;ft=atom&amp;crtr.dpt1D=6675" rel="external">Government of Canada News Releases</a> </li>
-					</ul>
-					<p class="text-right"><strong><a href="#">All news</a></strong></p>
-				</div>
-			</div>
-		</section>
-	</div>
-</div>
-<section>
-	<h2>Recent activities</h2>
-	<div class="row">
-		<section class="col-sm-4">
-			<h3>Initiatives</h3>
-			<ul class="lst-spcd">
-				<li><a href="#">[Initiatives 1]</a></li>
-				<li><a href="#">[Initiatives 2 with longer text to wrap]</a></li>
-				<li><a href="#">[Initiatives 3]</a></li>
-				<li><a href="#">[Initiatives 4 with longer text to wrap]</a></li>
-			</ul>
-		</section>
-		<section class="col-sm-4">
-			<h3>Speeches</h3>
-			<ul class="lst-spcd">
-				<li><a href="#">[Speech 1]</a></li>
-				<li><a href="#">[Speech 2 with longer text to wrap]</a></li>
-				<li><a href="#">[Speech 3]</a></li>
-				<li><a href="#">[Speech 4 with longer text to wrap]</a></li>
-			</ul>
-		</section>
-		<section class="col-sm-4">
-			<h3>Media advisories</h3>
-			<ul class="lst-spcd">
-				<li><a href="#">[Media advisory 1]</a></li>
-				<li><a href="#">[Media advisory 2 with longer text to wrap]</a></li>
-				<li><a href="#">[Media advisory 3]</a></li>
-				<li><a href="#">[Media advisory 4 with longer text to wrap]</a></li>
-			</ul>
-		</section>
-	</div>
-</section>
-<section>
-	<h2>Gallery</h2>
-	<div class="row">
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
+<section class="gc-features">
+	<h2>Features [optional]</h2>
+	<div class="row wb-eqht">
+		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
+			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
+			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<p>Brief description of the feature being promoted.</p>
 		</div>
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
+		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
+			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
+			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<p>Brief description of the feature being promoted.</p>
 		</div>
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
-		</div>
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
+		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
+			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
+			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<p>Brief description of the feature being promoted.</p>
 		</div>
 	</div>
-	<p><strong><a href="#">All photos and videos</a></strong></p>
 </section>

--- a/templates/ministerial/ministerial-fr.html
+++ b/templates/ministerial/ministerial-fr.html
@@ -1,22 +1,18 @@
 ---
-{
-	"title": "L’honorable [nom du ministre], député",
-	"language": "fr",
-	"altLangPrefix": "ministerial",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "Ministres du gouvernement du Canada", "link": "#" }
-	],
-	"dateModified": "2018-06-05",
-	"share": "true"
-}
+title: L’honorable [nom du ministre], député | [Nom du secrétaire parlementaire] | [Nom du chef de l'institution ou de l'organisation]
+description: Exemple pratique de la pages de profil des ministres
+language: fr
+altLangPage: ministerial-en.html
+dateModified: 2021-09-16
+share: true
 ---
+
 <div class="row">
 	<div class="col-md-3">
 		<p class="mrgn-tp-lg"><img src="img/265x352.png" alt="" class="img-responsive"></p>
 	</div>
-	<div class="col-md-6">
-		<p class="mrgn-tp-lg"><strong>Ministre de <a href="#">[nom du portefeuille no1]</a> et <a href="#">[nom du portefeuille no2]</a></strong></p>
+	<div class="col-md-9">
+		<p class="mrgn-tp-lg"><strong>Ministre de <a href="#">[nom du portefeuille no1]</a> et <a href="#">[nom du portefeuille no2]</a> | Secrétaire parlementaire du/de la <a href="#">[nom du ou de la ministre du portefeuille]</a> | [Titre officiel du chef de l'organisation]</strong></p>
 		<p>Représente la circonscription de <a href="#">[nom de la circonscription]</a></p>
 		<ul>
 			<li><a href="#">Lettre de mandat adressées aux ministres</a></li>
@@ -33,113 +29,24 @@
 				<strong>Courriel&nbsp;:</strong> <a href="mailto:">[prénom.nom@canada.ca]</a> <span class="glyphicon glyphicon-envelope"></span></p>
 		</section>
 	</div>
-	<div class="col-md-3">
-		<h2>Twitter</h2>
-		[Twitter feed]
-	</div>
 </div>
-<div class="row">
-	<div class="col-sm-12">
-		<section>
-			<h2>Nouveautés</h2>
-			<div class="gc-nws row">
-				<div class="col-md-8">
-					<div class="row">
-						<div class="col-md-6">
-							<a href="#">
-								<img src="../img/news-360x203.png" alt="" class="img-responsive thumbnail">
-								<p>[Titre de l’article]</p>
-							</a>
-							<p><small class="text-muted"><time>2018-06-05 19:00</time> - Type de produit médiatique</small><br />
-							Brève description de la nouvelle.</p>
-						</div>
-						<div class="col-md-6">
-							<a href="#">
-								<img src="../img/news-360x203.png" alt="" class="img-responsive thumbnail">
-								<p>[Titre de l’article]</p>
-							</a>
-							<p><small class="text-muted"><time>2018-06-05 19:00</time> - Type de produit médiatique</small><br />
-							Brève description de la nouvelle.</p>
-						</div>
-					</div>
-				</div>
-				<div class="wb-feeds limit-3 col-md-4">
-					<ul class="feeds-cont list-unstyled lst-spcd">
-						<li> <a href="http://news.gc.ca/web/fd-fr.do?mthd=dpt&amp;ft=atom&amp;crtr.dpt1D=6675" rel="external">Nouvelles du Gouvernement du Canada </a> </li>
-					</ul>
-					<p class="text-right"><strong><a href="#">Toutes les nouvelles</a></strong></p>
-				</div>
-			</div>
-		</section>
-	</div>
-</div>
-<section>
-	<h2>Activités récentes</h2>
-	<div class="row">
-		<section class="col-sm-4">
-			<h3>Initiatives</h3>
-			<ul class="lst-spcd">
-				<li><a href="#">[Initiatives 1]</a></li>
-				<li><a href="#">[Initiatives 2 contenant un texte plus long à insérer]</a></li>
-				<li><a href="#">[Initiatives 3]</a></li>
-				<li><a href="#">[Initiatives 4 contenant un texte plus long à insérer]</a></li>
-			</ul>
-		</section>
-		<section class="col-sm-4">
-			<h3>Discours</h3>
-			<ul class="lst-spcd">
-				<li><a href="#">[Discours 1]</a></li>
-				<li><a href="#">[Discours 2 contenant un texte plus long à insérer]</a></li>
-				<li><a href="#">[Discours 3]</a></li>
-				<li><a href="#">[Discours 4 contenant un texte plus long à insérer]</a></li>
-			</ul>
-		</section>
-		<section class="col-sm-4">
-			<h3>Avis aux médias</h3>
-			<ul class="lst-spcd">
-				<li><a href="#">[Avis aux médias 1]</a></li>
-				<li><a href="#">[Avis aux médias 2 contenant un texte plus long à insérer]</a></li>
-				<li><a href="#">[Avis aux médias 3]</a></li>
-				<li><a href="#">[Avis aux médias 4 contenant un texte plus long à insérer]</a></li>
-			</ul>
-		</section>
-	</div>
-</section>
-<section>
-	<h2>Galerie</h2>
-	<div class="row">
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
+<section class="gc-features">
+	<h2>En vedette [facultatif]</h2>
+	<div class="row wb-eqht">
+		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
+			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
+			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<p>Brève descripton de l'élément en vedette</p>
 		</div>
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
+		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
+			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
+			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<p>Brève descripton de l'élément en vedette</p>
 		</div>
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
-		</div>
-		<div class="col-lg-3 col-md-6 mrgn-bttm-lg">
-			<a href="#">
-				<figure>
-					<img src="img/250x250.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-					<figcaption>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum, fugiat!</figcaption>
-				</figure>
-			</a>
+		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
+			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
+			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<p>Brève descripton de l'élément en vedette</p>
 		</div>
 	</div>
-	<p><strong><a href="#">Toutes les photos et vidéos</a></strong></p>
 </section>


### PR DESCRIPTION
Minor updates to the Ministerial profile page template:
- Removal of the following sections: Latest, Recent activities, Twitter feed, Follow us and Gallery
- Creation of a Features optional section v6.1
- Change for 9 col instead of 6
- Creation of a documentation page (Eng and Fra)