### PR TITLE
Subway map menu: Use H2 for document navigation

### DIFF
--- a/components/gc-subway/gc-subway-en.html
+++ b/components/gc-subway/gc-subway-en.html
@@ -8,7 +8,7 @@
 	"breadcrumb": [
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
 	],
-	"dateModified": "2020-12-07",
+	"dateModified": "2021-10-15",
 	"share": "true"
 }
 ---
@@ -49,7 +49,7 @@
 <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nunc aliquam felis massa, ut congue enim faucibus in. Vivamus rhoncus elit in pharetra bibendum. In fringilla justo non consectetur feugiat. Ut bibendum nisi lacus, eu dapibus massa semper sit amet. Fusce condimentum pretium libero eget fermentum. Duis feugiat velit at commodo accumsan. Nunc in felis leo.</p>
 
 <nav class="mrgn-bttm-lg mrgn-tp-lg">
-	<h3 class="wb-inv">Document navigation</h3>
+	<h2 class="wb-inv">Document navigation</h2>
 	<ul class="pager">
 		<li class="next"><a href="page2-en.html#wb-cont" rel="next"><span class="wb-inv">Next: </span>[Page 2]</a></li>
 	</ul>

--- a/components/gc-subway/gc-subway-fr.html
+++ b/components/gc-subway/gc-subway-fr.html
@@ -8,7 +8,7 @@
 	"breadcrumb": [
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
 	],
-	"dateModified": "2020-12-07",
+	"dateModified": "2021-10-15",
 	"share": "true"
 }
 ---
@@ -49,7 +49,7 @@
 <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nunc aliquam felis massa, ut congue enim faucibus in. Vivamus rhoncus elit in pharetra bibendum. In fringilla justo non consectetur feugiat. Ut bibendum nisi lacus, eu dapibus massa semper sit amet. Fusce condimentum pretium libero eget fermentum. Duis feugiat velit at commodo accumsan. Nunc in felis leo.</p>
 
 <nav class="mrgn-bttm-lg mrgn-tp-lg">
-	<h3 class="wb-inv">Navigation du document</h3>
+	<h2 class="wb-inv">Navigation du document</h2>
 	<ul class="pager">
 		<li class="next"><a href="page2-fr.html#wb-cont" rel="next"><span class="wb-inv">Suivant: </span>[Page 2]</a></li>
 	</ul>

--- a/components/gc-subway/page2-en.html
+++ b/components/gc-subway/page2-en.html
@@ -9,7 +9,7 @@
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2020-12-07",
+	"dateModified": "2021-10-15",
 	"share": "true"
 }
 ---
@@ -50,7 +50,7 @@
 <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nunc aliquam felis massa, ut congue enim faucibus in. Vivamus rhoncus elit in pharetra bibendum. In fringilla justo non consectetur feugiat. Ut bibendum nisi lacus, eu dapibus massa semper sit amet. Fusce condimentum pretium libero eget fermentum. Duis feugiat velit at commodo accumsan. Nunc in felis leo.</p>
 
 <nav class="mrgn-bttm-lg mrgn-tp-lg">
-	<h3 class="wb-inv">Document navigation</h3>
+	<h2 class="wb-inv">Document navigation</h2>
 	<ul class="pager">
 		<li class="previous"><a href="gc-subway-en.html#wb-cont" rel="prev"><span class="wb-inv">Previous: </span>[Page 1]</a></li>
 		<li class="next"><a href="#wb-cont" rel="next"><span class="wb-inv">Next: </span>[Page 3]</a></li>

--- a/components/gc-subway/page2-fr.html
+++ b/components/gc-subway/page2-fr.html
@@ -9,7 +9,7 @@
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2020-12-07",
+	"dateModified": "2021-10-15",
 	"share": "true"
 }
 ---
@@ -50,7 +50,7 @@
 <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nunc aliquam felis massa, ut congue enim faucibus in. Vivamus rhoncus elit in pharetra bibendum. In fringilla justo non consectetur feugiat. Ut bibendum nisi lacus, eu dapibus massa semper sit amet. Fusce condimentum pretium libero eget fermentum. Duis feugiat velit at commodo accumsan. Nunc in felis leo.</p>
 
 <nav class="mrgn-bttm-lg mrgn-tp-lg">
-	<h3 class="wb-inv">Navigation du document</h3>
+	<h2 class="wb-inv">Navigation du document</h2>
 	<ul class="pager">
 		<li class="previous"><a href="gc-subway-fr.html#wb-cont" rel="prev"><span class="wb-inv">Précédent: </span>[Page 1]</a></li>
 		<li class="next"><a href="#wb-cont" rel="next"><span class="wb-inv">Suivant: </span>[Page 3]</a></li>


### PR DESCRIPTION
The document navigation section was previously using an H3 heading... which didn't make structural sense (it's preceded by an H1 heading and doesn't function as a subsection).

The H3 was probably a leftover from the advanced service initiation page template. That template intentionally used an H3 for its document navigation section.

CC @delisma