### PR TITLE
Page feedback tool: Revamp

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -326,6 +326,50 @@
 }
 ,{
 	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Page feedback tool",
+		"fr": "Outil de rétroaction sur la page"
+	},
+	"description": {
+		"en": "Page feedback tool for Canada.ca",
+		"fr": "Outil de rétroaction sur la page pour Canada.ca"
+	},
+	"modified": "2022-12-06",
+	"componentName": "gc-page-feedback",
+	"status": "stable",
+	"pages": {
+		"examples": [
+			{
+				"title": "Page feedback tool",
+				"language": "en",
+				"path": "gc-page-feedback-en.html"
+			},
+			{
+				"title": "Outil de rétroaction sur la page",
+				"language": "fr",
+				"path": "gc-page-feedback-fr.html"
+			},
+			{
+				"title": "Page feedback tool with custom parameters",
+				"language": "en",
+				"path": "gc-page-feedback-custom-en.html"
+			},
+			{
+				"title": "Outil de rétroaction sur la page avec paramètres personnalisés",
+				"language": "fr",
+				"path": "gc-page-feedback-custom-fr.html"
+			}
+		]
+	}
+}
+,{
+	"@context": {
 		"@version": 2.0,
 		"dct": "http://purl.org/dc/terms/",
 		"title": { "@id": "dct:title", "@container": "@language" },

--- a/_includes/gc-page-feedback/gc-page-feedback.html
+++ b/_includes/gc-page-feedback/gc-page-feedback.html
@@ -1,0 +1,12 @@
+<!--
+NOTES:
+-For testing/ease of development
+-Only works when pageDetails is enabled in "/sites/gc-page-feedback/*.html"
+-Remove this file before merging
+-->
+{%- if page.dir == "/sites/gc-page-feedback/" -%}
+	{%- include_relative includes/css.html -%}
+	{%- include_relative includes/gc-page-feedback.html -%}
+{%- else -%}
+	<p><strong>Error:</strong> The page feedback tool only can only be activated in pages located at "sites/gc-page-feedback/*.html".</p>
+{%- endif -%}

--- a/_includes/page-details/footer.html
+++ b/_includes/page-details/footer.html
@@ -1,3 +1,8 @@
+<!--
+NOTES:
+-For testing/ease of development
+-Remove this file before merging
+-->
 <footer class="pagedetails{% if include.addContainer %} container{% endif %}">
 	<h2 class="wb-inv">{{ i18nText-pageDetails }}</h2>
 

--- a/components/provisional-en.html
+++ b/components/provisional-en.html
@@ -7,7 +7,7 @@
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2021-01-19",
+	"dateModified": "2022-12-06",
 	"share": "true"
 }
 ---
@@ -93,9 +93,16 @@
 	</tr>
 	<tr>
 		<th>Template <code>.gc-pg-hlpfl</code></th>
-		<td>"Page success widget" design pattern to let users share their experience on the page.</td>
+		<td>
+			<p>"Page success widget" design pattern to let users share their experience on the page.</p>
+			<p>Feature has been revised and renamed to "page feedback tool" (<code>.gc-pft</code>):</p>
+			<ul>
+				<li><a href="../sites/gc-page-feedback/gc-page-feedback-en.html">Page feedback tool - Canada.ca site functionality</a></li>
+				<li><a href="../sites/gc-page-feedback/gc-page-feedback-custom-en.html">Page feedback tool with custom parameters - Canada.ca site functionality</a></li>
+			</ul>
+		</td>
 		<td>v7.0</td>
-		<td></td>
+		<td>Stable (vX.X.X) (TODO)</td>
 	</tr>
 	<tr>
 		<th>Plugin <code>.wb-chtwzrd</code></th>
@@ -401,81 +408,4 @@ if ( s.getTime() &lt; msT && msT &lt; e.getTime() ) {
 	<p class="h1">
 		<span class="glyphicon glyphicon-warning-sign provisional icon-warning-light mrgn-rght-md"></span> With "provisional icon-warning-light" class
 	</p>
-</div>
-<h3 id="gc-pg-hlpfl">Page success widget</h3>
-<p>Planned to eventually replace Report a problem. Uses multiple features: <code>wb-postback</code> and <code>data-wb-doaction</code> plugins, as well as <code>nojs-*</code> styles and Font Awesome.</p>
-<div class="row row-no-gutters mrgn-tp-xl">
-	<div class="col-sm-7 col-lg-6">
-		<section class="provisional gc-pg-hlpfl">
-			<div class="well mrgn-bttm-0">
-				<form id="gc-pg-hlpfl-frm" action="index-en.html" method="post" autocomplete="off" class="provisional wb-postback" data-wb-postback="{&quot;success&quot;:&quot;.gc-pg-hlpfl-thnk&quot;,&quot;content&quot;:&quot;#gc-pg-hlpfl-frm&quot;}">
-					<input type="hidden" name="pageTitle" value="Provisional functionality - GCWeb theme">
-					<input type="hidden" name="submissionPage" value="https://wet-boew.github.io/themes-dist/GCWeb/provisional-en.html">
-					<input type="hidden" name="tid" value="1234">
-					<input type="hidden" name="auke" value="5678">
-					<div class="gc-pg-hlpfl-btn">
-						<div class="row row-no-gutters">
-							<div class="col-xs-12 col-sm-7 mrgn-tp-sm">
-								<h2 class="mrgn-tp-sm h5">Did you find what you were looking for?</h2>
-							</div>
-							<div class="col-xs-8 col-sm-5 text-right">
-								<button type="submit" name="helpful" value="Yes" class="btn btn-primary">Yes</button>
-								<button type="button" class="btn btn-primary mrgn-lft-sm nojs-hide" data-wb-doaction="[
-									{&quot;action&quot;:&quot;removeClass&quot;,&quot;source&quot;:&quot;.gc-pg-hlpfl-no&quot;,&quot;class&quot;:&quot;nojs-show&quot;},
-									{&quot;action&quot;:&quot;addClass&quot;,&quot;source&quot;:&quot;.gc-pg-hlpfl-btn&quot;,&quot;class&quot;:&quot;hide&quot;}
-								]">No</button>
-							</div>
-						</div>
-					</div>
-					<p class="h3 hidden nojs-show">If not, tell us why:</p>
-					<div class="gc-pg-hlpfl-no nojs-show">
-						<fieldset>
-							<legend class="h4 mrgn-tp-0 mrgn-bttm-md">What was wrong?</legend>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem01" type="radio" value="The answer I need is missing">
-									The answer I need is missing
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem02" type="radio" value="The information isn’t clear">
-									The information isn’t clear
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem03" type="radio" value="I’m not in the right place">
-									I’m not in the right place
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem04" type="radio" value="Something is broken or incorrect">
-									Something is broken or incorrect
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem05" type="radio" value="Other reason">
-									Other reason
-								</label>
-							</div>
-						</fieldset>
-						<label for="problem06">Please provide more details</label>
-						<p class="small">
-							<strong>(Don’t include any personal information)</strong>
-							<br>
-							<span class="small">Maximum 300 characters</span>
-						</p>
-						<textarea name="details" id="problem06" class="full-width" maxlength="300"></textarea>
-						<button type="submit" name="helpful" value="No" class="btn btn-primary mrgn-tp-md mrgn-bttm-sm">Submit</button>
-					</div>
-				</form>
-				<div class="gc-pg-hlpfl-thnk hide">
-					<p class="h6 mrgn-tp-sm mrgn-bttm-sm"><span class="far fa-check-circle text-success mrgn-rght-sm" aria-hidden="true"></span> Thank you for your feedback</p>
-				</div>
-			</div>
-		</section>
-	</div>
 </div>

--- a/components/provisional-fr.html
+++ b/components/provisional-fr.html
@@ -7,7 +7,7 @@
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2021-01-19",
+	"dateModified": "2022-12-06",
 	"share": "true"
 }
 ---
