### PR TITLE
Add a possibility to customize the color for inline button used in Fi…

### DIFF
--- a/components/wb-fieldflow/fieldflow-doc-en.html
+++ b/components/wb-fieldflow/fieldflow-doc-en.html
@@ -331,14 +331,47 @@ dateModified: 2021-04-28
 			</tr>
 			<tr>
 				<td>inline</td>
-				<td>Indicate to render an inline interface. Available only for <code>{&quot;renderas&quot;:&quot;checkbox&quot;}</code> and <code>{&quot;renderas&quot;:&quot;radio&quot;}</code> </td>
-				<td><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[radio|checkbox]</em>&quot;, &quot;inline&quot;: <em>true</em>}</code></td>
+				<td>
+					<p>Indicate to render an inline interface. Available only for <code>{&quot;renderas&quot;:&quot;checkbox&quot;}</code> and <code>{&quot;renderas&quot;:&quot;radio&quot;}</code>.</p>
+					<p>Can also be applied to render an inline submit button <code>{&quot;inline&quot;:&quot;true&quot;}</code></p>
+				</td>
+				<td>
+					<p><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[radio|checkbox]</em>&quot;, &quot;inline&quot;: <em>true</em>}</code></p>
+					<p><code>data-wb-fieldflow='{ &quot;inline&quot;: <em>true</em>}</code></p>
+				</td>
 				<td>
 					<dl>
 						<dt>false (default):</dt>
 						<dd>Render one checkbox or radio per line</dd>
 						<dt>true</dt>
-						<dd>Checkbox or radio are side by side.</dd>
+						<dd>Checkbox or radio are side by side</dd>
+						<dd>(if applied without renderas) Submit button is inline.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>btnStyle</td>
+				<td>Select color for inline submit button. Available only for inline button interface.</td>
+				<td><code>data-wb-fieldflow='{&quot;inline&quot;: <em>true</em>, &quot;btnStyle&quot;: <em>&quot;[color class]&quot;</em>}</code></td>
+				<td>
+					<dl>
+						<dt>Default:</dt>
+						<dd>default class is "default"</dd>
+						<dt>String:</dt>
+						<dd>Any valid color class suffix from Bootstrap 3:"default", "primary", "success", "info", "warning", "danger", "link"</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>showLabel</td>
+				<td>Showing label for drop-down (select) with inline button (optional, if not provided, label will be hidden by default). Available only for drop-down with inline button.</td>
+				<td><code>data-wb-fieldflow='{&quot;inline&quot;: <em>true</em>, &quot;showLabel&quot;: <em>&quot;true &quot;</em>}</code></td>
+				<td>
+					<dl>
+						<dt>Default: false</dt>
+						<dd>the label of the inline select is not visible</dd>
+						<dt>Boolean: true</dt>
+						<dd>the label of the inline select is visible</dd>
 					</dl>
 				</td>
 			</tr>

--- a/components/wb-fieldflow/fieldflow-doc-fr.html
+++ b/components/wb-fieldflow/fieldflow-doc-fr.html
@@ -335,14 +335,47 @@ dateModified: "2021-04-28"
 			</tr>
 			<tr>
 				<td>inline</td>
-				<td>Indicate to render a inline interface. Availble only for <code>{&quot;renderas&quot;:&quot;checkbox&quot;}</code> and <code>{&quot;renderas&quot;:&quot;radio&quot;}</code> </td>
-				<td><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[radio|checkbox]</em>&quot;, &quot;inline&quot;: <em>true</em>}</code></td>
+				<td>
+					<p>Indicate to render an inline interface. Available only for <code>{&quot;renderas&quot;:&quot;checkbox&quot;}</code> and <code>{&quot;renderas&quot;:&quot;radio&quot;}</code>.</p>
+					<p>Can also be applied to render an inline submit button <code>{&quot;inline&quot;:&quot;true&quot;}</code></p>
+				</td>
+				<td>
+					<p><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[radio|checkbox]</em>&quot;, &quot;inline&quot;: <em>true</em>}</code></p>
+					<p><code>data-wb-fieldflow='{ &quot;inline&quot;: <em>true</em>}</code></p>
+				</td>
 				<td>
 					<dl>
 						<dt>false (default):</dt>
 						<dd>Render one checkbox or radio per line</dd>
 						<dt>true</dt>
