### PR TITLE
WCAG Upgrade SC.1.4.12 - Removal of important from certain class

### DIFF
--- a/components/gc-subway/_base.scss
+++ b/components/gc-subway/_base.scss
@@ -77,7 +77,7 @@
 
 			dd {
 				border-left: 4px solid #26374a;
-				line-height: inherit !important;
+				line-height: inherit;
 				margin-bottom: 0px;
 				margin-top: -3px;
 				padding: 0px 20px 20px 1em;
@@ -91,7 +91,7 @@
 			li {
 				@include dt-li(30px, .05em, 1.2em, 1.4em, -.05em, 1.4em);
 				&::first-line {
-					line-height: 1 !important;
+					line-height: 1;
 				}
 				&:last-child {
 					border-bottom: 4px solid #26374a;

--- a/sites/helpers/_base.scss
+++ b/sites/helpers/_base.scss
@@ -3,17 +3,17 @@
  */
 
 .margin-bottom-none {
-	margin-bottom: 0 !important;
+	margin-bottom: 0;
 }
 
 .margin-bottom-small {
-	margin-bottom: .25em !important;
+	margin-bottom: .25em;
 }
 
 .margin-top-large {
-	margin-top: 1.5em !important;
+	margin-top: 1.5em;
 }
 
 .margin-top-medium {
-	margin-top: .75em !important;
+	margin-top: .75em;
 }


### PR DESCRIPTION
Related to: 
PR# https://github.com/wet-boew/wet-boew/pull/9262
Removal of useless '!important' to certain class to ensure proper testing of WCAG 2.1 success criterion SC.1.4.12 Text Spacing. 