@@ -95,9 +95,16 @@
 		</tr>
 		<tr>
 			<th>Gabarit <code>.gc-pg-hlpfl</code></th>
-			<td>"Widget succès de page" configuration de conception pour laisser les utilisateurs partager leur expérience sur la page.</td>
+			<td>
+				<p>"Widget succès de page" configuration de conception pour laisser les utilisateurs partager leur expérience sur la page.</p>
+				<p>Cette fonctionnalité a été révisée et renommée «&nbsp;outil de rétroaction sur la page&nbsp;» (<code>.gc-pft</code>)&nbsp;:</p>
+				<ul>
+					<li><a href="../sites/gc-page-feedback/gc-page-feedback-fr.html">Outil de rétroaction sur la page - Fonctionnalité du site Canada.ca</a></li>
+					<li><a href="../sites/gc-page-feedback/gc-page-feedback-custom-fr.html">Outil de rétroaction sur la page avec paramètres personnalisés - Fonctionnalité du site Canada.ca</a></li>
+				</ul>
+			</td>
 			<td>v7.0</td>
-			<td></td>
+			<td>Stable (vX.X.X) (TODO)</td>
 		</tr>
 		<tr>
 			<th>Plugin <code>.wb-chtwzrd</code></th>
@@ -406,83 +413,5 @@ if ( s.getTime() &lt; msT && msT &lt; e.getTime() ) {
 		<p class="h1">
 			<span class="glyphicon glyphicon-warning-sign provisional icon-warning-light mrgn-rght-md"></span> With "provisional icon-warning-light" class
 		</p>
-	</div>
-</div>
-<h3 id="gc-pg-hlpfl">Widget succès de page</h3>
-<p>Est prévu pour remplacer Signaler un problème ou une erreur sur cette page éventuellement. Utilises plusieurs fonctionnalités&nbsp;: les plugiciels <code>wb-postback</code> et <code>data-wb-doaction</code>, ainsi que les styles <code>nojs-*</code> puis Font Awesome.</p>
-<div class="row row-no-gutters mrgn-tp-xl">
-	<div class="col-sm-7 col-lg-6">
-		<section class="provisional gc-pg-hlpfl">
-			<div class="well mrgn-bttm-0">
-				<form id="gc-pg-hlpfl-frm" action="index-fr.html" method="get" autocomplete="off" class="provisional wb-postback" data-wb-postback="{&quot;success&quot;:&quot;.gc-pg-hlpfl-thnk&quot;,&quot;content&quot;:&quot;#gc-pg-hlpfl-frm&quot;}">
-					<input type="hidden" name="pageTitle" value="Fonctionalités provisoires - Thème de GCWeb">
-					<input type="hidden" name="submissionPage" value="https://wet-boew.github.io/themes-dist/GCWeb/provisional-fr.html">
-					<input type="hidden" name="tid" value="1234">
-					<input type="hidden" name="auke" value="5678">
-					<div class="gc-pg-hlpfl-btn">
-						<div class="row row-no-gutters">
-							<div class="col-xs-12 col-sm-7 mrgn-tp-sm">
-								<h2 class="mrgn-tp-sm h5">Avez-vous trouvé ce que vous cherchiez?</h2>
-							</div>
-							<div class="col-xs-8 col-sm-5 text-right">
-								<button type="submit" name="helpful" value="Yes" class="btn btn-primary">Oui</button>
-								<button type="button" class="btn btn-primary mrgn-lft-sm nojs-hide" data-wb-doaction="[
-									{&quot;action&quot;:&quot;removeClass&quot;,&quot;source&quot;:&quot;.gc-pg-hlpfl-no&quot;,&quot;class&quot;:&quot;nojs-show&quot;},
-									{&quot;action&quot;:&quot;addClass&quot;,&quot;source&quot;:&quot;.gc-pg-hlpfl-btn&quot;,&quot;class&quot;:&quot;hide&quot;}
-								]">Non</button>
-							</div>
-						</div>
-					</div>
-					<p class="h3 hidden nojs-show">Sinon, dites nous pourquoi&nbsp;:</p>
-					<div class="gc-pg-hlpfl-no nojs-show">
-						<fieldset>
-							<legend class="h4 mrgn-tp-0 mrgn-bttm-md">Qu’est-ce qui n’allait pas?</legend>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem01" type="radio" value="I can’t find what I’m looking for">
-									La réponse dont j’ai besoin n’est pas là
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem02" type="radio" value="The information isn’t clear">
-									L'information n'est pas claire
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem03" type="radio" value="I’m not in the right place">
-									Je ne suis pas au bon endroit
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem04" type="radio" value="Something is broken or incorrect">
-									Quelque chose est brisé ou incorrect
-								</label>
-							</div>
-							<div class="radio">
-								<label>
-									<input name="problem" id="problem05" type="radio" value="Other reason">
-									Autre raison
-								</label>
-							</div>
-						</fieldset>
-						<label for="problem06">Veuillez fournir plus de détails</label>
-						<p class="small">
-							<strong>(N’incluez pas d’information personnelle)</strong>
-							<br>
-							<span class="small">Maximum de 300 caractères</span>
-						</p>
-						<textarea name="details" id="problem06" class="full-width" maxlength="300"></textarea>
-						<br>
-						<button type="submit" name="helpful" value="No" class="btn btn-primary mrgn-tp-md mrgn-bttm-sm">Soumettre</button>
-					</div>
-				</form>
-				<div class="gc-pg-hlpfl-thnk hide">
-					<p class="h6 mrgn-tp-sm mrgn-bttm-sm"><span class="far fa-check-circle text-success mrgn-rght-sm" aria-hidden="true"></span> Merci de vos commentaires</p>
-				</div>
-			</div>
-		</section>
 	</div>
 </div>

