### PR TITLE
GC Subway: Add documentation about the two hyperlinks per item

### DIFF
--- a/components/gc-subway/docs-en.html
+++ b/components/gc-subway/docs-en.html
@@ -13,7 +13,16 @@
 <p>In order to use the provisional subway map navigation, you will need to complete the following steps:</p>
 <ol>
 	<li>First, you'll need a <code>&lt;nav&gt;</code> element with both the <code>"provisional"</code> and the <code>"gc-subway"</code> classes. Inside of that <code>&lt;nav&gt;</code>, put your first <code>&lt;h1&gt;</code>; it will be the smaller, gray-ish, upper one.</li>
-	<li>Add a <code>&lt;ul&gt;</code> next to that <code>&lt;h1&gt;</code>. Put the links to your other pages related to that service initiation template in there.</li>
+	<li>Add a <code>&lt;ul&gt;</code> next to that <code>&lt;h1&gt;</code>.</li>
+	<li>Each list item should contain the links to your set of pages targeted by the subway map navigation, as such:
+		<code>
+			&lt;a href="the-link-to-your-page.html"&gt;[Page 1]&lt;/a&gt;
+		</code>.Optionally, you could offer an SPA feel when the user is on mobile by adding a second hyperlink with an anchor to the first H1, like so:
+		<code>
+			&lt;a href="the-link-to-your-page.html#gc-document-nav" class="visible-xs visible-sm"&gt;[Page 1]&lt;/a&gt;
+		</code>. If you do go forward with this option, make sure to hide the regular link (the one without the anchor) on small devices with the following class attribute:
+		<code>class="hidden-xs hidden-sm"</code>, and the new one to be visible only on small screen devices (as shown in the HTML code snippet above already).
+	</li>
 	<li>The rest just needs your own main content for that page. Do not forget the navigation buttons at the bottom of the pages. If you want the left column to stop being at 2/3 of the width on desktop at some point, then you can stop the propagation by using any HTML element with a <code>"gc-subway-section-end"</code> class on it; that element needs to be a sibling of your <code>&lt;nav class="gc-subway"&gt;</code>.</li>
 	<li>If you want to use the new bold short red underline underneath your regular H1, then add both the <code>"provisional"</code> and <code>"gc-thickline"</code> classes on it.</li>
 </ol>

--- a/components/gc-subway/docs-fr.html
+++ b/components/gc-subway/docs-fr.html
@@ -13,7 +13,16 @@
 <p>Afin d'utiliser la fonctionalité provisoire de navigation de style métro, vous devrez suivre les étapes suivantes:</p>
 <ol>
 	<li>Tout d'abord, vous aurez besoin d'un élément <code>&lt;nav&gt;</code> avec les classes <code>"provisoire"</code> et <code>"gc-subway"</code>. À l'intérieur de ce <code>&lt;nav&gt;</code>, mettez votre premier <code>&lt;h1&gt;</code>; il sera le plus petit, grisâtre et placé au haut de la page.</li>
-	<li>Ajoutez un <code>&lt;ul&gt;</code> à côté de ce <code>&lt;h1&gt;</code>. Placez-y les liens vers vos autres pages liées à la page de lancement de service.</li>
+	<li>Ajoutez un <code>&lt;ul&gt;</code> à côté de ce <code>&lt;h1&gt;</code>.</li>
+	<li>Chaque élément de la liste doit contenir les liens vers votre ensemble de pages ciblées par la navigation de style métro, comme suit:
+		<code>
+			&lt;a href="le-lien-vers-votre-page.html"&gt;[Page 1]&lt;/a&gt;
+		</code>. Optionnellement, vous pouvez offrir une sensation d'application monopage lorsque l'utilisateur est sur mobile en ajoutant un deuxième lien hypertexte avec une ancre au premier H1, comme ceci:
+		<code>
+			&lt;a href="le-lien-vers-votre-page.html#gc-document-nav" class="visible-xs visible-sm"&gt;[Page 1]&lt;/a&gt;
+		</code>. Si vous continuez avec cette option, assurez-vous de masquer le lien normal (celui sans l'ancre) sur les petits appareils avec l'attribut de classe suivant:
+		<code>class="hidden-xs hidden-sm"</code>, et le nouveau n'est visible que sur les appareils à petit écran (comme indiqué déjà dans l'extrait de code HTML ci-dessus).
+		</li>
 	<li>Le reste a juste besoin de votre propre contenu principal pour cette page. N'oubliez pas les boutons de navigation en bas des pages. Si vous voulez que la colonne de gauche cesse d'être aux 2/3 de la largeur d'un écran de bureau, vous pouvez alors arrêter la propagation en utilisant n'importe quel élément HTML avec une classe <code>"gc-subway-section-end"</code>; cet élément doit être un frère de votre <code>"&lt;nav class="gc-subway"&gt;</code>.</li>
 	<li>Si vous souhaitez utiliser le nouveau soulignement rouge court et gras sous votre H1, ajoutez-y les classes <code>"provisoire"</code> et <code>"gc-thickline"</code>.</li>
 </ol>


### PR DESCRIPTION
GC Subway: Add documentation about the two hyperlinks per item.

GC Subway working example has two hyperlinks for every bullet. Each hyperlink show up at different breakpoints, one is to offer an SPA feel when user is on mobile by having an anchor on an H1 and the other is the same link with no anchor, which is for regular surfing on a computer.

The goal of this PR is to document this choice of having two hyperlinks per item, and that it is optional. An item could have just one hyperlink without the anchor.
