### PR TITLE
Footer options - Hiding utility links and create working examples

### DIFF
--- a/_data/templates.json
+++ b/_data/templates.json
@@ -192,7 +192,7 @@
 		"en": "Template included but need to move in its own folder.",
 		"fr": "Gabarit inclus mais qu'il nécessite qu'ils soit déplacé dans son propre dossier."
 	},
-	"modified": "2021-02-12",
+	"modified": "2021-11-03",
 	"status": "stable",
 	"pages": {
 		"examples": [
@@ -262,9 +262,36 @@
 				"language": "fr",
 				"path": "content-signedon-fr.html"
 			},
-
-
-
+			{
+				"title": "Content page - Hidden Footer 'About government'",
+				"language": "en",
+				"path": "content-no-footer-about-en.html"
+			},
+			{
+				"title": "Page de contenu - Masquer le pied de page 'Au sujet du gouvernement'",
+				"language": "fr",
+				"path": "content-no-footer-about-fr.html"
+			},
+			{
+				"title": "Content page - Hidden Footer 'About this site'",
+				"language": "en",
+				"path": "content-no-footer-site-en.html"
+			},
+			{
+				"title": "Page de contenu - Masquer le pied de page 'Au sujet de ce site'",
+				"language": "fr",
+				"path": "content-no-footer-site-fr.html"
+			},
+			{
+				"title": "Content page - Hidden All Footers",
+				"language": "en",
+				"path": "content-no-footer-about-site-en.html"
+			},
+			{
+				"title": "Page de contenu - Masquer tout les pieds de page",
+				"language": "fr",
+				"path": "content-no-footer-about-site-fr.html"
+			},
 			{
 				"title": "Stay connected",
 				"language": "en",

--- a/docs/static-header-footer/site-assets/x-bootstrap-4.css
+++ b/docs/static-header-footer/site-assets/x-bootstrap-4.css
@@ -259,7 +259,7 @@ a.btn, .nav a {
 }
 #wb-info .brand object, #wb-info .brand img {
 	height: 40px;
-	margin-bottom: 10px;
+	margin-bottom: 2em;
 	margin-top: 20px;
 	width: auto;
 }

--- a/index-fr.md
+++ b/index-fr.md
@@ -225,13 +225,13 @@ language: fr
 	<ul>
 	{% for item in site.data.sites %}
 		{% assign list-pages = item.pages %}
-		<li>{{ item.title[ page.lang ] }} (État: {{ comp_status[ item.status ] | default: "Non définie" }})
+		<li>{{ item.title[ page.language ] }} (État: {{ comp_status[ item.status ] | default: "Non définie" }})
 		<ul>
 		{% for pgGroup in list-pages %}
 			{% assign grpkey = pgGroup[0] %}
 			<li>{{ page_group[ grpkey ] | default: "Groupe inconnu" }}
 				<ul>
-				{% assign examples = pgGroup[1] | where: "language", page.lang %}
+				{% assign examples = pgGroup[1] | where: "language", page.language %}
 				{% for example in examples %}
 					{% if example.path %}
 					<li><a href="sites/
@@ -239,9 +239,9 @@ language: fr
 									{{ item.componentName }}/
 								{%- endif -%}
 							{{ example.path }}">{{ example.title }}</a></li>
-					{% elsif example.url %}
-						<li><a href="{{ example.url }}">{{ example.title }}</a></li>
-					{% else %}
+								{% elsif example.url %}
+									<li><a href="{{ example.url }}">{{ example.title }}</a></li>
+								{% else %}
 						<li>{{ example.title }}</li>
 					{% endif %}
 				{% endfor %}

--- a/sites/footers/_base.scss
+++ b/sites/footers/_base.scss
@@ -23,7 +23,7 @@
 		object,
 		img {
 			height: 40px;
-			margin-bottom: 10px;
+			margin-bottom: 2em;
 			margin-top: 20px;
 			width: auto;
 		}

--- a/sites/footers/footers-en.html
+++ b/sites/footers/footers-en.html
@@ -1,0 +1,52 @@
+---
+{
+	"title": "Content page including complete footer",
+	"language": "en",
+	"altLangPage": "footers-fr.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true"
+}
+---
+<p>Content page presenting complete default footer including the "About gvernment" section and all utility links from "About this site" section.</p>
+
+<h2>Expected output code</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="landscape"&gt;
+		&lt;nav class="container wb-navcurr"&gt;
+			&lt;h2 class="wb-inv"&gt;About government&lt;/h2&gt;
+			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/contact.html"&gt;Contact us&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/dept.html"&gt;Departments and agencies&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/publicservice.html"&gt;Public service and military&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/news.html"&gt;News&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/system/laws.html"&gt;Treaties, laws and regulations&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/reporting.html"&gt;Government-wide reporting&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://pm.gc.ca/eng"&gt;Prime Minister&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/system.html"&gt;How government works&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://open.canada.ca/en/"&gt;Open government&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+		&lt;/nav&gt;
+	&lt;/div&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+				&lt;nav class="col-md-9 col-lg-10 ftr-urlt-lnk"&gt;
+					&lt;h2 class="wb-inv"&gt;About this site&lt;/h2&gt;
+					&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/social.html"&gt;Social media&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/en/mobile.html"&gt;Mobile applications&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www1.canada.ca/en/newsite.html"&gt;About Canada.ca&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/terms.html"&gt;Terms and conditions&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/privacy.html"&gt;Privacy&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+				&lt;/nav&gt;
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;
+					&lt;img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/footers-fr.html
+++ b/sites/footers/footers-fr.html
@@ -1,0 +1,52 @@
+---
+{
+	"title": "Page de contenu incluant le pied de page complet",
+	"language":	"fr",
+	"altLangPage": "footers-en.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true"
+}
+---
+<p>Page de contenu préstant le pied de page complet par défaut incluant la section "Au sujet du gouvernement" et les liens de la section "Au sujet de ce site".</p>
+
+<h2>Code de final attendu</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="landscape"&gt;
+		&lt;nav class="container wb-navcurr"&gt;
+			&lt;h2 class="wb-inv"&gt;Au sujet du gouvernement&lt;/h2&gt;
+			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/contact.html"&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/min.html"&gt;Ministères et organismes&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html"&gt;Fonction publique et force militaire&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/nouvelles.html"&gt;Nouvelles&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html"&gt;Traités, lois et règlements&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/rapports.html"&gt;Rapports à l'échelle du gouvernement&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://pm.gc.ca/fra"&gt;Premier ministre&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/systeme.html"&gt;Comment le gouvernement fonctionne&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://ouvert.canada.ca/"&gt;Gouvernement ouvert&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+		&lt;/nav&gt;
+	&lt;/div&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+				&lt;nav class="col-md-9 col-lg-10 ftr-urlt-lnk"&gt;
+					&lt;h2 class="wb-inv"&gt;À propos de ce site&lt;/h2&gt;
+					&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/sociaux.html"&gt;Médias sociaux&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/mobile.html"&gt;Applications mobiles&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www1.canada.ca/fr/nouveausite.html"&gt;À propos de Canada.ca&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/avis.html"&gt;Avis&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/confidentialite.html"&gt;Confidentialité&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+				&lt;/nav&gt;
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;
+					&lt;img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/includes/footer.html
+++ b/sites/footers/includes/footer.html
@@ -1,5 +1,5 @@
 <footer id="wb-info">
-{% unless page.nofooter %}
+{% unless page.noFooterAbout %}
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="wb-inv">{{ i18nText-footerAbout }}</h2>
@@ -32,6 +32,7 @@
 	<div class="brand">
 	<div class="container">
 		<div class="row ">
+{% unless page.noFooterSite %}
 			<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
 				<h2 class="wb-inv">{{ i18nText-footerSite }}</h2>
 				<ul>
@@ -50,10 +51,15 @@
 {%- endif -%}
 				</ul>
 			</nav>
+{% endunless %}
 			<div class="col-xs-6 visible-sm visible-xs tofpg">
 				<a href="#wb-cont">{{ i18nText-top }} <span class="glyphicon glyphicon-chevron-up"></span></a>
 			</div>
+{%- if page.noFooterSite == "true" -%}
+			<div class="col-xs-6 col-md-12 text-right">
+{%- else -%}
 			<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+{%- endif -%}
 				<img src="{{ setting-resourcesBasePathTheme }}/{{ i18nText-wmmsImg }}" alt="{{ i18nText-wmms }}" />
 			</div>
 		</div>

--- a/sites/footers/index.json-ld
+++ b/sites/footers/index.json-ld
@@ -1,0 +1,64 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Footers",
+		"fr": "Pieds de page"
+	},
+	"description": {
+		"en": "Documentation and working example on how to use footers.",
+		"fr": "Documentation et example pratique sur l'utilisation des pieds de page."
+	},
+	"modified": "2022-01-12",
+	"componentName": "footers",
+	"status": "stable",
+	"pages": {
+		"examples": [
+			{
+				"title": "Complete footer",
+				"language": "en",
+				"path": "footers-en.html"
+			},
+			{
+				"title": "Pied de page complet",
+				"language": "fr",
+				"path": "footers-fr.html"
+			},
+			{
+				"title": "Hide 'About government' from footer",
+				"language": "en",
+				"path": "no-footer-about-en.html"
+			},
+			{
+				"title": "Masquer 'Au sujet du gouvernement' du pied de page",
+				"language": "fr",
+				"path": "no-footer-about-fr.html"
+			},
+			{
+				"title": "Hide 'About this site' from footer",
+				"language": "en",
+				"path": "no-footer-site-en.html"
+			},
+			{
+				"title": "Masquer 'Au sujet de ce site' du pied de page ",
+				"language": "fr",
+				"path": "no-footer-site-fr.html"
+			},
+			{
+				"title": "Hide 'About government' and 'About this site' from footer",
+				"language": "en",
+				"path": "no-footers-en.html"
+			},
+			{
+				"title": "Masquer 'Au sujet du gouvernement' et 'Au sujet de ce site' du pied de page",
+				"language": "fr",
+				"path": "no-footers-fr.html"
+			}
+		]
+	}
+}