--- a/sites/gc-page-feedback/_base.scss
+++ b/sites/gc-page-feedback/_base.scss
@@ -1,0 +1,24 @@
+/*
+  @title: Page feedback tool - Base
+ */
+
+/* In noscript/basic HTML mode... */
+.no-js,
+.wb-disable {
+	.gc-pft {
+		/* Disable row gutters (default selector isn't specific-enough) */
+		.row-no-gutters {
+			@extend .row-no-gutters;
+		}
+
+		/* Make the legend full width */
+		.nojs-col-sm-12 {
+			@extend .col-sm-12;
+		}
+
+		/* Left-align the legend and yes/no buttons */
+		.nojs-text-left {
+			text-align: left;
+		}
+	}
+}

--- a/sites/gc-page-feedback/_print.scss
+++ b/sites/gc-page-feedback/_print.scss
@@ -1,0 +1,7 @@
+/*
+  @title: Page feedback tool - Print view
+ */
+
+.gc-pft {
+	@extend %gcweb-print-display-none-important;
+}

--- a/sites/gc-page-feedback/_screen-sm-min.scss
+++ b/sites/gc-page-feedback/_screen-sm-min.scss
@@ -1,0 +1,14 @@
+/*
+  @title: Page feedback tool - Small view and over
+ */
+
+/* In noscript/basic HTML mode... */
+.no-js,
+.wb-disable {
+	.gc-pft {
+		/* Disable the legend's right padding */
+		.nojs-pr-sm-0 {
+			padding-right: 0 !important;
+		}
+	}
+}

--- a/sites/gc-page-feedback/gc-page-feedback-custom-en.html
+++ b/sites/gc-page-feedback/gc-page-feedback-custom-en.html
@@ -1,0 +1,29 @@
+---
+{
+	"altLangPage": "gc-page-feedback-custom-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
+	],
+	"css": ["https://use.fontawesome.com/releases/v5.15.4/css/all.css"],
+	"dateModified": "2022-12-06",
+	"description": "Page feedback tool for Canada.ca",
+	"language": "en",
+	"title": "Page feedback tool with custom parameters",
+	"pageFeedback": {
+		"institutionopt": "Custom institution",
+		"themeopt": "Custom theme",
+		"sectionopt": "Custom section",
+		"pageTitle": "true",
+		"language": "true",
+		"submissionPage": "true"
+	}
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>HTML code</h2>
+{%- comment -%} Manually-included variable-core.liquid so that gc-page-feedback.html's code sample can use the i18nText-lang variable {%- endcomment -%}
+{% include variable-core.liquid %}
+{% highlight text %}
+{% include_relative includes/gc-page-feedback.html %}
+{% endhighlight %}

