### PR TITLE
Adjust the structured data for breadcrumb

### DIFF
--- a/sites/breadcrumbs/breadcrumbs-en.html
+++ b/sites/breadcrumbs/breadcrumbs-en.html
@@ -2,9 +2,10 @@
 {
 	"altLangPage": "breadcrumbs-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index.html" }
+		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" },
+		{ "title": "Méli-mélo", "link": "https://wet-boew.github.io/GCWeb/méli-mélo/méli-mélo-en.html" }
 	],
-	"dateModified": "2021-03-30",
+	"dateModified": "2021-12-02",
 	"description": "Documentation on how to use breadcrumbs.",
 	"language": "en",
 	"title": "Breadcrumbs"
@@ -17,3 +18,34 @@
 <ul>
 	<li>The page title should not be included within the breadcrumbs list items.</li>
 </ul>
+
+<p>Here is the html output with structured data in RDFa format for the above breadcrumb example:</p>
+<pre>
+	<code>
+		&lt;nav id="wb-bc" property="breadcrumb"&gt;
+			&lt;h2&gt;You are here:&lt;/h2&gt;
+			&lt;div class="container"&gt;
+				&lt;ol class="breadcrumb" typeof="BreadcrumbList"&gt;
+					&lt;li property="itemListElement" typeof="ListItem"&gt;
+						&lt;a property="item" typeof="WebPage" href="https://www.canada.ca/en.html"&gt;
+							&lt;span property="name">Canada.ca&lt;/span&gt;
+						&lt;/a&gt;
+						&lt;meta property="position" content="1"&gt;
+					&lt;/li&gt;
+					&lt;li property="itemListElement" typeof="ListItem"&gt;
+						&lt;a property="item" typeof="WebPage" href="https://wet-boew.github.io/GCWeb/index-en.html"&gt;
+							&lt;span property="name"&gt;GCWeb home&lt;/span&gt;
+						&lt;/a&gt;
+						&lt;meta property="position" content="2"&gt;
+					&lt;/li&gt;
+					&lt;li property="itemListElement" typeof="ListItem"&gt;
+						&lt;a property="item" typeof="WebPage" href="https://wet-boew.github.io/GCWeb/méli-mélo/méli-mélo-en.html"&gt;
+							&lt;span property="name"&gt;Méli-mélo&lt;/span&gt;
+						&lt;/a&gt;
+						&lt;meta property="position" content="3"&gt;
+					&lt;/li&gt;
+				&lt;/ol&gt;
+			&lt;/div&gt;
+		&lt;/nav&gt;
+	</code>
+</pre>

--- a/sites/breadcrumbs/breadcrumbs-fr.html
+++ b/sites/breadcrumbs/breadcrumbs-fr.html
@@ -2,11 +2,13 @@
 {
 	"altLangPage": "breadcrumbs-en.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index.html" }
+		{ "title": "GCWeb accueil", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" },
+		{ "title": "Méli-mélo", "link": "https://wet-boew.github.io/GCWeb/méli-mélo/méli-mélo-fr.html" }
+
 	],
-	"dateModified": "2021-03-30",
+	"dateModified": "2021-12-02",
 	"description": "Documentation sur l'utilisation du fil d'arianne.",
-	"lang": "fr",
+	"language": "fr",
 	"title": "Fil d'arianne"
 }
 ---
@@ -17,3 +19,34 @@
 <ul>
 	<li>Le titre de la page ne dois pas être inclus parmis la liste de fil d'arianne.</li>
 </ul>
+
+<p>Voici la sortie html avec des données structurées au format RDFa pour l'exemple de fil d'Ariane ci-dessus:</p>
+<pre>
+<code>
+	&lt;nav id="wb-bc" property="breadcrumb"&gt;
+		&lt;h2&gt;Vous êtes ici:&lt;/h2&gt;
+		&lt;div class="container"&gt;
+			&lt;ol class="breadcrumb" typeof="BreadcrumbList"&gt;
+				&lt;li property="itemListElement" typeof="ListItem"&gt;
+					&lt;a property="item" typeof="WebPage" href="https://www.canada.ca/fr.html"&gt;
+						&lt;span property="name">Canada.ca&lt;/span&gt;
+					&lt;/a&gt;
+					&lt;meta property="position" content="1"&gt;
+				&lt;/li&gt;
+				&lt;li property="itemListElement" typeof="ListItem"&gt;
+					&lt;a property="item" typeof="WebPage" href="https://wet-boew.github.io/GCWeb/index-fr.html"&gt;
+						&lt;span property="name"&gt;GCWeb accueil&lt;/span&gt;
+					&lt;/a&gt;
+					&lt;meta property="position" content="2"&gt;
+				&lt;/li&gt;
+				&lt;li property="itemListElement" typeof="ListItem"&gt;
+					&lt;a property="item" typeof="WebPage" href="https://wet-boew.github.io/GCWeb/méli-mélo/méli-mélo-fr.html"&gt;
+						&lt;span property="name"&gt;GCWeb accueil&lt;/span&gt;
+					&lt;/a&gt;
+					&lt;meta property="position" content="3"&gt;
+				&lt;/li&gt;
+			&lt;/ol&gt;
+		&lt;/div&gt;
+	&lt;/nav&gt;
+</code>
+</pre>

--- a/sites/breadcrumbs/inc-breadcrumbs.html
+++ b/sites/breadcrumbs/inc-breadcrumbs.html
@@ -2,11 +2,23 @@
 <nav id="wb-bc" property="breadcrumb">
 	<h2>{{ i18nText-breadcrumb }}</h2>
 	<div class="container">
-		<ol class="breadcrumb">
-			<li><a href="{{ i18nText-homePage }}">{{ i18nText-home }}</a></li>
+		<ol class="breadcrumb" typeof="BreadcrumbList">
+			<li property="itemListElement" typeof="ListItem">
+				<a property="item" typeof="WebPage" href="{{ i18nText-homePage }}">
+					<span property="name">{{ i18nText-home }}</span>
+				</a>
+				<meta property="position" content="1">
+			</li>
 {%- if page.breadcrumbs -%}
+	{% assign breadcrumbCounter = 2 %}
 	{% for breadcrumb in page.breadcrumbs %}
-			<li><a href="{{ breadcrumb.link | relative_url }}">{{ breadcrumb.title }}</a></li>
+		<li property="itemListElement" typeof="ListItem">
+			<a property="item" typeof="WebPage" href="{{ breadcrumb.link | relative_url }}">
+				<span property="name">{{ breadcrumb.title }}</span>
+			</a>
+			<meta property="position" content="{{ breadcrumbCounter }}">
+		</li>
+		{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
 	{%- endfor -%}
 {% endif %}
 		</ol>


### PR DESCRIPTION
Previous breadcrumb used typeof=”Breadcrumb”, which doesn’t offer a data structure as rich as the typeof=”BreadcrumbList”.
This PR will replace it with the typeof=”BreadcrumbList” approach, which includes things such as a typeof ListItem on each list items.

Here is a valid example: https://search.google.com/test/rich-results/result?id=zGU8HNwVFWXt4fBPF2cl8w

As per WET-148