--- a/sites/footers/no-footer-about-en.html
+++ b/sites/footers/no-footer-about-en.html
@@ -1,0 +1,37 @@
+---
+{
+	"title": "Hide 'About government' section from the footer",
+	"language": "en",
+	"altLangPage": "no-footer-about-fr.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterAbout": "true"
+}
+---
+<p>By setting the <code>noFooterAbout</code> variable to "true", the 'About government' section will will be hidden on page load.</p>
+
+<h2>Expected output code</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+				&lt;nav class="col-md-9 col-lg-10 ftr-urlt-lnk"&gt;
+					&lt;h2 class="wb-inv"&gt;About this site&lt;/h2&gt;
+					&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/social.html"&gt;Social media&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/en/mobile.html"&gt;Mobile applications&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www1.canada.ca/en/newsite.html"&gt;About Canada.ca&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/terms.html"&gt;Terms and conditions&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/privacy.html"&gt;Privacy&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+				&lt;/nav&gt;
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/no-footer-about-fr.html
+++ b/sites/footers/no-footer-about-fr.html
@@ -1,0 +1,37 @@
+---
+{
+	"title": "Masquer la section 'Au sujet du gouvernement' du pied de page",
+	"language":	"fr",
+	"altLangPage": "no-footer-about-en.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterAbout": "true"
+}
+---
+<p>En définnissant la variable <code>noFooterAbout</code> à "true", la section 'Au sujet du gouvernement' sera masquée au chargement de la page.</p>
+
+<h2>Code de final attendu</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+				&lt;nav class="col-md-9 col-lg-10 ftr-urlt-lnk"&gt;
+					&lt;h2 class="wb-inv"&gt;À propos de ce site&lt;/h2&gt;
+					&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/sociaux.html"&gt;Médias sociaux&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/mobile.html"&gt;Applications mobiles&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www1.canada.ca/fr/nouveausite.html"&gt;À propos de Canada.ca&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/avis.html"&gt;Avis&lt;/a&gt;&lt;/li&gt;
+						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/confidentialite.html"&gt;Confidentialité&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+				&lt;/nav&gt;
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/no-footer-site-en.html
+++ b/sites/footers/no-footer-site-en.html
@@ -1,0 +1,44 @@
+---
+{
+	"title": "Hide utility links from 'About this site' section",
+	"language": "en",
+	"altLangPage": "no-footer-site-fr.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterSite": "true"
+}
+---
+<p>By setting the <code>noFooterSite</code> variable to "true", all utility links from 'About this site' section will be hidden on page load but the Canada wordmark will remain.</p>
+
+<h2>Expected output code</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="landscape"&gt;
+		&lt;nav class="container wb-navcurr"&gt;
+			&lt;h2 class="wb-inv"&gt;About government&lt;/h2&gt;
+			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/contact.html"&gt;Contact us&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/dept.html"&gt;Departments and agencies&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/publicservice.html"&gt;Public service and military&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/news.html"&gt;News&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/system/laws.html"&gt;Treaties, laws and regulations&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/reporting.html"&gt;Government-wide reporting&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://pm.gc.ca/eng"&gt;Prime Minister&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/system.html"&gt;How government works&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://open.canada.ca/en/"&gt;Open government&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+		&lt;/nav&gt;
+	&lt;/div&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/no-footer-site-fr.html
+++ b/sites/footers/no-footer-site-fr.html
@@ -1,0 +1,44 @@
+---
+{
+	"title": "Masquer les liens de la section 'Au sujet de ce site'",
+	"language":	"fr",
+	"altLangPage": "no-footer-site-en.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterSite": "true"
+}
+---
+<p>En définnissant la variable <code>noFooterAbout</code> à "true", les liens de la section "Au sujet de ce site" seront masqués au chargement de la page mais le mot-symbole « Canada » restera affiché.</p>
+
+<h2>Code de final attendu</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="landscape"&gt;
+		&lt;nav class="container wb-navcurr"&gt;
+			&lt;h2 class="wb-inv"&gt;Au sujet du gouvernement&lt;/h2&gt;
+			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/contact.html"&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/min.html"&gt;Ministères et organismes&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html"&gt;Fonction publique et force militaire&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/nouvelles.html"&gt;Nouvelles&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/systeme/lois.html"&gt;Traités, lois et règlements&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/rapports.html"&gt;Rapports à l'échelle du gouvernement&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://pm.gc.ca/fra"&gt;Premier ministre&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/systeme.html"&gt;Comment le gouvernement fonctionne&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href="https://ouvert.canada.ca/"&gt;Gouvernement ouvert&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
+		&lt;/nav&gt;
+	&lt;/div&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/no-footers-en.html
+++ b/sites/footers/no-footers-en.html
@@ -1,0 +1,32 @@
+---
+{
+	"title": "Hide 'About government' section and utility links from 'About this site'",
+	"language": "en",
+	"altLangPage": "no-footers-fr.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterAbout": "true",
+	"noFooterSite": "true"
+}
+---
+<p>By setting the <code>noFooterAbout</code> and <code>noFooterSite</code> variables to "true", the 'About gvernment' section and all utility links from 'About this site' will be hidden on page load but the Canada wordmark will remain.</p>
+
+<p>Also by hidding all footers, the "Skip to About this site" is disabled from the skip navigation links.</p>
+
+<h2>Expected output code</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/footers/no-footers-fr.html
+++ b/sites/footers/no-footers-fr.html
@@ -1,0 +1,32 @@
+---
+{
+	"title": "Masquer la section 'Au sujet du gouvernement' et les liens de la section 'Au sujet de ce site'",
+	"language":	"fr",
+	"altLangPage": "no-footers-en.html",
+	"breadcrumb": [
+		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
+	],
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterAbout": "true",
+	"noFooterSite": "true"
+}
+---
+<p>En définnissant les variables <code>noFooterAbout</code> et <code>noFooterSite</code> à "true", la section «&nbsp;Au sujet du gouvernement&nbsp;» et les liens de la section « Au sujet de ce site » seront masqués au chargement de la page mais le le mot-symbole « Canada » restera affiché.</p>
+
+<p>De plus, en masquant tous les pieds de page, le lien «&nbsp;Passer à 'À propos de ce site'&nbsp;» est désactivé à partir des liens «&nbsp;saut de navigation&nbsp;».</p>
+
+<h2>Code de final attendu</h2>
+<pre><code>&lt;footer id="wb-info"&gt;
+	&lt;div class="brand"&gt;
+		&lt;div class="container"&gt;
+			&lt;div class="row "&gt;
+				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
+					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/footer&gt;</code></pre>