--- a/sites/gc-page-feedback/gc-page-feedback-custom-fr.html
+++ b/sites/gc-page-feedback/gc-page-feedback-custom-fr.html
@@ -1,0 +1,29 @@
+---
+{
+	"altLangPage": "gc-page-feedback-custom-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
+	],
+	"css": ["https://use.fontawesome.com/releases/v5.15.4/css/all.css"],
+	"dateModified": "2022-12-06",
+	"description": "Outil de rétroaction sur la page pour Canada.ca",
+	"language": "fr",
+	"title": "Outil de rétroaction sur la page avec paramètres personnalisés",
+	"pageFeedback": {
+		"institutionopt": "Institution personnalisée",
+		"themeopt": "Thème personnalisé",
+		"sectionopt": "Section personnalisée",
+		"pageTitle": "true",
+		"language": "true",
+		"submissionPage": "true"
+	}
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>Code HTML</h2>
+{%- comment -%} Manually-included variable-core.liquid so that gc-page-feedback.html's code sample can use the i18nText-lang variable {%- endcomment -%}
+{% include variable-core.liquid %}
+{% highlight text %}
+{% include_relative includes/gc-page-feedback.html %}
+{% endhighlight %}

--- a/sites/gc-page-feedback/gc-page-feedback-en.html
+++ b/sites/gc-page-feedback/gc-page-feedback-en.html
@@ -1,0 +1,23 @@
+---
+{
+	"altLangPage": "gc-page-feedback-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
+	],
+	"css": ["https://use.fontawesome.com/releases/v5.15.4/css/all.css"],
+	"dateModified": "2022-12-06",
+	"description": "Page feedback tool for Canada.ca",
+	"language": "en",
+	"title": "Page feedback tool",
+	"pageFeedback": "true",
+	"share": "true"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>HTML code</h2>
+{%- comment -%} Manually-included variable-core.liquid so that gc-page-feedback.html's code sample can use the i18nText-lang variable {%- endcomment -%}
+{% include variable-core.liquid %}
+{% highlight text %}
+{% include_relative includes/gc-page-feedback.html %}
+{% endhighlight %}

--- a/sites/gc-page-feedback/gc-page-feedback-fr.html
+++ b/sites/gc-page-feedback/gc-page-feedback-fr.html
@@ -1,0 +1,23 @@
+---
+{
+	"altLangPage": "gc-page-feedback-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
+	],
+	"css": ["https://use.fontawesome.com/releases/v5.15.4/css/all.css"],
+	"dateModified": "2022-12-06",
+	"description": "Outil de rétroaction sur la page pour Canada.ca",
+	"language": "fr",
+	"title": "Outil de rétroaction sur la page",
+	"pageFeedback": "true",
+	"share": "true"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>Code HTML</h2>
+{%- comment -%} Manually-included variable-core.liquid so that gc-page-feedback.html's code sample can use the i18nText-lang variable {%- endcomment -%}
+{% include variable-core.liquid %}
+{% highlight text %}
+{% include_relative includes/gc-page-feedback.html %}
+{% endhighlight %}

