### PR TITLE
Package: Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "post": "grunt"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wet-boew/GCWeb.git"
+  },
   "license": "MIT",
   "dependencies": {
     "bootstrap-sass": "3.4.1",


### PR DESCRIPTION
Avoids a "No repository field" warning when running ``npm install``.