-						<dd>Checkbox or radio are side by side.</dd>
+						<dd>Checkbox or radio are side by side</dd>
+						<dd>(if applied without renderas)Submit button is inline.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>btnStyle</td>
+				<td>Select color for inline submit button. Available only for inline button interface.</td>
+				<td><code>data-wb-fieldflow='{&quot;inline&quot;: <em>true</em>, &quot;btnStyle&quot;: <em>&quot;[color class]&quot;</em>}</code></td>
+				<td>
+					<dl>
+						<dt>Default:</dt>
+						<dd>default class is "default"</dd>
+						<dt>String:</dt>
+						<dd>Any valid color class suffix from Bootstrap 3:"default", "primary", "success", "info", "warning", "danger", "link"</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>showLabel</td>
+				<td>Showing label for drop-down (select) with inline button (optional, if not provided, label will be hidden by default). Available only for drop-down with inline button.</td>
+				<td><code>data-wb-fieldflow='{&quot;inline&quot;: <em>true</em>, &quot;showLabel&quot;: <em>&quot;true &quot;</em>}</code></td>
+				<td>
+					<dl>
+						<dt>Default: false</dt>
+						<dd>the label of the inline select is not visible</dd>
+						<dt>Boolean: true</dt>
+						<dd>the label of the inline select is visible</dd>
 					</dl>
 				</td>
 			</tr>

--- a/components/wb-fieldflow/fieldflow-en.html
+++ b/components/wb-fieldflow/fieldflow-en.html
@@ -35,6 +35,9 @@ dateModified: 2016-11-30
 		<li><a href="#grouping">Grouping</a></li>
 		<li><a href="#nesting">Nesting</a></li>
 		<li><a href="#inline">Inline button</a></li>
+		<li><a href="#inline-btn-color">Color for inline button</a></li>
+		<li><a href="#inline-show-label">Showing label for inline button</a></li>
+
 	</ul>
 </nav>
 
@@ -237,6 +240,58 @@ dateModified: 2016-11-30
 	</ul>
 </div>
 <pre><code>&lt;div class=&quot;wb-fieldflow&quot; <strong>data-wb-fieldflow='{&quot;inline&quot;: true}'</strong>&gt;
+	&lt;p&gt;Find the plugin for the action you need:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+</code></pre>
+
+<h2 id="inline-btn-color">Color for inline button</h2>
+<p>Note: CSS class can be applied only for inline button. Value for <code>btnStyle</code> option can be any valid color class suffix from Bootstrap 3: <code>default</code>, <code>primary</code>, <code>success</code>, <code>info</code>, <code>warning</code>, <code>danger</code>, <code>link</code></p>
+<div class="wb-fieldflow" data-wb-fieldflow='{"inline": true, "btnStyle":"success"}'>
+	<p>Find the plugin for the action you need:</p>
+	<ul>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+	</ul>
+</div>
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;inline&quot;: true, <strong>&quot;btnStyle&quot;: &quot;success&quot;</strong>}'&gt;
+	&lt;p&gt;Find the plugin for the action you need:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+</code></pre>
+
+<h2 id="inline-show-label">Showing label for drop-down (select) with inline button</h2>
+<p>Note: Applicable only for drop-down with inline button. This property is optional. By default, the label is hidden for drop-down with inline submit button. Add the property <code>showLabel</code> with a value of <code>true</code>.</p>
+<div class="wb-fieldflow" data-wb-fieldflow='{"inline": true, "showLabel":true}'>
+	<p>Find the plugin for the action you need:</p>
+	<ul>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+	</ul>
+</div>
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;inline&quot;: true, <strong>&quot;showLabel&quot;: true</strong>}'&gt;
 	&lt;p&gt;Find the plugin for the action you need:&lt;/p&gt;
 	&lt;ul&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;

--- a/components/wb-fieldflow/fieldflow-fr.html
+++ b/components/wb-fieldflow/fieldflow-fr.html
@@ -33,6 +33,8 @@ dateModified: "2016-11-30"
 		<li><a href="#regroupement">Regroupement</a></li>
 		<li><a href="#imbrication">Imbrication</a></li>
 		<li><a href="#aligne">Bouton aligné</a></li>
+		<li><a href="#inline-btn-color">Couleur pour bouton aligné</a></li>
+		<li><a href="#inline-show-label">Affichage d'étiquette pour la liste déroulante avec un bouton aligné</a></li>
 	</ul>
 </nav>
 