--- a/sites/gc-page-feedback/includes/css.html
+++ b/sites/gc-page-feedback/includes/css.html
@@ -1,0 +1,121 @@
+<style>
+/* Custom CSS for testing on GitHub Pages - should be equivalent to updated SCSS files */
+
+/*----------*/
+
+/* sites/page-details/_base.scss */
+/*
+ * Share/feedback-specific overrides
+ */
+
+/* Undo the old report a problem well selector */
+.pagedetails .well {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+/* More specific well selector for report a problem (to prevent a conflict with the page feedback tool's well) */
+.pagedetails details .well {
+	margin-left: -1.1em;
+	margin-right: -1.1em;
+}
+
+/*----------*/
+
+/* sites/page-details/_screen-sm-min.scss */
+@media screen and (min-width: 768px) {
+	/*
+	 * Share/feedback-specific overrides (small view and over)
+	 */
+
+	/* Add a larger top margin on the share button (only if its plugin has initialized) if adjacent to the page feedback tool. */
+	.pagedetails div:has(.gc-pft) + .wb-share-inited {
+		margin-top: 29px;
+	}
+}
+
+/*----------*/
+
+/* sites/page-details/_screen-md-min.scss */
+@media screen and (min-width: 992px) {
+	/*
+	 * Share/feedback-specific overrides (medium view and over)
+	 */
+
+	/* Add a larger top margin on the share button (only if its plugin has initialized) if adjacent to the page feedback tool. */
+	.pagedetails div:has(.gc-pft) + .wb-share-inited {
+		margin-top: 21px;
+	}
+}
+
+/*----------*/
+
+/* sites/gc-page-feedback/_base.scss */
+/*
+  @title: Page feedback tool - Base
+ */
+
+/* In noscript/basic HTML mode...*/
+
+/* Disable row gutters (default selector isn't specific-enough) */
+.no-js .gc-pft .row-no-gutters [class*="col-"],
+.wb-disable .gc-pft .row-no-gutters [class*="col-"] {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+/* Make the legend full width */
+.no-js .gc-pft .nojs-col-sm-12,
+.wb-disable .gc-pft .nojs-col-sm-12 {
+	position: relative;
+	min-height: 1px;
+	padding-right: 15px;
+	padding-left: 15px;
+}
+
+/* Left-align the legend and yes/no buttons */
+.no-js .gc-pft .nojs-text-left,
+.wb-disable .gc-pft .nojs-text-left {
+	text-align: left;
+}
+
+@media (min-width: 768px) {
+	.no-js .gc-pft .nojs-col-sm-12,
+	.wb-disable .gc-pft .nojs-col-sm-12 {
+		float: left;
+	}
+
+	.no-js .gc-pft .nojs-col-sm-12,
+	.wb-disable .gc-pft .nojs-col-sm-12 {
+		width: 100%;
+	}
+}
+
+/*----------*/
+
+/* sites/gc-page-feedback/_screen-sm-min.scss */
+@media screen and (min-width: 768px) {
+	/*
+	  @title: Page feedback tool - Small view and over
+	 */
+
+	/* Disable the legend's right padding */
+	.no-js .gc-pft .nojs-pr-sm-0,
+	.wb-disable .gc-pft .nojs-pr-sm-0 {
+		padding-right: 0 !important;
+	}
+}
+
+/*----------*/
+
+/* sites/gc-page-feedback/_print.scss */
+@media print {
+	/*
+	  @title: Page feedback tool - Print view
+	 */
+
+	.gc-pft {
+		display: none !important;
+	}
+}
+</style>

--- a/sites/gc-page-feedback/includes/gc-page-feedback.html
+++ b/sites/gc-page-feedback/includes/gc-page-feedback.html
@@ -1,0 +1,62 @@
+{%- include_relative includes/parameters.liquid -%}
+{%- include_relative includes/strings.liquid -%}
+
+<div class="gc-pft row">
+	<div class="col-sm-10 col-md-9 col-lg-8">
+		<section class="well mrgn-bttm-0" aria-live="polite">
+			<h3 class="wb-inv">{{ pft_h3 }}</h3>
+			<form id="gc-pft-frm" action="https://pagesuccessemailqueue.azurewebsites.net/api/QueueProblemForm" method="post" class="wb-postback" data-wb-postback='{"success":".gc-pft-thnk","content":"#gc-pft-frm"}'>
+				<input type="hidden" name="institutionopt" value="{{ pft_institutionopt_value }}" />
+				<input type="hidden" name="themeopt" value="{{ pft_themeopt_value }}" />
+				<input type="hidden" name="sectionopt" value="{{ pft_sectionopt_value }}" />
+				<input type="hidden" name="pageTitle" value="{{ pft_pageTitle_value }}" />
+				<input type="hidden" name="language" value="{{ pft_language_value }}" />
+				<input type="hidden" name="submissionPage" value="{{ pft_submissionPage_value }}" />
+				<fieldset class="gc-pft-btns chkbxrdio-grp row row-no-gutters d-sm-flex flex-sm-wrap align-items-sm-center">
+					<legend class="col-xs-12 col-sm-7 nojs-col-sm-12 col-md-9 col-lg-8 text-center text-sm-left nojs-text-left mrgn-tp-sm pr-sm-3 nojs-pr-sm-0"><span class="field-name">{{ pft_legend }}</span></legend>
+					<div class="col-xs-12 nojs-show">
+						<button type="submit" name="helpful" value="{{ pft_yes_value }}" class="btn btn-primary" aria-describedby="why-note">{{ pft_yes }}</button>
+					</div>
+					<div class="col-xs-12 col-sm-5 col-md-3 col-lg-4 text-center text-sm-right nojs-hide">
+						<button type="submit" name="helpful" value="{{ pft_yes_value }}" class="btn btn-primary mrgn-tp-sm mrgn-bttm-sm">{{ pft_yes }}</button>
+						<button type="button" class="btn btn-primary mrgn-tp-sm mrgn-bttm-sm mrgn-lft-sm" data-wb-doaction='[
+							{"action":"removeClass","source":".gc-pft-no","class":"nojs-show"},
+							{"action":"addClass","source":".gc-pft-btns","class":"hide"}
+						]'>{{ pft_no }}</button>
+					</div>
+				</fieldset>
+				<div class="gc-pft-no nojs-show">
+					<p id="why-note" class="nojs-show mrgn-tp-lg mrgn-bttm-md"><strong>{{ pft_why_note_nojs }}</strong></p>
+					<p class="nojs-hide wb-inv"><strong>{{ pft_why_note_js }}</strong></p>
+					<div aria-live="off">
+						<fieldset class="chkbxrdio-grp">
+							<legend><span class="field-name">{{ pft_no_legend }}</span></legend>
+							<div class="radio">
+								<label for="problem1"><input name="problem" id="problem1" type="radio" value="{{ pft_problem1_value }}" /> {{ pft_problem1_label }}</label>
+							</div>
+							<div class="radio">
+								<label for="problem2"><input name="problem" id="problem2" type="radio" value="{{ pft_problem2_value }}" /> {{ pft_problem2_label }}</label>
+							</div>
+							<div class="radio">
+								<label for="problem3"><input name="problem" id="problem3" type="radio" value="{{ pft_problem3_value }}" /> {{ pft_problem3_label }}</label>
+							</div>
+							<div class="radio">
+								<label for="problem4"><input name="problem" id="problem4" type="radio" value="{{ pft_problem4_value }}" /> {{ pft_problem4_label }}</label>
+							</div>
+							<input type="hidden" name="problem" value="" />
+						</fieldset>
+						<div class="form-group">
+							<label for="problem6" class="mrgn-tp-sm mrgn-bttm-0"><span class="field-name">{{ pft_problem6_label }}</span></label>
+							<textarea id="problem6" aria-describedby="problem6-note" name="details" class="form-control full-width" maxlength="300"></textarea>
+							<p id="problem6-note"><small>{{ pft_problem6_note }}</small></p>
+						</div>
+						<button name="helpful" value="{{ pft_no_value }}" class="btn btn-primary">{{ pft_submit }}</button>
+					</div>
+				</div>
+			</form>
+			<div class="gc-pft-thnk hide">
+				<p class="mrgn-tp-sm mrgn-bttm-0"><span class="far fa-check-circle text-success mrgn-rght-sm" aria-hidden="true"></span> {{ pft_submit_message }}</p>
+			</div>
+		</section>
+	</div>
+</div>

--- a/sites/gc-page-feedback/includes/parameters.liquid
+++ b/sites/gc-page-feedback/includes/parameters.liquid
@@ -1,0 +1,57 @@
+{%- comment -%}
+Set parameter variables
+{%- endcomment -%}
+
+{%- capture pft_institutionopt_value -%}
+	{%- if page.pageFeedback.institutionopt -%}
+		{{ page.pageFeedback.institutionopt }}
+	{%- else -%}
+		Institution - required - must use same abbreviation value EN and FR
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture pft_themeopt_value -%}
+	{%- if page.pageFeedback.themeopt -%}
+		{{ page.pageFeedback.themeopt }}
+	{%- else -%}
+		Theme - required - must use same value EN and FR
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture pft_sectionopt_value -%}
+	{%- if page.pageFeedback.sectionopt -%}
+		{{ page.pageFeedback.sectionopt }}
+	{%- else -%}
+		Section - required but can be blank - same value EN and FR
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture pft_pageTitle_value -%}
+	{%- if page.pageFeedback.pageTitle == "true" -%}
+		{{ page.title }}
+	{%- elsif page.pageFeedback.title -%}
+		{{ page.pageFeedback.pageTitle }}
+	{%- else -%}
+		Page title (EN) - required
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture pft_language_value -%}
+	{%- if page.pageFeedback.language == "true" -%}
+		{{ i18nText-lang }}
+	{%- elsif page.pageFeedback.language -%}
+		{{ page.pageFeedback.language }}
+	{%- else -%}
+		Language - required - use EN or FR
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture pft_submissionPage_value -%}
+	{%- if page.pageFeedback.submissionPage == "true" -%}
+		{{ page.url | absolute_url }}
+	{%- elsif page.pageFeedback.submissionPage -%}
+		{{ page.pageFeedback.submissionPage }}
+	{%- else -%}
+		Page URL - required
+	{%- endif -%}
+{%- endcapture -%}