--- a/sites/inc-skiplinks.html
+++ b/sites/inc-skiplinks.html
@@ -1,6 +1,6 @@
 <nav><ul id="wb-tphp">
 	<li class="wb-slc"><a class="wb-sl" href="#wb-cont">{{ i18nText-skipCont }}</a></li>
-{%- unless page.nofooter -%}
+{%- unless page.noFooterAbout and page.noFooterSite -%}
 	<li class="wb-slc visible-sm visible-md visible-lg"><a class="wb-sl" href="#wb-info">{{ i18nText-skipAbout }}</a></li>
 {%- endunless -%}
 {%- if page.secondarymenu -%}

--- a/templates/index.json-ld
+++ b/templates/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "Template included but need to move in its own folder.",
 		"fr": "Gabarit inclus mais qu'il nécessite qu'ils soit déplacé dans son propre dossier."
 	},
-	"modified": "2021-02-12",
+	"modified": "2021-12-09",
 	"status": "stable",
 	"pages": {
 		"examples": [
@@ -84,9 +84,6 @@
 				"language": "fr",
 				"path": "content-signedon-fr.html"
 			},
-
-
-
 			{
 				"title": "Stay connected",
 				"language": "en",
@@ -97,7 +94,6 @@
 				"language": "fr",
 				"path": "widgets-fr.html"
 			},
-
 			{
 				"title": "[Theme title]",
 				"language": "en",


### PR DESCRIPTION
- A new variable 'noFooterSite' has been created in order to hide all utility links from 'About this site' section.
- The `noFooter` variable has been updated to `noFooterAbout` to be consistent with sections name.
- A working example for each footer options have been created

**Release note:**

When using `noFooterSite` to hide utility links from the footer, in order to keep the wordmark in place, the `col-lg-2` is removed and `col-md-3` is replaced by `col-md-12` from the `div` element