@@ -249,3 +251,55 @@ dateModified: "2016-11-30"
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
+
+<h2 id="inline-btn-color">Couleur pour bouton aligné</h2>
+<p>Note: La classe CSS peut être appliquée seulement pour le bouton aligné. La valeur pour l'option <code>btnStyle</code> peut être n'importe quel suffixe d'une classe de couleur valide de Bootstrap 3: <code>default</code>, <code>primary</code>, <code>success</code>, <code>info</code>, <code>warning</code>, <code>danger</code>, <code>link</code></p>
+<div class="wb-fieldflow" data-wb-fieldflow='{"inline": true, "btnStyle":"success"}'>
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+	<ul>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+	</ul>
+</div>
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;inline&quot;: true, <strong>&quot;btnStyle&quot;: &quot;success&quot;</strong>}'&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+</code></pre>
+
+<h2 id="inline-show-label">Affichage d'étiquette pour la liste déroulante (select) avec un bouton aligné</h2>
+<p>Note: Applicable uniquement pour la liste déroulante avec un bouton aligné. Cette propriété est optionnelle. Par défaut, l'étiquette pour la liste déroulante avec un bouton d'envoi aligné n'est pas affichée. Ajoutez la propriété <code>showLabel</code> avec la valeur <code>true</code>.</p>
+<div class="wb-fieldflow" data-wb-fieldflow='{"inline": true, "showLabel":true}'>
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+	<ul>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+	</ul>
+</div>
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;inline&quot;: true, <strong>&quot;showLabel&quot;: true</strong>}'&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+</code></pre>

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -134,7 +134,10 @@ var componentName = "wb-fieldflow",
 			// Transform the list into a select, use the first paragrap content for the label, and extract for i18n the name of the button action.
 			var bodyID = wb.getId(),
 				stdOut,
-				formElm, $form;
+				formElm,
+				$form,
+				btnStyle = config.btnStyle && [ "default", "primary", "success", "info", "warning", "danger", "link" ].indexOf( config.btnStyle ) >= 0 ? config.btnStyle : "default",
+				showLabel = !!config.showLabel;
 
 			if ( config.noForm ) {
 				stdOut = "<div class='mrgn-tp-md'><div id='" + bodyID + "'></div></div>";
@@ -146,8 +149,8 @@ var componentName = "wb-fieldflow",
 				}
 				$( formElm.parentElement ).addClass( formComponent );
 			} else if ( config.inline && !config.renderas ) {
-				stdOut = "<div class='wb-frmvld " + formComponent + "'><form><div class='input-group'><div id='" + bodyID + "'>";
-				stdOut = stdOut + "</div><span class='input-group-btn'><input type=\"submit\" value=\"" + i18n.btn + "\" class=\"btn btn-default mrgn-bttm-md\" /></span></div> </form></div>";
+				stdOut = "<div class='wb-frmvld mrgn-bttm-md " + formComponent + "'><form><div class='input-group'><div id='" + bodyID + "'>";
+				stdOut = stdOut + "</div><span class='input-group-btn" + ( showLabel ? " align-bottom" : "" ) + "'><input type=\"submit\" value=\"" + i18n.btn + "\" class=\"btn btn-" + btnStyle + "\" /></span></div> </form></div>";
 			} else {
 				stdOut = "<div class='wb-frmvld " + formComponent + "'><form><div id='" + bodyID + "'>";
 				stdOut = stdOut + "</div><input type=\"submit\" value=\"" + i18n.btn + "\" class=\"btn btn-primary mrgn-bttm-md\" /> </form></div>";
@@ -542,7 +545,8 @@ var componentName = "wb-fieldflow",
 				noreqlabel: data.noreqlabel,
 				items: $items,
 				inline: data.inline,
-				gcChckbxrdio: data.gcChckbxrdio
+				gcChckbxrdio: data.gcChckbxrdio,
+				showLabel: data.showLabel
 			} );
 		}
 	},
@@ -561,7 +565,7 @@ var componentName = "wb-fieldflow",
 			i18n = $elm.data( configData ).i18n,
 			autoID = wb.getId(),
 			labelPrefix = "<label for='" + autoID + "'",
-			labelInvisible = data.inline ? " wb-inv" : "",
+			labelInvisible = ( data.inline && !data.showLabel ) ? " wb-inv" : "",
 			labelSuffix = "</span>",
 			$out, $tmpLabel,
 			selectOut, $selectOut,


### PR DESCRIPTION
Add a possibility to customize the color of inline buttons used in the Field flow component. 
Render visible the drop-down's label as requested in the ticket's technical requirement.
Button color can be implemented as follows:
`<div class="wb-fieldflow" data-wb-fieldflow='{"inline": true, "btnColor": "warning"}'>`
where:
 -  **"inline"** is the Field flow option to render the button aligned with the drop-down list. Can accept the values : true, false; 
 - **"btnStyle"** is the Field flow option to customize the inline button color. Can accept the following values:  "default", "primary", "success", "info", "warning", "danger". Please refer to the Bootstrap button colors, e.g.,  "btn-default", "btn-success", etc.
 **Note:**  This option applies to inline buttons **only** .

Update: 25-11-2021
new attribute is added "`showLabel`" with a value of `true `in order to add a way to show/hide the labels for selects with inline button.
 **Note:**  This option applies to drop-downs with inline buttons **only** .
`<div class="wb-fieldflow" data-wb-fieldflow='{"inline": true, "showLabel": true}'>
`

Field flow documentation updated accordingly.
WET-171