--- a/sites/gc-page-feedback/includes/strings.liquid
+++ b/sites/gc-page-feedback/includes/strings.liquid
@@ -1,0 +1,58 @@
+{%- comment -%}
+Set string variables
+{%- endcomment -%}
+
+{%- assign pft_yes_en = "Yes" -%}
+{%- assign pft_no_en = "No" -%}
+{%- assign pft_problem1_label_en = "I can’t <strong>find</strong> the information" -%}
+{%- assign pft_problem2_label_en = "The information is hard to <strong>understand</strong>" -%}
+{%- assign pft_problem3_label_en = "There was an error or something <strong>didn’t work</strong>" -%}
+{%- assign pft_problem4_label_en = "Other reason" -%}
+
+{%- assign pft_yes_fr = "Oui" -%}
+{%- assign pft_no_fr = "Non" -%}
+{%- assign pft_problem1_label_fr = "Je ne peux pas <strong>trouver</strong> l’information" -%}
+{%- assign pft_problem2_label_fr = "L’information est difficile à <strong>comprendre</strong>" -%}
+{%- assign pft_problem3_label_fr = "Il y avait une erreur ou quelque chose <strong>ne fonctionnait pas</strong>" -%}
+{%- assign pft_problem4_label_fr = "Autre raison" -%}
+
+{%- assign pft_yes_value = pft_yes_en | append: "-" | append: pft_yes_fr -%}
+{%- assign pft_no_value = pft_no_en | strip_html | append: "-" | append: pft_no_fr | strip_html -%}
+{%- assign pft_problem1_value = pft_problem1_label_en | strip_html | append: "-" | append: pft_problem1_label_fr | strip_html -%}
+{%- assign pft_problem2_value = pft_problem2_label_en | strip_html | append: "-" | append: pft_problem2_label_fr | strip_html -%}
+{%- assign pft_problem3_value = pft_problem3_label_en | strip_html | append: "-" | append: pft_problem3_label_fr | strip_html -%}
+{%- assign pft_problem4_value = pft_problem4_label_en | strip_html | append: "-" | append: pft_problem4_label_fr | strip_html -%}
+
+{%- if i18nText-lang == "en" -%}
+	{%- assign pft_h3 = "Page feedback" -%}
+	{%- assign pft_legend = "Did you find what you were looking for?" -%}
+	{%- assign pft_yes = pft_yes_en -%}
+	{%- assign pft_no = pft_no_en -%}
+	{%- assign pft_why_note_nojs = "If not, tell us why below:" -%}
+	{%- assign pft_why_note_js = "Tell us why below:" -%}
+	{%- assign pft_no_legend = "What was wrong?" -%}
+	{%- assign pft_problem1_label = pft_problem1_label_en -%}
+	{%- assign pft_problem2_label = pft_problem2_label_en -%}
+	{%- assign pft_problem3_label = pft_problem3_label_en -%}
+	{%- assign pft_problem4_label = pft_problem4_label_en -%}
+	{%- assign pft_problem6_label = "Please provide more details (maximum 300 characters)" -%}
+	{%- assign pft_problem6_note = "You will not receive a reply. Telephone numbers and email addresses will be removed." -%}
+	{%- assign pft_submit = "Submit" -%}
+	{%- assign pft_submit_message = "Thank you for your feedback." -%}
+{%- elsif i18nText-lang == "fr" -%}
+	{%- assign pft_h3 = "Rétroaction sur la page" -%}
+	{%- assign pft_legend = "Avez-vous trouvé ce que vous cherchiez?" -%}
+	{%- assign pft_yes = pft_yes_fr -%}
+	{%- assign pft_no = pft_no_fr -%}
+	{%- assign pft_why_note_nojs = "Sinon, dites nous pourquoi ci-dessous&nbsp;:" -%}
+	{%- assign pft_why_note_js = "Dites nous pourquoi ci-dessous&nbsp;:" -%}
+	{%- assign pft_no_legend = "Qu’est-ce qui n’allait pas?" -%}
+	{%- assign pft_problem1_label = pft_problem1_label_fr -%}
+	{%- assign pft_problem2_label = pft_problem2_label_fr -%}
+	{%- assign pft_problem3_label = pft_problem3_label_fr -%}
+	{%- assign pft_problem4_label = pft_problem4_label_fr -%}
+	{%- assign pft_problem6_label = "Veuillez fournir plus de détails (maximum de 300 caractères)" -%}
+	{%- assign pft_problem6_note = "Vous ne recevrez aucune réponse. Les numéros de téléphone et les adresses électroniques seront supprimés." -%}
+	{%- assign pft_submit = "Soumettre" -%}
+	{%- assign pft_submit_message = "Merci de vos commentaires." -%}
+{%- endif -%}

--- a/sites/gc-page-feedback/index.json-ld
+++ b/sites/gc-page-feedback/index.json-ld
@@ -1,0 +1,44 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Page feedback tool",
+		"fr": "Outil de rétroaction sur la page"
+	},
+	"description": {
+		"en": "Page feedback tool for Canada.ca",
+		"fr": "Outil de rétroaction sur la page pour Canada.ca"
+	},
+	"modified": "2022-12-06",
+	"componentName": "gc-page-feedback",
+	"status": "stable",
+	"pages": {
+		"examples": [
+			{
+				"title": "Page feedback tool",
+				"language": "en",
+				"path": "gc-page-feedback-en.html"
+			},
+			{
+				"title": "Outil de rétroaction sur la page",
+				"language": "fr",
+				"path": "gc-page-feedback-fr.html"
+			},
+			{
+				"title": "Page feedback tool with custom parameters",
+				"language": "en",
+				"path": "gc-page-feedback-custom-en.html"
+			},
+			{
+				"title": "Outil de rétroaction sur la page avec paramètres personnalisés",
+				"language": "fr",
+				"path": "gc-page-feedback-custom-fr.html"
+			}
+		]
+	}
+}

--- a/sites/page-details/_base.scss
+++ b/sites/page-details/_base.scss
@@ -76,15 +76,15 @@ main {
 		}
 	}
 
-	.well {
-		margin: {
-			left: -$details-identation;
-			right: -$details-identation;
-		}
-	}
-
 	details {
 		margin-bottom: 0;
+
+		.well {
+			margin: {
+				left: -$details-identation;
+				right: -$details-identation;
+			}
+		}
 	}
 
 	// Add a top margin on the share button (only if its plugin has initialized).

--- a/sites/page-details/_screen-md-min.scss
+++ b/sites/page-details/_screen-md-min.scss
@@ -1,0 +1,16 @@
+/*
+ * Share/feedback-specific overrides (medium view and over)
+ */
+
+/* Add a larger top margin on the share button (only if its plugin has initialized) if adjacent to the page feedback tool. */
+.pagedetails {
+	div {
+		&:has( .gc-pft ) {
+			+ {
+				.wb-share-inited {
+					margin-top: 21px;
+				}
+			}
+		}
+	}
+}

--- a/sites/page-details/_screen-sm-min.scss
+++ b/sites/page-details/_screen-sm-min.scss
@@ -1,0 +1,16 @@
+/*
+ * Share/feedback-specific overrides (small view and over)
+ */
+
+/* Add a larger top margin on the share button (only if its plugin has initialized) if adjacent to the page feedback tool. */
+.pagedetails {
+	div {
+		&:has( .gc-pft ) {
+			+ {
+				.wb-share-inited {
+					margin-top: 29px;
+				}
+			}
+		}
+	}
+}

--- a/sites/theme.scss
+++ b/sites/theme.scss
@@ -74,6 +74,7 @@
 @import "search/base";
 @import "secondary-menu/base";
 @import "page-details/base";
+@import "gc-page-feedback/base";
 @import "gcweb-menu/base";
 @import "authentication/base";
 @import "header/base";
@@ -332,6 +333,7 @@
 
 	@import "baseline/lists/screen-md-min";
 	@import "gcweb-menu/screen-md-min";
+	@import "page-details/screen-md-min";
 
 	@import "wet-boew/src/plugins/feeds/screen-md-min";
 	@import "wet-boew/src/plugins/tabs/screen-md-min";
@@ -392,6 +394,8 @@
 	@import "../misc/views/screen-sm-min-to-screen-sm-max";
 
 	@import "search/screen-sm-min-to-screen-sm-max";
+	@import "page-details/screen-sm-min";
+	@import "gc-page-feedback/screen-sm-min";
 
 	@import "../templates/campaign/screen-sm-min-to-screen-sm-max";
 
@@ -441,6 +445,7 @@
 	@import "search/print";
 	@import "secondary-menu/print";
 	@import "page-details/print";
+	@import "gc-page-feedback/print";
 
 	@import "wet-boew/src/plugins/footnotes/print";
 	@import "wet-boew/src/plugins/geomap/print";


### PR DESCRIPTION
**Progress checklist:**
https://github.com/wet-boew/GCWeb/pull/1916#issuecomment-1154473960

**General:**
* Rename "page success widget" to "page feedback tool"
* Turn it into a site component

**Jekyll:**
* Change the tool into an include
* Use sub-includes for parameter/string variable declarations
* Add a ``pageFeedback`` variable to enable the tool in page templates
* Add ``pageFeedback`` sub-variables to optionally override the default values of the tool's form parameters:
  * ``institutionopt``
  * ``themeopt``
  * ``sectionopt``
  * ``pageTitle`` (``true`` re-uses the current page's title, without " - Canada.ca")
  * ``language`` (``true`` re-uses the current page's language)
  * ``submissionPage`` (``true`` re-uses the current page's URL)
* Update the page details footer include to accommodate the tool:
  * Declare ``col-modified = "col-xs-12"`` only once at the beginning of variable assignments
  * Support ``pageFeedback`` and prioritize it over report a problem
  * Make ``pageFeedback`` take priority over ``noReportProblem`` (i.e. setting former to ``true`` and latter to ``false`` will show the page feedback tool)

**SCSS:**
* Add new classes (tied to the ``gc-pft`` class):
  * ``nojs-col-sm-12``
  * ``nojs-pr-sm-0``
  * ``nojs-text-left``
* Increase the share widget's top margin to make it look vertically-centered when used alongside the tool in small/medium view and over
  * Depends on the ``has()`` pseudo-class

**HTML:**
* Rename the ``gc-pg-hlpfl`` id/class prefix to ``gc-pft``
* Rename the ``gc-pg-hlpfl-btn`` class to ``gc-pft-btns`` ("s" suffix)
* Use a ``fieldset`` for "Did you find what you were looking for?" and its yes/no buttons
* Change "Did you find what you were looking for?" into a legend
* Improve layout:
  * Remove heading classes
  * Use form classes (i.e. ``chkbxrdio-grp``, ``field-name`` and ``form-group``)
  * Increase spacing between groups of content
  * Move the details field's secondary information paragraph below the field
  * JS mode:
    * Center-align "Did you find what you were looking for?" in extra-small view
    * Vertically-center "Did you find what you were looking for?" and yes/no buttons in small view and over
  * Noscript/Basic HTML mode:
    * Position the yes button directly below "Did you find what you were looking for?" in all views
* Use ``aria-live`` regions to announce transition messages to screen reader users:
  * "Tell us why below:" upon pressing the no button
  * "Thank you for your feedback." upon pressing the yes button or submitting the no button's questionnaire
* Add ``aria-describedby`` attributes to:
  * Programmatically-associate the yes button to the "If not, tell us why below:" paragraph in noscript/basic HTML mode (to make screen readers announce the no button's instructions right after the yes button)
  * Programmatically-associate the secondary information paragraph to the more details field

**Content:**
* Add a visually-hidden "Page feedback" ``H3`` heading
* Add a period to the end of "Thank you for your feedback"
* Add "below" to the end of "If not, tell us why:" in noscript/basic HTML mode
* Add a visually-hidden "Tell us why below:" paragraph in JS mode
* Combine "Please provide more details" and "Maximum 300 characters" into the same label
* Write all values in an "EN-FR" format, derived from labels

**Demo pages:**
* Add a standard demo page (``pageFeedback`` enabled)
* Add a custom demo page (``pageFeedback`` with sub-variables)

**Provisional functionality page:**
* Portray the widget as stable in the feature availability table
* Remove "page success widget" section/example

CC @HamzaAburaneh @LanaStewa @delisma