### PR TITLE
Repo: Fix outdated breadcrumbs/language toggles

### DIFF
--- a/components/components-en.html
+++ b/components/components-en.html
@@ -2,11 +2,8 @@
 {
 	"title": "Components page",
 	"language": "en",
-	"altLangPrefix": "components",
+	"altLangPage": "components-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2021-09-28",
 	"share": "true"

--- a/components/components-fr.html
+++ b/components/components-fr.html
@@ -2,11 +2,8 @@
 {
 	"title": "Page de composantes",
 	"language":	"fr",
-	"altLangPrefix": "components",
+	"altLangPage": "components-en.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2021-09-28",
 	"share": "true"

--- a/components/deprecated-en.html
+++ b/components/deprecated-en.html
@@ -2,10 +2,7 @@
 {
 	"title": "Deprecated markup",
 	"language": "en",
-	"altLangPrefix": "deprecated",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
+	"altLangPage": "deprecated-fr.html",
 	"secondlevel": false,
 	"dateModified": "2018-03-21",
 	"share": "true"

--- a/components/deprecated-fr.html
+++ b/components/deprecated-fr.html
@@ -2,10 +2,7 @@
 {
 	"title": "Balisage déconseillé",
 	"language": "fr",
-	"altLangPrefix": "deprecated",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
+	"altLangPage": "deprecated-en.html",
 	"secondlevel": false,
 	"dateModified": "2018-03-21",
 	"share": "true"

--- a/components/gc-feeds/gc-feeds-en.html
+++ b/components/gc-feeds/gc-feeds-en.html
@@ -1,5 +1,5 @@
 ---
-breadcrumb: [
+breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
 ]
 dateModified: "2021-06-02"

--- a/components/gc-feeds/gc-feeds-fr.html
+++ b/components/gc-feeds/gc-feeds-fr.html
@@ -1,5 +1,5 @@
 ---
-breadcrumb: [
+breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
 ]
 dateModified: "2021-06-02"

--- a/components/gc-most-requested/gc-most-requested-en.html
+++ b/components/gc-most-requested/gc-most-requested-en.html
@@ -1,5 +1,5 @@
 ---
-breadcrumb: [
+breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
 ]
 dateModified: "2021-05-21"

--- a/components/gc-most-requested/gc-most-requested-fr.html
+++ b/components/gc-most-requested/gc-most-requested-fr.html
@@ -1,5 +1,5 @@
 ---
-breadcrumb: [
+breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
 ]
 dateModified: "2021-05-21"

--- a/components/gc-servinfo/gc-srvinfo-examples.html
+++ b/components/gc-servinfo/gc-srvinfo-examples.html
@@ -2,10 +2,9 @@
 {
 	"title": "Services and information - Working examples",
 	"language": "en",
-	"altLangPrefix": "gc-srvinfo-examples",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" },
-		{ "title": "gc-srvinfo", "link": "gc-srvinfo.html" }
+		{ "title": "gc-srvinfo", "link": "components/gc-servinfo/gc-srvinfo.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-01-16",

--- a/components/gc-servinfo/gc-srvinfo.html
+++ b/components/gc-servinfo/gc-srvinfo.html
@@ -2,8 +2,7 @@
 {
 	"title": "Services and information - Common design pattern",
 	"language": "en",
-	"altLangPrefix": "gc-servinfo",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/components/gc-subway/gc-subway-en.html
+++ b/components/gc-subway/gc-subway-en.html
@@ -5,9 +5,6 @@
 	"altLangPage": "gc-subway-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2021-10-15",
 	"share": "true"
 }

--- a/components/gc-subway/gc-subway-fr.html
+++ b/components/gc-subway/gc-subway-fr.html
@@ -5,9 +5,6 @@
 	"altLangPage": "gc-subway-en.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2021-10-15",
 	"share": "true"
 }

--- a/components/gc-subway/index-en.html
+++ b/components/gc-subway/index-en.html
@@ -6,9 +6,6 @@
 	"parentdir": "gc-subway",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"breadcrumb": [
-	{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2020-12-07",
 	"share": "true"
 }

--- a/components/gc-subway/index-fr.html
+++ b/components/gc-subway/index-fr.html
@@ -6,9 +6,6 @@
 	"parentdir": "gc-subway",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"breadcrumb": [
-	{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2020-12-07",
 	"share": "true"
 }

--- a/components/gc-subway/page2-en.html
+++ b/components/gc-subway/page2-en.html
@@ -5,9 +5,6 @@
 	"altLangPage": "page2-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2021-10-15",
 	"share": "true"

--- a/components/gc-subway/page2-fr.html
+++ b/components/gc-subway/page2-fr.html
@@ -5,9 +5,6 @@
 	"altLangPage": "page2-en.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2021-10-15",
 	"share": "true"

--- a/components/header-rwd/well-header-rwd-en.html
+++ b/components/header-rwd/well-header-rwd-en.html
@@ -2,8 +2,8 @@
 {
 	"title": "Well header responsive - GCWeb theme",
 	"language": "en",
-	"altLangPrefix": "well-header-rwd",
-	"breadcrumb": [
+	"altLangPage": "well-header-rwd-fr.html",
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/components/header-rwd/well-header-rwd-fr.html
+++ b/components/header-rwd/well-header-rwd-fr.html
@@ -2,8 +2,8 @@
 {
 	"title": "Entête well responsive - Thème de GCWeb",
 	"language": "fr",
-	"altLangPrefix": "well-header-rwd",
-	"breadcrumb": [
+	"altLangPage": "well-header-rwd-en.html",
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,

--- a/components/list/list-en.html
+++ b/components/list/list-en.html
@@ -2,8 +2,8 @@
 {
 	"title": "List - Additional style - GCWeb theme V5",
 	"language": "en",
-	"altLangPrefix": "list",
-	"breadcrumb": [
+	"altLangPage": "list-fr.html",
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/components/list/list-fr.html
+++ b/components/list/list-fr.html
@@ -2,8 +2,8 @@
 {
 	"title": "Liste - Style additionel - Thème de GCWeb V5",
 	"language": "fr",
-	"altLangPrefix": "list",
-	"breadcrumb": [
+	"altLangPage": "list-en.html",
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,

--- a/components/provisional-en.html
+++ b/components/provisional-en.html
@@ -2,8 +2,8 @@
 {
 	"title": "Provisional functionality - GCWeb theme",
 	"language": "en",
-	"altLangPrefix": "provisional",
-	"breadcrumb": [
+	"altLangPage": "provisional-fr.html",
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/components/provisional-fr.html
+++ b/components/provisional-fr.html
@@ -2,8 +2,8 @@
 {
 	"title": "Fonctionalités provisoires - Thème de GCWeb",
 	"language": "fr",
-	"altLangPrefix": "provisional",
-	"breadcrumb": [
+	"altLangPage": "provisional-en.html",
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,

--- a/components/redacted-en.html
+++ b/components/redacted-en.html
@@ -2,8 +2,8 @@
 {
 	"title": "Redacted text",
 	"language": "en",
-	"altLangPrefix": "redacted",
-	"breadcrumb": [
+	"altLangPage": "redacted-fr.html",
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"description": "Guidance on how to code redacted text.",

--- a/components/redacted-fr.html
+++ b/components/redacted-fr.html
@@ -2,8 +2,8 @@
 {
 	"title": "Texte caviardé",
 	"language": "en",
-	"altLangPrefix": "redacted",
-	"breadcrumb": [
+	"altLangPage": "redacted-en.html",
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "index-fr.html" }
 	],
 	"description": "Ligne directrice sur le codage de texte caviarder (ou expurgé).",

--- a/components/tbl-floatcolumn-en.html
+++ b/components/tbl-floatcolumn-en.html
@@ -2,11 +2,8 @@
 {
 	"title": "Float column in a data table",
 	"language": "en",
-	"altLangPrefix": "tbl-floatcolumn",
+	"altLangPage": "tbl-floatcolumn-fr.html",
 	"css": ["https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome"],
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2018-10-10",
 	"share": "true"
 }

--- a/components/tbl-floatcolumn-fr.html
+++ b/components/tbl-floatcolumn-fr.html
@@ -2,11 +2,8 @@
 {
 	"title": "Float column in a data table",
 	"language": "en",
-	"altLangPrefix": "tbl-floatcolumn",
+	"altLangPage": "tbl-floatcolumn-en.html",
 	"css": ["https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome"],
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2018-10-10",
 	"share": "true"
 }

--- a/components/video-en.html
+++ b/components/video-en.html
@@ -2,10 +2,7 @@
 {
 	"title": "Video example",
 	"language": "en",
-	"altLangPrefix": "video",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
+	"altLangPage": "video-fr.html",
 	"dateModified": "2019-09-06",
 	"share": "true"
 }

--- a/components/video-fr.html
+++ b/components/video-fr.html
@@ -2,10 +2,7 @@
 {
 	"title": "Exemple de vidéo",
 	"language": "fr",
-	"altLangPrefix": "video",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
+	"altLangPage": "video-en.html",
 	"dateModified": "2019-09-06",
 	"share": "true"
 }

--- a/components/wb-chtwzrd/chatwizard-en.html
+++ b/components/wb-chtwzrd/chatwizard-en.html
@@ -5,7 +5,7 @@ category: "Plugins"
 description: "Working example - provisional feature"
 tag: "chatwizard"
 parentdir: "chatwizard"
-altLangPrefix: "chatwizard"
+altLangPage: "chatwizard-fr.html"
 dateModified: "2020-04-16"
 ---
 

--- a/components/wb-chtwzrd/chatwizard-fr.html
+++ b/components/wb-chtwzrd/chatwizard-fr.html
@@ -5,7 +5,7 @@ category: "Plugiciels"
 description: "Example pratique d'utilisation du chat wizard"
 tag: "chatwizard"
 parentdir: "chatwizard"
-altLangPrefix: "chatwizard"
+altLangPage: "chatwizard-en.html"
 dateModified: "2020-04-16"
 ---
 {% include alert-provisional.html provisionaldir="../" %}

--- a/components/wb-chtwzrd/chatwizard-json-en.html
+++ b/components/wb-chtwzrd/chatwizard-json-en.html
@@ -5,7 +5,7 @@ category: "Plugins"
 description: "Working example - provisional feature"
 tag: "chatwizard"
 parentdir: "chatwizard"
-altLangPrefix: "chatwizard-json"
+altLangPage: "chatwizard-json-fr.html"
 dateModified: "2020-04-16"
 ---
 {% include alert-provisional.html provisionaldir="../" %}

--- a/components/wb-chtwzrd/chatwizard-json-fr.html
+++ b/components/wb-chtwzrd/chatwizard-json-fr.html
@@ -5,7 +5,7 @@ category: "Plugiciels"
 description: "Example pratique d'utilisation du chat wizard"
 tag: "chatwizard"
 parentdir: "chatwizard"
-altLangPrefix: "chatwizard-json"
+altLangPage: "chatwizard-json-en.html"
 dateModified: "2020-04-16"
 ---
 {% include alert-provisional.html provisionaldir="../" %}

--- a/components/wb-data-json/data-json-doc-en.html
+++ b/components/wb-data-json/data-json-doc-en.html
@@ -5,7 +5,7 @@
 	"category": "Plugins",
 	"categoryfile": "plugins",
 	"description": "Insert content extracted from a JSON file and leverage HTML 5 template element.",
-	"altLangPrefix": "data-json-doc",
+	"altLangPage": "data-json-doc-fr.html",
 	"dateModified": "2017-01-31"
 }
 ---

--- a/components/wb-data-json/data-json-doc-fr.html
+++ b/components/wb-data-json/data-json-doc-fr.html
@@ -5,7 +5,7 @@
 	"category": "Plugiciels",
 	"categoryfile": "plugins",
 	"description": "Insertion de contenu extrait d'un fichier JSON et prends avantage de l'élément template du HTML 5.",
-	"altLangPrefix": "data-json-doc",
+	"altLangPage": "data-json-doc-en.html",
 	"dateModified": "2017-01-31"
 }
 ---

--- a/components/wb-data-json/data-json-en.html
+++ b/components/wb-data-json/data-json-en.html
@@ -6,7 +6,7 @@
 	"description": "Insert content extracted from a JSON file.",
 	"tag": "data-json",
 	"parentdir": "data-json",
-	"altLangPrefix": "data-json",
+	"altLangPage": "data-json-fr.html",
 	"dateModified": "2017-01-31"
 }
 ---

--- a/components/wb-data-json/data-json-fr.html
+++ b/components/wb-data-json/data-json-fr.html
@@ -6,7 +6,7 @@
 	"description": "Insertion de contenu extrait d'un fichier JSON",
 	"tag": "data-json",
 	"parentdir": "data-json",
-	"altLangPrefix": "data-json",
+	"altLangPage": "data-json-en.html",
 	"dateModified": "2017-01-31"
 }
 ---

--- a/components/wb-data-json/template-en.html
+++ b/components/wb-data-json/template-en.html
@@ -6,7 +6,7 @@
 	"description": "Leverage HTML 5 template element by using the data json plugin.",
 	"tag": "data-json",
 	"parentdir": "data-json",
-	"altLangPrefix": "template",
+	"altLangPage": "template-fr.html",
 	"dateModified": "2020-03-02"
 }
 ---

--- a/components/wb-data-json/template-fr.html
+++ b/components/wb-data-json/template-fr.html
@@ -6,7 +6,7 @@
 	"description": "Prendre avantage de l'élément template du HTML 5 avec le plugiciel data json",
 	"tag": "data-json",
 	"parentdir": "data-json",
-	"altLangPrefix": "template",
+	"altLangPage": "template-en.html",
 	"dateModified": "2022-03-02"
 }
 ---

--- a/components/wb-doaction/doaction-doc-en.html
+++ b/components/wb-doaction/doaction-doc-en.html
@@ -5,7 +5,7 @@
 	"category": "Plugins",
 	"categoryfile": "plugins",
 	"description": "Execute action, like filter a table, based on pre-established set of configuration.",
-	"altLangPrefix": "doaction-doc",
+	"altLangPage": "doaction-doc-fr.html",
 	"dateModified": "2019-09-04"
 }
 ---

--- a/components/wb-doaction/doaction-doc-fr.html
+++ b/components/wb-doaction/doaction-doc-fr.html
@@ -5,7 +5,7 @@
 	"category": "Plugiciels",
 	"categoryfile": "plugins",
 	"description": "Exécute des actions, tel que filtrer un tableau, selon une configuration pré-établis.",
-	"altLangPrefix": "doaction-doc",
+	"altLangPage": "doaction-doc-en.html",
 	"dateModified": "2017-07-16"
 }
 ---

--- a/components/wb-doaction/json-en.html
+++ b/components/wb-doaction/json-en.html
@@ -6,7 +6,7 @@
 	"description": "Execute JSON loading and patching action through the JSON manager",
 	"tag": "doaction",
 	"parentdir": "doaction",
-	"altLangPrefix": "json",
+	"altLangPage": "json-fr.html",
 	"dateModified": "2019-09-05"
 }
 ---

--- a/components/wb-doaction/json-fr.html
+++ b/components/wb-doaction/json-fr.html
@@ -6,7 +6,7 @@
 	"description": "Execute JSON loading and patching action through the JSON manager",
 	"tag": "doaction",
 	"parentdir": "doaction",
-	"altLangPrefix": "json",
+	"altLangPage": "json-en.html",
 	"dateModified": "2019-09-05"
 }
 ---

--- a/components/wb-doaction/tblfilter-en.html
+++ b/components/wb-doaction/tblfilter-en.html
@@ -6,7 +6,7 @@
 	"description": "Execute action, like filter a table, based on pre-established set of configuration.",
 	"tag": "doaction",
 	"parentdir": "doaction",
-	"altLangPrefix": "tblfilter",
+	"altLangPage": "tblfilter-fr.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-doaction/tblfilter-fr.html
+++ b/components/wb-doaction/tblfilter-fr.html
@@ -6,7 +6,7 @@
 	"description": "Exécute des actions, tel que filtrer un tableau, selon une configuration pré-établis.",
 	"tag": "doaction",
 	"parentdir": "doaction",
-	"altLangPrefix": "tblfilter",
+	"altLangPage": "tblfilter-en.html",
 	"dateModified": "2017-07-16"
 }
 ---

--- a/components/wb-fieldflow/advanced-en.html
+++ b/components/wb-fieldflow/advanced-en.html
@@ -6,7 +6,7 @@ category: "Plugins"
 description: "How to go beyond with field flow."
 tag: "fieldflow"
 parentdir: "fieldflow"
-altLangPrefix: "advanced"
+altLangPage: "advanced-fr.html"
 dateModified: "2016-11-30"
 ---
 <ul class="list-inline">

--- a/components/wb-fieldflow/advanced-fr.html
+++ b/components/wb-fieldflow/advanced-fr.html
@@ -6,7 +6,7 @@ category: "Plugiciels"
 description: "Comment aller au-delà avec le déroulement de champs."
 tag: "fieldflow"
 parentdir: "fieldflow"
-altLangPrefix: "advanced"
+altLangPage: "advanced-en.html"
 dateModified: "2016-11-30"
 ---
 <ul class="list-inline">

--- a/components/wb-fieldflow/basic-en.html
+++ b/components/wb-fieldflow/basic-en.html
@@ -6,7 +6,7 @@ category: "Plugins"
 description: "How to use field flow to create small scale user interaction."
 tag: "fieldflow"
 parentdir: "fieldflow"
-altLangPrefix: "basic"
+altLangPage: "basic-fr.html"
 dateModified: "2016-11-30"
 ---
 <ul class="list-inline">

--- a/components/wb-fieldflow/basic-fr.html
+++ b/components/wb-fieldflow/basic-fr.html
@@ -6,7 +6,7 @@ category: "Plugiciels"
 description: "Comment utiliser le déroulement de champs afin de créer des interaction utilisateur à petite échèle."
 tag: "fieldflow"
 parentdir: "fieldflow"
-altLangPrefix: "basic"
+altLangPage: "basic-en.html"
 dateModified: "2016-11-30"
 ---
 <ul class="list-inline">

--- a/components/wb-jsonmanager/jsonmanager-doaction-en.html
+++ b/components/wb-jsonmanager/jsonmanager-doaction-en.html
@@ -6,7 +6,7 @@
 	"description": "Manage dataset and apply JSON Patch with DoAction plugin",
 	"tag": "jsonmanager",
 	"parentdir": "jsonmanager",
-	"altLangPrefix": "jsonmanager-doaction",
+	"altLangPage": "jsonmanager-doaction-fr.html",
 	"dateModified": "2020-10-12"
 }
 ---

--- a/components/wb-jsonmanager/jsonmanager-doaction-fr.html
+++ b/components/wb-jsonmanager/jsonmanager-doaction-fr.html
@@ -6,7 +6,7 @@
 	"description": "Gérer des jeux de données et applique des correctifs JSON avec l'exécuteur d'action de patches.",
 	"tag": "jsonmanager",
 	"parentdir": "jsonmanager",
-	"altLangPrefix": "jsonmanager-doaction",
+	"altLangPage": "jsonmanager-doaction-en.html",
 	"dateModified": "2020-10-12"
 }
 ---

--- a/components/wb-jsonmanager/jsonmanager-doc-en.html
+++ b/components/wb-jsonmanager/jsonmanager-doc-en.html
@@ -5,7 +5,7 @@
 	"category": "Plugins",
 	"categoryfile": "plugins",
 	"description": "Manage dataset and apply JSON Patch",
-	"altLangPrefix": "jsonmanager-doc",
+	"altLangPage": "jsonmanager-doc-fr.html",
 	"dateModified": "2017-02-02"
 }
 ---

--- a/components/wb-jsonmanager/jsonmanager-doc-fr.html
+++ b/components/wb-jsonmanager/jsonmanager-doc-fr.html
@@ -5,7 +5,7 @@
 	"category": "Plugiciels",
 	"categoryfile": "plugins",
 	"description": "Gérer des jeux de données et applique des correctifs JSON.",
-	"altLangPrefix": "jsonmanager-doc",
+	"altLangPage": "jsonmanager-doc-en.html",
 	"dateModified": "2017-02-02"
 }
 ---

--- a/components/wb-jsonmanager/jsonmanager-en.html
+++ b/components/wb-jsonmanager/jsonmanager-en.html
@@ -6,7 +6,7 @@
 	"description": "Manage dataset and apply JSON Patch",
 	"tag": "jsonmanager",
 	"parentdir": "jsonmanager",
-	"altLangPrefix": "jsonmanager",
+	"altLangPage": "jsonmanager-fr.html",
 	"dateModified": "2017-02-02"
 }
 ---

--- a/components/wb-jsonmanager/jsonmanager-fr.html
+++ b/components/wb-jsonmanager/jsonmanager-fr.html
@@ -6,7 +6,7 @@
 	"description": "Gérer des jeux de données et applique des correctifs JSON.",
 	"tag": "jsonmanager",
 	"parentdir": "jsonmanager",
-	"altLangPrefix": "jsonmanager",
+	"altLangPage": "jsonmanager-en.html",
 	"dateModified": "2017-02-02"
 }
 ---

--- a/components/wb-suggest/suggest-fr.html
+++ b/components/wb-suggest/suggest-fr.html
@@ -3,7 +3,7 @@
 	"title": "Suggestion interative avec un datalist",
 	"language": "en",
 	"description": "Chargement de suggestion pour un datalist avec un fichier JSON.",
-	"altLangPage": "suggest-fr.html",
+	"altLangPage": "suggest-en.html",
 	"dateModified": "2021-04-20"
 }
 ---

--- a/components/wb-urlmapping/ajax-en.html
+++ b/components/wb-urlmapping/ajax-en.html
@@ -6,7 +6,7 @@
 	"description": "Execute pre-configured ajax action based on url query string.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "ajax",
+	"altLangPage": "ajax-fr.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/ajax-fr.html
+++ b/components/wb-urlmapping/ajax-fr.html
@@ -6,7 +6,7 @@
 	"description": "Exécute des requête ajax pré-établis selon la correspondance des paramètres de l'URL.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "ajax",
+	"altLangPage": "ajax-en.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/geomap-en.html
+++ b/components/wb-urlmapping/geomap-en.html
@@ -6,7 +6,7 @@
 	"description": "Execute pre-configured geomap filtering based on url query string.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "geomap",
+	"altLangPage": "geomap-fr.html",
 	"dateModified": "2019-03-20"
 }
 ---

--- a/components/wb-urlmapping/geomap-fr.html
+++ b/components/wb-urlmapping/geomap-fr.html
@@ -6,7 +6,7 @@
 	"description": "Exécute des requête de filtrage de géomap pré-établis selon la correspondance des paramètres de l'URL.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "geomap",
+	"altLangPage": "geomap-en.html",
 	"dateModified": "2019-03-20"
 }
 ---

--- a/components/wb-urlmapping/patches-en.html
+++ b/components/wb-urlmapping/patches-en.html
@@ -6,7 +6,7 @@
 	"description": "Execute pre-configured patches action based on url query string.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "patches",
+	"altLangPage": "patches-fr.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/patches-fr.html
+++ b/components/wb-urlmapping/patches-fr.html
@@ -6,7 +6,7 @@
 	"description": "Exécute des requête d'application de correctifs JSON pré-établis selon la correspondance des paramètres de l'URL.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "patches",
+	"altLangPage": "patches-en.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/tblfilter-en.html
+++ b/components/wb-urlmapping/tblfilter-en.html
@@ -6,7 +6,7 @@
 	"description": "Execute pre-configured table filtering action based on url query string.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "tblfilter",
+	"altLangPage": "tblfilter-fr.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/tblfilter-fr.html
+++ b/components/wb-urlmapping/tblfilter-fr.html
@@ -6,7 +6,7 @@
 	"description": "Exécute des requête de filtrage de tableau pré-établis selon la correspondance des paramètres de l'URL.",
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
-	"altLangPrefix": "tblfilter",
+	"altLangPage": "tblfilter-en.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/urlmapping-doc-en.html
+++ b/components/wb-urlmapping/urlmapping-doc-en.html
@@ -5,7 +5,7 @@
 	"category": "Plugins",
 	"categoryfile": "plugins",
 	"description": "Execute pre-configured action based on url query string.",
-	"altLangPrefix": "urlmapping-doc",
+	"altLangPage": "urlmapping-doc-fr.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/wb-urlmapping/urlmapping-doc-fr.html
+++ b/components/wb-urlmapping/urlmapping-doc-fr.html
@@ -5,7 +5,7 @@
 	"category": "Plugiciels",
 	"categoryfile": "plugins",
 	"description": "Exécute des requête pré-établis selon la correspondance des paramètres de l'URL.",
-	"altLangPrefix": "urlmapping-doc",
+	"altLangPage": "urlmapping-doc-en.html",
 	"dateModified": "2017-02-03"
 }
 ---

--- a/components/well-bold/well-bold-en.html
+++ b/components/well-bold/well-bold-en.html
@@ -1,5 +1,5 @@
 ---
-breadcrumb: [
+breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
 ]
 dateModified: "2021-05-25"

--- a/components/well-bold/well-bold-fr.html
+++ b/components/well-bold/well-bold-fr.html
@@ -1,5 +1,5 @@
 ---
-breadcrumb: [
+breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
 ]
 dateModified: "2021-05-25"

--- a/docs/GCWeb-en.html
+++ b/docs/GCWeb-en.html
@@ -5,7 +5,7 @@
 	"category": "Themes",
 	"categoryfile": "themesstyle",
 	"description": "This theme implements the layout and design requirements for Canada.ca.",
-	"altLangPrefix": "GCWeb",
+	"altLangPage": "GCWeb-fr.html",
 	"dateModified": "2014-10-09"
 }
 ---

--- a/docs/GCWeb-fr.html
+++ b/docs/GCWeb-fr.html
@@ -5,7 +5,7 @@
 	"category": "Thèmes",
 	"categoryfile": "themesstyle",
 	"description": "Ce thème met en place la mise en page et la mise en forme exigés pour le site Canada.ca.",
-	"altLangPrefix": "GCWeb",
+	"altLangPage": "GCWeb-en.html",
 	"dateModified": "2014-10-09"
 }
 ---

--- a/docs/developing-fr.md
+++ b/docs/developing-fr.md
@@ -3,7 +3,7 @@
 	"title": "Developing for GCWeb",
 	"language": "fr",
 	"description": "Instructions sur comment développer pour le thème de Canada.ca.",
-	"altLangPage": "developing-fr.html",
+	"altLangPage": "developing-en.html",
 	"dateModified": "2021-12-03"
 }
 ---

--- a/docs/evaluation-report/1-accessibility.html
+++ b/docs/evaluation-report/1-accessibility.html
@@ -2,9 +2,8 @@
 {
 	"title": "1 - Accessibility assesment of GCWeb theme version 2",
 	"language": "en",
-	"altLangPrefix": "1-accessibility",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2018-11-14",

--- a/docs/evaluation-report/2-wetplugin-gcweb2.html
+++ b/docs/evaluation-report/2-wetplugin-gcweb2.html
@@ -2,9 +2,8 @@
 {
 	"title": "2 - Regression user acceptance testing of WET plugin for GCWeb theme version 2",
 	"language": "en",
-	"altLangPrefix": "2-wetplugin-gcweb2",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2018-11-16",

--- a/docs/implementing.html
+++ b/docs/implementing.html
@@ -2,9 +2,8 @@
 {
 	"title": "Quick implementation guide - GCWeb theme",
 	"language": "en",
-	"altLangPrefix": "implementing",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-12-10",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,9 +2,8 @@
 {
 	"title": "GCWeb theme - Meta information",
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-09-12",

--- a/docs/release/dev-build.html
+++ b/docs/release/dev-build.html
@@ -3,10 +3,9 @@
 	"title": "Developper build pre-release notes",
 	"description": "Developper build pre-release notes - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "dev-build",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-11-12",

--- a/docs/release/index-en.html
+++ b/docs/release/index-en.html
@@ -3,10 +3,10 @@
 	"title": "Version history - Canada.ca theme (GCWeb)",
 	"description": "Link to all release notes from GCWeb v5.0 and upward - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-11-12",

--- a/docs/release/index-fr.html
+++ b/docs/release/index-fr.html
@@ -3,10 +3,10 @@
 	"title": "Historique des versions - Canada.ca theme (GCWeb)",
 	"description": "Liens vers toutes les notes de versions de GCWeb v5.0 et plus récente - Historique des versions - Thème Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "GCWeb accueil", "link": "../../index-fr.html" },
-		{ "title": "GCWeb thème", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb accueil", "link": "index-fr.html" },
+		{ "title": "GCWeb thème", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-11-12",

--- a/docs/release/v5.0-en.html
+++ b/docs/release/v5.0-en.html
@@ -3,10 +3,10 @@
 	"title": "v5.0.x release notes",
 	"description": "v5.0.x release notes - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "v5.0",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "v5.0-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-02-23",

--- a/docs/release/v5.0-fr.html
+++ b/docs/release/v5.0-fr.html
@@ -3,10 +3,10 @@
 	"title": "v5.0.x - Notes de version",
 	"description": "v5.0.x - Notes de version - Historique des versions - Thème de Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "v5.0",
-	"breadcrumb": [
-		{ "title": "Accueil de GCWeb", "link": "../../index-en.html" },
-		{ "title": "Thème de GCWeb", "link": "../index-en.html" }
+	"altLangPage": "v5.0-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
+		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-02-23",

--- a/docs/release/v5.1-en.html
+++ b/docs/release/v5.1-en.html
@@ -3,10 +3,10 @@
 	"title": "v5.1.x release notes",
 	"description": "v5.1.x release notes - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "v5.1",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "v5.1-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-09-16",

--- a/docs/release/v5.1-fr.html
+++ b/docs/release/v5.1-fr.html
@@ -3,10 +3,10 @@
 	"title": "v5.1 - Notes de version",
 	"description": "v5.1 - Notes de version - Historique des versions - Thème de Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "v5.1",
-	"breadcrumb": [
-		{ "title": "Accueil de GCWeb", "link": "../../index-fr.html" },
-		{ "title": "Thème de GCWeb", "link": "../index-fr.html" }
+	"altLangPage": "v5.1-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
+		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-09-16",

--- a/docs/release/v6.0-en.html
+++ b/docs/release/v6.0-en.html
@@ -3,10 +3,10 @@
 	"title": "v6.0.x release notes",
 	"description": "v6.0.x release notes - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "v6.0",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "v6.0-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-11-08",

--- a/docs/release/v6.0-fr.html
+++ b/docs/release/v6.0-fr.html
@@ -3,10 +3,10 @@
 	"title": "v6.0 - Notes de version",
 	"description": "v6.0 - Notes de version - Historique des versions - Thème de Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "v6.0",
-	"breadcrumb": [
-		{ "title": "Accueil de GCWeb", "link": "../../index-fr.html" },
-		{ "title": "Thème de GCWeb", "link": "../index-fr.html" }
+	"altLangPage": "v6.0-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
+		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-11-12",

--- a/docs/release/v6.1-en.html
+++ b/docs/release/v6.1-en.html
@@ -3,10 +3,10 @@
 	"title": "v6.1 - release notes",
 	"description": "v6.1 - release notes - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "v6.1",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "v6.1-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2020-03-19",

--- a/docs/release/v6.1-fr.html
+++ b/docs/release/v6.1-fr.html
@@ -3,10 +3,10 @@
 	"title": "v6.1 - Notes de version",
 	"description": "v6.1 - Notes de version - Historique des versions - Thème de Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "v6.1",
-	"breadcrumb": [
-		{ "title": "Accueil de GCWeb", "link": "../../index-fr.html" },
-		{ "title": "Thème de GCWeb", "link": "../index-fr.html" }
+	"altLangPage": "v6.1-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
+		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2020-03-19",

--- a/docs/release/v7.0-en.html
+++ b/docs/release/v7.0-en.html
@@ -3,10 +3,10 @@
 	"title": "v7.0.x - release notes",
 	"description": "v7.0.x - release notes - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "v7.0",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "v7.0-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2020-04-29",

--- a/docs/release/v7.0-fr.html
+++ b/docs/release/v7.0-fr.html
@@ -3,10 +3,10 @@
 	"title": "v7.0.x - Notes de version",
 	"description": "v7.0.x - Notes de version - Historique des versions - Thème de Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "v7.0",
-	"breadcrumb": [
-		{ "title": "Accueil de GCWeb", "link": "../../index-fr.html" },
-		{ "title": "Thème de GCWeb", "link": "../index-fr.html" }
+	"altLangPage": "v7.0-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
+		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2020-04-29",

--- a/docs/release/v8.0-en.html
+++ b/docs/release/v8.0-en.html
@@ -3,10 +3,10 @@
 	"title": "v8.0.x - Migration instructions",
 	"description": "v8.0.x - Migration instructions - Version history - Canada.ca theme (GCWeb)",
 	"language": "en",
-	"altLangPrefix": "v8.0",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../../index-en.html" },
-		{ "title": "GCWeb theme", "link": "../index-en.html" }
+	"altLangPage": "v8.0-fr.html",
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2020-06-15",

--- a/docs/release/v8.0-fr.html
+++ b/docs/release/v8.0-fr.html
@@ -3,10 +3,10 @@
 	"title": "v8.0.x - Instructions de migration",
 	"description": "v8.0.x - Instructions de migration - Historique des versions - Thème de Canada.ca (GCWeb)",
 	"language": "fr",
-	"altLangPrefix": "v8.0",
-	"breadcrumb": [
-		{ "title": "Accueil de GCWeb", "link": "../../index-fr.html" },
-		{ "title": "Thème de GCWeb", "link": "../index-fr.html" }
+	"altLangPage": "v8.0-en.html",
+	"breadcrumbs": [
+		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
+		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2020-06-15",

--- a/docs/temp-v5issue.html
+++ b/docs/temp-v5issue.html
@@ -2,10 +2,9 @@
 {
 	"title": "Temporary issue and todo list - GCWeb theme V5",
 	"language": "en",
-	"altLangPrefix": "temp-v5issue",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" },
-		{ "title": "Theme meta", "link": "index.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "Theme meta", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-01-16",

--- a/docs/test-case-1.html
+++ b/docs/test-case-1.html
@@ -2,9 +2,8 @@
 {
 	"title": "From examples - test cases",
 	"language": "en",
-	"altLangPrefix": "test-case-1",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-07-31",

--- a/docs/test-menu.html
+++ b/docs/test-menu.html
@@ -2,9 +2,8 @@
 {
 	"title": "Menu - test",
 	"language": "fr",
-	"altLangPrefix": "test-menu",
-	"breadcrumb": [
-		{ "title": "GCWeb accueil", "link": "../index-fr.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb accueil", "link": "index-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-01-20",

--- a/docs/v5-migration.html
+++ b/docs/v5-migration.html
@@ -3,10 +3,9 @@
 	"title": "Migration instruction - GCWeb theme V5",
 	"language": "en",
 	"languagetoggle": "false",
-	"altLangPrefix": "v5-migration",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" },
-		{ "title": "Theme meta", "link": "index.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "Theme meta", "link": "docs/index.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2018-11-02",

--- a/sites/archived/archived-en.html
+++ b/sites/archived/archived-en.html
@@ -2,10 +2,7 @@
 {
 	"title": "Content page",
 	"language": "en",
-	"altLangPrefix": "archived",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
+	"altLangPage": "archived-fr.html",
 	"secondlevel": false,
 	"dateModified": "2016-10-06",
 	"share": "true",

--- a/sites/archived/archived-fr.html
+++ b/sites/archived/archived-fr.html
@@ -2,10 +2,7 @@
 {
 	"title": "Page de contenu",
 	"language":	"fr",
-	"altLangPrefix": "archived",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
+	"altLangPage": "archived-en.html",
 	"secondlevel": false,
 	"dateModified": "2016-10-06",
 	"share": "true",

--- a/sites/breadcrumbs/inc-breadcrumbs.html
+++ b/sites/breadcrumbs/inc-breadcrumbs.html
@@ -1,4 +1,4 @@
-{%- unless page.pageclass contains "home" -%}
+{%- unless page.pageclass contains "home" or page.breadcrumbs == false -%}
 <nav id="wb-bc" property="breadcrumb">
 	<h2>{{ i18nText-breadcrumb }}</h2>
 	<div class="container">
@@ -12,13 +12,13 @@
 {%- if page.breadcrumbs -%}
 	{% assign breadcrumbCounter = 2 %}
 	{% for breadcrumb in page.breadcrumbs %}
-		<li property="itemListElement" typeof="ListItem">
-			<a property="item" typeof="WebPage" href="{{ breadcrumb.link | relative_url }}">
-				<span property="name">{{ breadcrumb.title }}</span>
-			</a>
-			<meta property="position" content="{{ breadcrumbCounter }}">
-		</li>
-		{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
+			<li property="itemListElement" typeof="ListItem">
+				<a property="item" typeof="WebPage" href="{{ breadcrumb.link | relative_url }}">
+					<span property="name">{{ breadcrumb.title }}</span>
+				</a>
+				<meta property="position" content="{{ breadcrumbCounter }}">
+			</li>
+			{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
 	{%- endfor -%}
 {% endif %}
 		</ol>

--- a/sites/footers/footers-en.html
+++ b/sites/footers/footers-en.html
@@ -3,9 +3,6 @@
 	"title": "Content page including complete footer",
 	"language": "en",
 	"altLangPage": "footers-fr.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true"

--- a/sites/footers/footers-fr.html
+++ b/sites/footers/footers-fr.html
@@ -3,9 +3,6 @@
 	"title": "Page de contenu incluant le pied de page complet",
 	"language":	"fr",
 	"altLangPage": "footers-en.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true"

--- a/sites/footers/no-footer-about-en.html
+++ b/sites/footers/no-footer-about-en.html
@@ -3,9 +3,6 @@
 	"title": "Hide 'About government' section from the footer",
 	"language": "en",
 	"altLangPage": "no-footer-about-fr.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",

--- a/sites/footers/no-footer-about-fr.html
+++ b/sites/footers/no-footer-about-fr.html
@@ -3,9 +3,6 @@
 	"title": "Masquer la section 'Au sujet du gouvernement' du pied de page",
 	"language":	"fr",
 	"altLangPage": "no-footer-about-en.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",

--- a/sites/footers/no-footer-site-en.html
+++ b/sites/footers/no-footer-site-en.html
@@ -3,9 +3,6 @@
 	"title": "Hide utility links from 'About this site' section",
 	"language": "en",
 	"altLangPage": "no-footer-site-fr.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",

--- a/sites/footers/no-footer-site-fr.html
+++ b/sites/footers/no-footer-site-fr.html
@@ -3,9 +3,6 @@
 	"title": "Masquer les liens de la section 'Au sujet de ce site'",
 	"language":	"fr",
 	"altLangPage": "no-footer-site-en.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",

--- a/sites/footers/no-footers-en.html
+++ b/sites/footers/no-footers-en.html
@@ -3,9 +3,6 @@
 	"title": "Hide 'About government' section and utility links from 'About this site'",
 	"language": "en",
 	"altLangPage": "no-footers-fr.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",

--- a/sites/footers/no-footers-fr.html
+++ b/sites/footers/no-footers-fr.html
@@ -3,9 +3,6 @@
 	"title": "Masquer la section 'Au sujet du gouvernement' et les liens de la section 'Au sujet de ce site'",
 	"language":	"fr",
 	"altLangPage": "no-footers-en.html",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",

--- a/sites/helpers/colour-en.html
+++ b/sites/helpers/colour-en.html
@@ -2,8 +2,8 @@
 {
 	"title": "Colour",
 	"language": "en",
-	"altLangPrefix": "",
-	"breadcrumb": [
+	"altLangPage": "colour-fr.html",
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/sites/helpers/colour-fr.html
+++ b/sites/helpers/colour-fr.html
@@ -2,8 +2,8 @@
 {
 	"title": "Couleur",
 	"language": "fr",
-	"altLangPrefix": "",
-	"breadcrumb": [
+	"altLangPage": "colour-en.html",
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,

--- a/templates/advancedservice/index-en.html
+++ b/templates/advancedservice/index-en.html
@@ -3,9 +3,8 @@
 	"title": "[Service name] - 1. [Step / section page name]",
 	"secondTitle": "1. [Step / section page name]",
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "#" },
 		{ "title": "[Topic name]", "link": "#" },
 		{ "title": "[Service name]", "link": "#" }

--- a/templates/advancedservice/index-fr.html
+++ b/templates/advancedservice/index-fr.html
@@ -3,9 +3,8 @@
 	"title": "[Nom du service] - 1. [Nom de la page de la section ou de l’étape]",
 	"secondTitle": "1. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "#" },
 		{ "title": "[Nom du sujet]", "link": "#" },
 		{ "title": "[Nom du service]", "link": "#" }

--- a/templates/advancedservice/page2-en.html
+++ b/templates/advancedservice/page2-en.html
@@ -3,9 +3,8 @@
 	"title": "[Service name] - 2. [Step / section page name]",
 	"secondTitle": "2. [Step / section page name]",
 	"language": "en",
-	"altLangPrefix": "page2",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "page2-fr.html",
+	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "#" },
 		{ "title": "[Topic name]", "link": "#" },
 		{ "title": "[Service name]", "link": "#" }

--- a/templates/advancedservice/page2-fr.html
+++ b/templates/advancedservice/page2-fr.html
@@ -3,9 +3,8 @@
 	"title": "[Nom du service] - 2. [Nom de la page de la section ou de l’étape]",
 	"secondTitle": "2. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
-	"altLangPrefix": "page2",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "page2-en.html",
+	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "#" },
 		{ "title": "[Nom du sujet]", "link": "#" },
 		{ "title": "[Nom du service]", "link": "#" }

--- a/templates/advancedservice/page3-en.html
+++ b/templates/advancedservice/page3-en.html
@@ -3,9 +3,8 @@
 	"title": "[Service name] - 3. [Step / section page name]",
 	"secondTitle": "3. [Step / section page name]",
 	"language": "en",
-	"altLangPrefix": "page3",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "page3-fr.html",
+	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "#" },
 		{ "title": "[Topic name]", "link": "#" },
 		{ "title": "[Service name]", "link": "#" }

--- a/templates/advancedservice/page3-fr.html
+++ b/templates/advancedservice/page3-fr.html
@@ -3,9 +3,8 @@
 	"title": "[Nom du service] - 3. [Nom de la page de la section ou de l’étape]",
 	"secondTitle": "3. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
-	"altLangPrefix": "page3",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "page3-en.html",
+	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "#" },
 		{ "title": "[Nom du sujet]", "link": "#" },
 		{ "title": "[Nom du service]", "link": "#" }

--- a/templates/advancedservice/page4-en.html
+++ b/templates/advancedservice/page4-en.html
@@ -3,9 +3,8 @@
 	"title": "[Service name] - 4. [Step / section page name]",
 	"secondTitle": "4. [Step / section page name]",
 	"language": "en",
-	"altLangPrefix": "page4",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "page4-fr.html",
+	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "#" },
 		{ "title": "[Topic name]", "link": "#" },
 		{ "title": "[Service name]", "link": "#" }

--- a/templates/advancedservice/page4-fr.html
+++ b/templates/advancedservice/page4-fr.html
@@ -3,9 +3,8 @@
 	"title": "[Nom du service] - 4. [Nom de la page de la section ou de l’étape]",
 	"secondTitle": "4. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
-	"altLangPrefix": "page4",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "page4-en.html",
+	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "#" },
 		{ "title": "[Nom du sujet]", "link": "#" },
 		{ "title": "[Nom du service]", "link": "#" }

--- a/templates/advancedservice/page5-en.html
+++ b/templates/advancedservice/page5-en.html
@@ -3,9 +3,8 @@
 	"title": "[Service name] - 5. [Step / section page name]",
 	"secondTitle": "5. [Step / section page name]",
 	"language": "en",
-	"altLangPrefix": "page5",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "page5-fr.html",
+	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "#" },
 		{ "title": "[Topic name]", "link": "#" },
 		{ "title": "[Service name]", "link": "#" }

--- a/templates/advancedservice/page5-fr.html
+++ b/templates/advancedservice/page5-fr.html
@@ -3,9 +3,8 @@
 	"title": "[Nom du service] - 5. [Nom de la page de la section ou de l’étape]",
 	"secondTitle": "5. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
-	"altLangPrefix": "page4",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "page4-en.html",
+	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "#" },
 		{ "title": "[Nom du sujet]", "link": "#" },
 		{ "title": "[Nom du service]", "link": "#" }

--- a/templates/advancedservice/page6-en.html
+++ b/templates/advancedservice/page6-en.html
@@ -3,9 +3,8 @@
 	"title": "[Service name] - 6. [Step / section page name]",
 	"secondTitle": "6. [Step / section page name]",
 	"language": "en",
-	"altLangPrefix": "page6",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "page6-fr.html",
+	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "#" },
 		{ "title": "[Topic name]", "link": "#" },
 		{ "title": "[Service name]", "link": "#" }

--- a/templates/advancedservice/page6-fr.html
+++ b/templates/advancedservice/page6-fr.html
@@ -3,9 +3,8 @@
 	"title": "[Nom du service] - 6. [Nom de la page de la section ou de l’étape]",
 	"secondTitle": "6. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
-	"altLangPrefix": "page4",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "page4-en.html",
+	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "#" },
 		{ "title": "[Nom du sujet]", "link": "#" },
 		{ "title": "[Nom du service]", "link": "#" }

--- a/templates/campaign/api.html
+++ b/templates/campaign/api.html
@@ -2,8 +2,7 @@
 {
 	"title": "[ESDC peers template] - Meta information",
 	"language": "en",
-	"altLangPrefix": "esdc",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/templates/campaign/campaign-en.html
+++ b/templates/campaign/campaign-en.html
@@ -2,12 +2,9 @@
 {
 	"title": "Campaign name",
 	"language": "en",
-	"altLangPrefix": "campaign",
+	"altLangPage": "campaign-fr.html",
 	"promotion": "carousel",
 	"deptfeature": true,
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2017-10-02",
 	"share": "true"

--- a/templates/campaign/campaign-fr.html
+++ b/templates/campaign/campaign-fr.html
@@ -2,12 +2,9 @@
 {
 	"title": "Nom de la campagne",
 	"language": "fr",
-	"altLangPrefix": "campaign",
+	"altLangPage": "campaign-en.html",
 	"promotion": "carousel",
 	"deptfeature": true,
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2017-10-02",
 	"share": "true"

--- a/templates/campaign/campaign2-en.html
+++ b/templates/campaign/campaign2-en.html
@@ -2,10 +2,7 @@
 {
 	"title": "[Campaign name]",
 	"language": "en",
-	"altLangPrefix": "campaign2",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
+	"altLangPage": "campaign2-fr.html",
 	"secondlevel": false,
 	"dateModified": "2018-10-10",
 	"share": "true"

--- a/templates/campaign/campaign2-fr.html
+++ b/templates/campaign/campaign2-fr.html
@@ -2,10 +2,7 @@
 {
 	"title": "[Nom de la campagne]",
 	"language": "fr",
-	"altLangPrefix": "campaign2",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
+	"altLangPage": "campaign2-en.html",
 	"secondlevel": false,
 	"dateModified": "2018-10-10",
 	"share": "true"

--- a/templates/content-en.md
+++ b/templates/content-en.md
@@ -4,9 +4,6 @@ language: en
 category: templates
 altLangPrefix: content
 altLangPage: content-fr.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/en.html
 secondlevel: false
 dateModified: 2017-09-29
 share: true

--- a/templates/content-fluid-en.md
+++ b/templates/content-fluid-en.md
@@ -4,9 +4,6 @@ title: "Fluid content page"
 language: en
 altLangPrefix: content
 altLangPage: content-fluid-fr.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/en.html
 secondlevel: false
 dateModified: 2021-02-05
 share: true

--- a/templates/content-fluid-fr.md
+++ b/templates/content-fluid-fr.md
@@ -4,9 +4,6 @@ title: "Page de contenu fluide"
 language: fr
 altLangPrefix: content
 altLangPage: content-fluid-en.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/fr.html
 secondlevel: false
 dateModified: 2021-02-05
 share: true

--- a/templates/content-fr.md
+++ b/templates/content-fr.md
@@ -3,9 +3,6 @@ title: "Page de contenu"
 language: fr
 altLangPrefix: content
 altLangPage: content-en.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/fr.html
 secondlevel: false
 dateModified: 2017-09-29
 share: true

--- a/templates/content-gcweb-4-0-29-font-style-en.html
+++ b/templates/content-gcweb-4-0-29-font-style-en.html
@@ -2,10 +2,7 @@
 {
 	"title": "Content page - GCWeb 4.0.29 font style",
 	"language": "en",
-	"altLangPrefix": "content-gcweb-4-0-29-font-style",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
+	"altLangPage": "content-gcweb-4-0-29-font-style-fr.html",
 	"secondlevel": false,
 	"dateModified": "2018-11-29",
 	"share": "true"

--- a/templates/content-gcweb-4-0-29-font-style-fr.html
+++ b/templates/content-gcweb-4-0-29-font-style-fr.html
@@ -2,10 +2,7 @@
 {
 	"title": "Page de contenu - Police de caractère de GCWeb 4.0.29",
 	"language":	"fr",
-	"altLangPrefix": "content-gcweb-4-0-29-font-style",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
+	"altLangPage": "content-gcweb-4-0-29-font-style-en.html",
 	"secondlevel": false,
 	"dateModified": "2017-09-29",
 	"share": "true"

--- a/templates/content-limit-en.html
+++ b/templates/content-limit-en.html
@@ -2,11 +2,8 @@
 {
 	"title": "Content page - Limited width content",
 	"language": "en",
-	"altLangPrefix": "content-limit",
+	"altLangPage": "content-limit-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2017-09-29",
 	"share": "true"

--- a/templates/content-limit-fr.html
+++ b/templates/content-limit-fr.html
@@ -2,11 +2,8 @@
 {
 	"title": "Page de contenu - Largeur de contenu limitée",
 	"language": "fr",
-	"altLangPrefix": "content-limit",
+	"altLangPage": "content-limit-en.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2017-09-29",
 	"share": "true"

--- a/templates/content-signedoff-en.md
+++ b/templates/content-signedoff-en.md
@@ -4,9 +4,6 @@ language: en
 category: templates
 altLangPrefix: content
 altLangPage: content-fr.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/en.html
 secondlevel: false
 dateModified: 2017-09-29
 share: true

--- a/templates/content-signedoff-fr.md
+++ b/templates/content-signedoff-fr.md
@@ -3,9 +3,6 @@ title: "Page de contenu - Session Fermée"
 language: fr
 altLangPrefix: content
 altLangPage: content-en.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/fr.html
 secondlevel: false
 dateModified: 2017-09-29
 share: true

--- a/templates/content-signedon-en.md
+++ b/templates/content-signedon-en.md
@@ -4,9 +4,6 @@ language: en
 category: templates
 altLangPrefix: content
 altLangPage: content-fr.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/en.html
 secondlevel: false
 dateModified: 2017-09-29
 share: true

--- a/templates/content-signedon-fr.md
+++ b/templates/content-signedon-fr.md
@@ -3,9 +3,6 @@ title: "Page de contenu - Session Ouverte"
 language: fr
 altLangPrefix: content
 altLangPage: content-en.html
-breadcrumb:
-- title: "Canada.ca"
-  link: https://www.canada.ca/fr.html
 secondlevel: false
 dateModified: 2017-09-29
 share: true

--- a/templates/dept-en.html
+++ b/templates/dept-en.html
@@ -2,10 +2,7 @@
 {
 	"title": "Departments and agencies",
 	"language": "en",
-	"altLangPrefix": "dept",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
+	"altLangPage": "dept-fr.html",
 	"dateModified": "2018-07-12",
 	"share": "true"
 }

--- a/templates/dept-fr.html
+++ b/templates/dept-fr.html
@@ -2,10 +2,7 @@
 {
 	"title": "Ministères et organismes",
 	"language": "fr",
-	"altLangPrefix": "dept",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
+	"altLangPage": "dept-en.html",
 	"dateModified": "2018-07-12",
 	"share": "true"
 }

--- a/templates/event-en.html
+++ b/templates/event-en.html
@@ -2,13 +2,10 @@
 {
 	"title": "Event name",
 	"language": "en",
-	"altLangPrefix": "event",
+	"altLangPage": "event-fr.html",
 	"promotion": "carousel",
 	"deptfeature": true,
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2017-10-02",
 	"share": "true"

--- a/templates/event-fr.html
+++ b/templates/event-fr.html
@@ -2,13 +2,10 @@
 {
 	"title": "Nom de l’activité",
 	"language": "fr",
-	"altLangPrefix": "event",
+	"altLangPage": "event-en.html",
 	"promotion": "carousel",
 	"deptfeature": true,
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2017-10-02",
 	"share": "true"

--- a/templates/feedback-en.html
+++ b/templates/feedback-en.html
@@ -3,11 +3,8 @@
 	"title": "Feedback form",
 	"language": "en",
 	"description": "Allows users to submit feedback for a specific Web page or Web site.",
-	"altLangPrefix": "feedback",
+	"altLangPage": "feedback-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"css": ["https://wet-boew.github.io/v4.0-ci/demos/feedback/demo/feedback.min.css"],
 	"script": ["https://wet-boew.github.io/v4.0-ci/demos/feedback/demo/feedback.min.js"],
 	"dateModified": "2014-02-28"

--- a/templates/feedback-fr.html
+++ b/templates/feedback-fr.html
@@ -3,11 +3,8 @@
 	"title": "Formulaire de rétroaction",
 	"language": "fr",
 	"description": "Un formulaire normalisé pour soumettre une rétroaction au sujet d'une page ou d'un site Web particulier.",
-	"altLangPrefix": "feedback",
+	"altLangPage": "feedback-en.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"css": ["https://wet-boew.github.io/v4.0-ci/demos/feedback/demo/feedback.min.css"],
 	"script": ["https://wet-boew.github.io/v4.0-ci/demos/feedback/demo/feedback.min.js"],
 	"dateModified": "2014-02-28"

--- a/templates/gc-audience-en.html
+++ b/templates/gc-audience-en.html
@@ -2,12 +2,9 @@
 {
 	"title": "[Audience name]",
 	"language": "en",
-	"altLangPrefix": "gc-audience",
+	"altLangPage": "gc-audience-fr.html",
 	"pageType": "gcaudience",
 	"pageclass": "page-type-nav cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2017-12-05",
 	"share": "true"
 }

--- a/templates/gc-audience-fr.html
+++ b/templates/gc-audience-fr.html
@@ -2,12 +2,9 @@
 {
 	"title": "[Public cible]",
 	"language": "fr",
-	"altLangPrefix": "gc-audience",
+	"altLangPage": "gc-audience-en.html",
 	"pageType": "gcaudience",
 	"pageclass": "page-type-nav cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2017-12-05",
 	"share": "true"
 }

--- a/templates/home/api.html
+++ b/templates/home/api.html
@@ -2,9 +2,8 @@
 {
 	"title": "Home page - Meta information",
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2018-12-27",

--- a/templates/index/api.html
+++ b/templates/index/api.html
@@ -2,10 +2,6 @@
 {
 	"title": "[Long index page] - Meta information",
 	"language": "en",
-	"altLangPrefix": "longindex",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2018-06-29",
 	"share": "true"

--- a/templates/index/longindex-en.html
+++ b/templates/index/longindex-en.html
@@ -2,11 +2,8 @@
 {
 	"title": "[Long index page]",
 	"language": "en",
-	"altLangPrefix": "longindex",
+	"altLangPage": "longindex-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2018-07-12",
 	"share": "true"

--- a/templates/index/longindex-fr.html
+++ b/templates/index/longindex-fr.html
@@ -2,11 +2,8 @@
 {
 	"title": "[Page d’index long]",
 	"language":	"fr",
-	"altLangPrefix": "longindex",
+	"altLangPage": "longindex-en.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2018-07-12",
 	"share": "true"

--- a/templates/institutional/institution-arms-en.html
+++ b/templates/institutional/institution-arms-en.html
@@ -3,11 +3,10 @@
 	"title": "[Institution Name]",
 	"layout": "without-h1",
 	"language": "en",
-	"altLangPrefix": "institution-arms",
+	"altLangPage": "institution-arms-fr.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
 	"dateModified": "2018-03-21",

--- a/templates/institutional/institution-arms-fr.html
+++ b/templates/institutional/institution-arms-fr.html
@@ -3,11 +3,10 @@
 	"title": "[Nom de l’institution]",
 	"layout": "without-h1",
 	"language": "fr",
-	"altLangPrefix": "institution-arms",
+	"altLangPage": "institution-arms-en.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
 	"dateModified": "2018-03-21",

--- a/templates/institutional/institution-contact-en.html
+++ b/templates/institutional/institution-contact-en.html
@@ -2,10 +2,9 @@
 {
 	"title": "Contact [Institution name]",
 	"language": "en",
-	"altLangPrefix": "institution-contact",
+	"altLangPage": "institution-contact-fr.html",
 	"pageType": "institution",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/institutional/institution-contact-fr.html
+++ b/templates/institutional/institution-contact-fr.html
@@ -2,10 +2,9 @@
 {
 	"title": "Coordonnées [nom de l’institution]",
 	"language": "fr",
-	"altLangPrefix": "institution-contact",
+	"altLangPage": "institution-contact-en.html",
 	"pageType": "institution",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/institutional/institution-en.html
+++ b/templates/institutional/institution-en.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Institution Name]",
 	"language": "en",
-	"altLangPrefix": "institution",
+	"altLangPage": "institution-fr.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/institutional/institution-fr.html
+++ b/templates/institutional/institution-fr.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Nom de l’institution]",
 	"language": "fr",
-	"altLangPrefix": "institution",
+	"altLangPage": "institution-en.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/institutional/institution-landing-en.html
+++ b/templates/institutional/institution-landing-en.html
@@ -3,8 +3,7 @@ title: "[Institution-landing-page]"
 layout: no-container
 language: "en"
 altLangPage: "institution-landing-fr.html"
-breadcrumb: [
-	{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+breadcrumbs: [
 	{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 ]
 dateModified: "2021-06-03"

--- a/templates/institutional/institution-landing-fr.html
+++ b/templates/institutional/institution-landing-fr.html
@@ -3,8 +3,7 @@ title: "[Institution-landing-page]"
 layout: no-container
 language: "fr"
 altLangPage: "institution-landing-en.html"
-breadcrumb: [
-	{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+breadcrumbs: [
 	{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 ]
 dateModified: "2021-06-03"

--- a/templates/institutional/institutional-service-performance-en.html
+++ b/templates/institutional/institutional-service-performance-en.html
@@ -2,11 +2,8 @@
 {
 	"title": "[Institution] service performance reporting for fiscal year 2015 to 2016",
 	"language": "en",
-	"altLangPrefix": "institutional-service-performance",
+	"altLangPage": "institutional-service-performance-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2017-09-29",
 	"share": "true"
 }

--- a/templates/institutional/institutional-service-performance-fr.html
+++ b/templates/institutional/institutional-service-performance-fr.html
@@ -2,11 +2,8 @@
 {
 	"title": "Compte rendu du rendement des services de [Nom de l’institution] pour l’exercice financier de 2015 à 2016",
 	"language": "fr",
-	"altLangPrefix": "institutional-service-performance",
+	"altLangPage": "institutional-service-performance-en.html",
 	"pageclass": "cnt-wdth-lmtd",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2017-09-29",
 	"share": "true"
 }

--- a/templates/legislation/act-en.html
+++ b/templates/legislation/act-en.html
@@ -2,9 +2,8 @@
 {
 	"title": "[Act name] <small>([NN-XX])</small>",
 	"language": "en",
-	"altLangPrefix": "act",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "act-fr.html",
+	"breadcrumbs": [
 		{ "title": "Acts & regulations", "link": "#" }
 	],
 	"dateModified": "2014-10-23",

--- a/templates/legislation/act-fr.html
+++ b/templates/legislation/act-fr.html
@@ -2,9 +2,8 @@
 {
 	"title": "[Titre de la loi] <small>([NN-XX])</small>",
 	"language": "fr",
-	"altLangPrefix": "act",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "act-en.html",
+	"breadcrumbs": [
 		{ "title": "Lois et règlements", "link": "#" }
 	],
 	"dateModified": "2014-10-23",

--- a/templates/legislation/regulations-en.html
+++ b/templates/legislation/regulations-en.html
@@ -2,9 +2,8 @@
 {
 	"title": "[Regulation name] <small>([NN-XX])</small>",
 	"language": "en",
-	"altLangPrefix": "regulations",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"altLangPage": "regulations-fr.html",
+	"breadcrumbs": [
 		{ "title": "Acts & regulations", "link": "#" }
 	],
 	"dateModified": "2014-10-23",

--- a/templates/legislation/regulations-fr.html
+++ b/templates/legislation/regulations-fr.html
@@ -2,9 +2,8 @@
 {
 	"title": "[Nom du règlement] <small>([NN-XX])</small>",
 	"language": "fr",
-	"altLangPrefix": "regulations",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"altLangPage": "regulations-en.html",
+	"breadcrumbs": [
 		{ "title": "Lois et règlements", "link": "#" }
 	],
 	"dateModified": "2014-10-23",

--- a/templates/localnav/index-en.html
+++ b/templates/localnav/index-en.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Topic - Local navigation]",
 	"language": "en",
-	"altLangPrefix": "index",
+	"altLangPage": "index-fr.html",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Theme Name]", "link": "theme-en.html" }
+	"breadcrumbs": [
+		{ "title": "[Theme Name]", "link": "templates/theme-en.html" }
 	],
 	"dateModified": "2018-06-05",
 	"share": "true",

--- a/templates/localnav/index-fr.html
+++ b/templates/localnav/index-fr.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Sujet - Navigation locale]",
 	"language": "fr",
-	"altLangPrefix": "index",
+	"altLangPage": "index-en.html",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Thème]", "link": "theme-fr.html" }
+	"breadcrumbs": [
+		{ "title": "[Thème]", "link": "templates/theme-fr.html" }
 	],
 	"dateModified": "2018-06-05",
 	"share": "true",

--- a/templates/localnav/task1/index-en.html
+++ b/templates/localnav/task1/index-en.html
@@ -22,11 +22,10 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2017-09-29",

--- a/templates/localnav/task1/index-fr.html
+++ b/templates/localnav/task1/index-fr.html
@@ -22,11 +22,10 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2017-09-29",

--- a/templates/localnav/task1/task1/index-en.html
+++ b/templates/localnav/task1/task1/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task1/index-fr.html
+++ b/templates/localnav/task1/task1/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task1/task2/index-en.html
+++ b/templates/localnav/task1/task2/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task2/index-fr.html
+++ b/templates/localnav/task1/task2/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task1/task3/index-en.html
+++ b/templates/localnav/task1/task3/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task3/index-fr.html
+++ b/templates/localnav/task1/task3/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task1/task4/index-en.html
+++ b/templates/localnav/task1/task4/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task4/index-fr.html
+++ b/templates/localnav/task1/task4/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task1/task5/index-en.html
+++ b/templates/localnav/task1/task5/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task5/index-fr.html
+++ b/templates/localnav/task1/task5/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task1/task6/index-en.html
+++ b/templates/localnav/task1/task6/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task6/index-fr.html
+++ b/templates/localnav/task1/task6/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task1/task7/index-en.html
+++ b/templates/localnav/task1/task7/index-en.html
@@ -15,12 +15,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 1]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task1/task7/index-fr.html
+++ b/templates/localnav/task1/task7/index-fr.html
@@ -15,12 +15,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 1]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 1]", "link": "templates/localnav/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task2/index-en.html
+++ b/templates/localnav/task2/index-en.html
@@ -12,11 +12,10 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task2/index-fr.html
+++ b/templates/localnav/task2/index-fr.html
@@ -12,11 +12,10 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task3/index-en.html
+++ b/templates/localnav/task3/index-en.html
@@ -18,11 +18,10 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task3/index-fr.html
+++ b/templates/localnav/task3/index-fr.html
@@ -18,11 +18,10 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task3/task1/index-en.html
+++ b/templates/localnav/task3/task1/index-en.html
@@ -11,12 +11,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 3]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task3/task1/index-fr.html
+++ b/templates/localnav/task3/task1/index-fr.html
@@ -11,12 +11,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 3]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 3]", "link": "templates/localnav/task3/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task3/task2/index-en.html
+++ b/templates/localnav/task3/task2/index-en.html
@@ -16,12 +16,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 3]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task3/task2/index-fr.html
+++ b/templates/localnav/task3/task2/index-fr.html
@@ -16,12 +16,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 3]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 3]", "link": "templates/localnav/task3/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task3/task2/task1/index-en.html
+++ b/templates/localnav/task3/task2/task1/index-en.html
@@ -10,13 +10,12 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../../index-en.html" },
-		{ "title": "[Task 3]", "link": "../../index-en.html" },
-		{ "title": "[Sub task 2]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" },
+		{ "title": "[Sub task 2]", "link": "templates/localnav/task3/task2/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task3/task2/task1/index-fr.html
+++ b/templates/localnav/task3/task2/task1/index-fr.html
@@ -10,13 +10,12 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../../index-fr.html" },
-		{ "title": "[Tache 3]", "link": "../../index-fr.html" },
-		{ "title": "[Sub Tache 2]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 3]", "link": "templates/localnav/task3/index-fr.html" },
+		{ "title": "[Sub Tache 2]", "link": "templates/localnav/task3/task2/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task3/task2/task2/index-en.html
+++ b/templates/localnav/task3/task2/task2/index-en.html
@@ -10,13 +10,12 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../../index-en.html" },
-		{ "title": "[Task 3]", "link": "../../index-en.html" },
-		{ "title": "[Sub task 2]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" },
+		{ "title": "[Sub task 2]", "link": "templates/localnav/task3/task2/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task3/task2/task2/index-fr.html
+++ b/templates/localnav/task3/task2/task2/index-fr.html
@@ -10,13 +10,12 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../../index-fr.html" },
-		{ "title": "[Tache 3]", "link": "../../index-fr.html" },
-		{ "title": "[Sub Tache 2]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 3]", "link": "templates/localnav/task3/index-fr.html" },
+		{ "title": "[Sub Tache 2]", "link": "templates/localnav/task3/task2/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task3/task3/index-en.html
+++ b/templates/localnav/task3/task3/index-en.html
@@ -11,12 +11,11 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../../index-en.html" },
-		{ "title": "[Task 3]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task3/task3/index-fr.html
+++ b/templates/localnav/task3/task3/index-fr.html
@@ -11,12 +11,11 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../../index-fr.html" },
-		{ "title": "[Tache 3]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
+		{ "title": "[Tache 3]", "link": "templates/localnav/task3/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/localnav/task4/index-en.html
+++ b/templates/localnav/task4/index-en.html
@@ -12,11 +12,10 @@
 		"link":"../index-en.html"
 	}],
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Institution name]", "link": "../../institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "../index-en.html" }
+	"altLangPage": "index-fr.html",
+	"breadcrumbs": [
+		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
+		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/localnav/task4/index-fr.html
+++ b/templates/localnav/task4/index-fr.html
@@ -12,11 +12,10 @@
 		"link":"../index-fr.html"
 	}],
 	"language": "fr",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Nom de l'institution]", "link": "../../institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "../index-fr.html" }
+	"altLangPage": "index-en.html",
+	"breadcrumbs": [
+		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/news/news-en.html
+++ b/templates/news/news-en.html
@@ -2,9 +2,9 @@
 {
 	"title": "News",
 	"language": "en",
-	"altLangPrefix": "news",
+	"altLangPage": "news-fr.html",
 	"promotion": "carousel",
-	"breadcrumb": "false",
+	"breadcrumbs": false,
 	"secondlevel": false,
 	"dateModified": "2017-10-02",
 	"share": "true",

--- a/templates/news/news-fr.html
+++ b/templates/news/news-fr.html
@@ -2,8 +2,8 @@
 {
 	"title": "Page de contenu",
 	"language":	"fr",
-	"altLangPrefix": "news",
-	"breadcrumb": "false",
+	"altLangPage": "news-en.html",
+	"breadcrumbs": false,
 	"secondlevel": false,
 	"dateModified": "2016-07-20",
 	"share": "true",

--- a/templates/organizational/organizational-arms-en.html
+++ b/templates/organizational/organizational-arms-en.html
@@ -3,11 +3,10 @@
 	"title": "[Organization Name]",
 	"layout": "without-h1",
 	"language": "en",
-	"altLangPrefix": "organizational-arms",
+	"altLangPage": "organizational-arms-fr.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/organizational/organizational-arms-fr.html
+++ b/templates/organizational/organizational-arms-fr.html
@@ -3,11 +3,10 @@
 	"title": "[Nom de l’organisme]",
 	"layout": "without-h1",
 	"language": "fr",
-	"altLangPrefix": "organizational-arms",
+	"altLangPage": "organizational-arms-en.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/organizational/organizational-en.html
+++ b/templates/organizational/organizational-en.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Organization Name]",
 	"language": "en",
-	"altLangPrefix": "organizational",
+	"altLangPage": "organizational-fr.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/organizational/organizational-fr.html
+++ b/templates/organizational/organizational-fr.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Nom de l’organisme]",
 	"language": "fr",
-	"altLangPrefix": "organizational",
+	"altLangPage": "organizational-en.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
 	"dateModified": "2017-12-05",

--- a/templates/search/api.html
+++ b/templates/search/api.html
@@ -2,9 +2,8 @@
 {
 	"title": "Search template - Meta information",
 	"language": "en",
-	"altLangPrefix": "index",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-07-31",

--- a/templates/search/results-contextual-en.html
+++ b/templates/search/results-contextual-en.html
@@ -2,12 +2,9 @@
 {
 	"title": "Search results (Contextual)",
 	"language": "en",
-	"altLangPrefix": "results-contextual",
+	"altLangPage": "results-contextual-fr.html",
 	"pageType": "search",
 	"pageclass": "page-type-search",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2018-12-21",
 	"share": "false",
 	"deptfeature": false

--- a/templates/search/results-contextual-fr.html
+++ b/templates/search/results-contextual-fr.html
@@ -2,12 +2,9 @@
 {
 	"title": "Résultats de la recherche (Contextuel)",
 	"language": "fr",
-	"altLangPrefix": "results-contextual",
+	"altLangPage": "results-contextual-en.html",
 	"pageType": "recherche",
 	"pageclass": "page-type-search",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2018-12-21",
 	"share": "false",
 	"deptfeature": false

--- a/templates/search/results-en.html
+++ b/templates/search/results-en.html
@@ -2,12 +2,9 @@
 {
 	"title": "Search results",
 	"language": "en",
-	"altLangPrefix": "results",
+	"altLangPage": "results-fr.html",
 	"pageType": "search",
 	"pageclass": "page-type-search",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2019-02-06",
 	"share": "false",
 	"deptfeature": false

--- a/templates/search/results-filters-en.html
+++ b/templates/search/results-filters-en.html
@@ -2,12 +2,9 @@
 {
 	"title": "Search facets/filters results",
 	"language": "en",
-	"altLangPrefix": "search",
+	"altLangPage": "results-filters-fr.html",
 	"pageType": "search",
 	"pageclass": "page-type-search",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2019-02-06",
 	"share": "false",
 	"deptfeature": false

--- a/templates/search/results-filters-fr.html
+++ b/templates/search/results-filters-fr.html
@@ -2,12 +2,9 @@
 {
 	"title": "Résultats de la recherche (avec filtre)",
 	"language": "fr",
-	"altLangPrefix": "results-filters",
+	"altLangPage": "results-filters-en.html",
 	"pageType": "recherche",
 	"pageclass": "page-type-search",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2019-02-06",
 	"share": "false",
 	"deptfeature": false

--- a/templates/search/results-fr.html
+++ b/templates/search/results-fr.html
@@ -2,12 +2,9 @@
 {
 	"title": "Résultats de la recherche",
 	"language": "fr",
-	"altLangPrefix": "results",
+	"altLangPage": "results-en.html",
 	"pageType": "recherche",
 	"pageclass": "page-type-search",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2019-02-06",
 	"share": "false",
 	"deptfeature": false

--- a/templates/search/test-pagination.html
+++ b/templates/search/test-pagination.html
@@ -2,10 +2,9 @@
 {
 	"title": "Test - Pagination for search template",
 	"language": "en",
-	"altLangPrefix": "test-pagination",
-	"breadcrumb": [
-		{ "title": "GCWeb home", "link": "../index-en.html" },
-		{ "title": "Search templat", "link": "index-en.html" }
+	"breadcrumbs": [
+		{ "title": "GCWeb home", "link": "index-en.html" },
+		{ "title": "Search templat", "link": "templates/search/api.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2019-03-01",

--- a/templates/service-en.html
+++ b/templates/service-en.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Service name]",
 	"language": "en",
-	"altLangPrefix": "service",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "Institution name", "link": "./institutional/institution-en.html" },
-		{ "title": "Topic name", "link": "./topic-en.html" }
+	"altLangPage": "service-fr.html",
+	"breadcrumbs": [
+		{ "title": "Institution name", "link": "templates/institutional/institution-en.html" },
+		{ "title": "Topic name", "link": "templates/topic/topic-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2016-11-04",

--- a/templates/service-fr.html
+++ b/templates/service-fr.html
@@ -2,11 +2,10 @@
 {
 	"title": "[Nom du service]",
 	"language": "fr",
-	"altLangPrefix": "service",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "Nom de l'institution", "link": "./institutional/institution-fr.html" },
-		{ "title": "Nom du sujet", "link": "./topic-fr.html" }
+	"altLangPage": "service-en.html",
+	"breadcrumbs": [
+		{ "title": "Nom de l'institution", "link": "templates/institutional/institution-fr.html" },
+		{ "title": "Nom du sujet", "link": "templates/topic/topic-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2016-11-04",

--- a/templates/thematic/dark-theme-en.html
+++ b/templates/thematic/dark-theme-en.html
@@ -2,9 +2,9 @@
 {
 	"title": "Provisional - Dark theme - GCWeb theme",
 	"language": "en",
-	"altLangPrefix": "dark-theme",
+	"altLangPage": "dark-theme-fr.html",
 	"pageclass": "provisional dark-theme",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/templates/thematic/dark-theme-fr.html
+++ b/templates/thematic/dark-theme-fr.html
@@ -2,9 +2,9 @@
 {
 	"title": "provisoires - Thème sombre - Thème de GCWeb",
 	"language": "fr",
-	"altLangPrefix": "dark-theme",
+	"altLangPage": "dark-theme-en.html",
 	"pageclass": "provisional dark-theme",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,

--- a/templates/thematic/pink-day-en.html
+++ b/templates/thematic/pink-day-en.html
@@ -2,9 +2,9 @@
 {
 	"title": "Provisional - Pink Day - GCWeb theme",
 	"language": "en",
-	"altLangPrefix": "pink-day",
+	"altLangPage": "pink-day-fr.html",
 	"pageclass": "provisional pnkDy-theme",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,

--- a/templates/thematic/pink-day-fr.html
+++ b/templates/thematic/pink-day-fr.html
@@ -2,9 +2,9 @@
 {
 	"title": "Provisoires - Journée rose - Thème de GCWeb",
 	"language": "fr",
-	"altLangPrefix": "pink-day",
+	"altLangPage": "pink-day-en.html",
 	"pageclass": "provisional pnkDy-theme",
-	"breadcrumb": [
+	"breadcrumbs": [
 		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
 	],
 	"secondlevel": false,

--- a/templates/theme-en.html
+++ b/templates/theme-en.html
@@ -2,12 +2,9 @@
 {
 	"title": "[Theme title]",
 	"language": "en",
-	"altLangPrefix": "theme",
+	"altLangPage": "theme-fr.html",
 	"pageclass": "page-type-nav",
 	"pageType": "theme",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"dateModified": "2017-12-05",
 	"share": "true",
 	"deptfeature": true

--- a/templates/theme-fr.html
+++ b/templates/theme-fr.html
@@ -2,12 +2,9 @@
 {
 	"title": "[Titre du thème]",
 	"language": "fr",
-	"altLangPrefix": "theme",
+	"altLangPage": "theme-en.html",
 	"pageclass": "page-type-nav",
 	"pageType": "theme",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" }
-	],
 	"dateModified": "2017-12-05",
 	"share": "true",
 	"deptfeature": true

--- a/templates/theme-topic/theme-topic-en.md
+++ b/templates/theme-topic/theme-topic-en.md
@@ -5,11 +5,6 @@ language: "en"
 altLangPage: "theme-topic-fr.html"
 pageclass: "page-type-nav"
 pageType: "theme-topic"
-breadcrumb:
- - title: "Canada.ca"
-   link: "https://www.canada.ca/en.html"
- - title: "[Theme - Topic title]"
-   link: "theme-topic-en.html"
 dateModified: "2021-01-19"
 share: true
 noMainContainer: true

--- a/templates/theme-topic/theme-topic-fr.md
+++ b/templates/theme-topic/theme-topic-fr.md
@@ -5,11 +5,6 @@ language: "fr"
 altLangPage: "theme-topic-en.html"
 pageclass: "page-type-nav"
 pageType: "theme-topic"
-breadcrumb:
- - title: "Canada.ca"
-   link": "https://www.canada.ca/fr.html"
- - title: "[Titre du thème ou du sujet]"
-   link: "theme-topic-fr.html"
 dateModified: "2021-01-19"
 share: true
 noMainContainer: true

--- a/templates/topic/topic-en.html
+++ b/templates/topic/topic-en.html
@@ -4,9 +4,8 @@
 	"language": "en",
 	"altLangPage": "topic-fr.html",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Theme Name]", "link": "theme-en.html" }
+	"breadcrumbs": [
+		{ "title": "[Theme Name]", "link": "templates/theme-en.html" }
 	],
 	"dateModified": "2017-12-05",
 	"share": "true",

--- a/templates/topic/topic-fr.html
+++ b/templates/topic/topic-fr.html
@@ -4,9 +4,8 @@
 	"language": "fr",
 	"altLangPage": "topic-en.html",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Thème]", "link": "theme-fr.html" }
+	"breadcrumbs": [
+		{ "title": "[Thème]", "link": "templates/theme-fr.html" }
 	],
 	"dateModified": "2017-12-05",
 	"share": "true",

--- a/templates/topic/topic-testcase-1-en.html
+++ b/templates/topic/topic-testcase-1-en.html
@@ -4,9 +4,8 @@
 	"language": "en",
 	"altLangPage": "topic-testcase-1-fr.html",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
-		{ "title": "[Theme Name]", "link": "theme-testcase-1-en.html" }
+	"breadcrumbs": [
+		{ "title": "[Theme Name]", "link": "templates/theme-en.html" }
 	],
 	"dateModified": "2021-01-22",
 	"share": "true",

--- a/templates/topic/topic-testcase-1-fr.html
+++ b/templates/topic/topic-testcase-1-fr.html
@@ -4,9 +4,8 @@
 	"language": "fr",
 	"altLangPage": "topic-testcase-1-en.html",
 	"pageclass": "page-type-nav",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
-		{ "title": "[Thème]", "link": "theme-testcase-1-fr.html" }
+	"breadcrumbs": [
+		{ "title": "[Thème]", "link": "templates/theme-fr.html" }
 	],
 	"dateModified": "2021-01-22",
 	"share": "true",

--- a/templates/widgets-en.html
+++ b/templates/widgets-en.html
@@ -2,10 +2,9 @@
 {
 	"title": "Stay connected",
 	"language": "en",
-	"altLangPrefix": "widgets",
+	"altLangPage": "widgets-fr.html",
 	"pageclass": "theme",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" },
+	"breadcrumbs": [
 		{ "title": "Environment & natural resources", "link": "https://www.canada.ca/en/services/environment.html" }
 	],
 	"secondlevel": false,

--- a/templates/widgets-fr.html
+++ b/templates/widgets-fr.html
@@ -2,10 +2,9 @@
 {
 	"title": "Restez branché",
 	"language": "fr",
-	"altLangPrefix": "widgets",
+	"altLangPage": "widgets-en.html",
 	"pageclass": "theme",
-	"breadcrumb": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/fr.html" },
+	"breadcrumbs": [
 		{ "title": "Environnement et ressources naturelles", "link": "https://www.canada.ca/fr/services/environnement.html" }
 	],
 	"secondlevel": false,


### PR DESCRIPTION
Countless GCWeb pages use WET 4.0's `altLangPrefix` and ``breadcrumb`` variables for custom breadcrumbs and language toggles. But they stopped working when the GCWeb repo was restructured and reworked to use Jekyll.

This fixes them via the following changes:
* ``altLangPrefix``:
  * Rename variable to ``altLangPage``
  * Add language suffixes and file extensions to the end of the values (e.g. "filename" to "filename-fr.html")
  * Remove the variable from unilingual pages
* ``breadcrumb``:
  * Rename variable to ``breadcrumbs``
  * Change values to be relative to ``site.baseurl`` (not specified in GCWeb, GitHub Pages automatically sets it to "/GCWeb")
  * Stop hardcoding the "Canada.ca" link in custom breadcrumbs to prevent duplicate versions of it from appearing (GCWeb uses its built-in version of the link as the first breadcrumb item)
* Enhance breadcrumb include:
  * Omit breadcrumb if ``breadcrumbs`` variable's value is set to ``false``
  * Increase indentation of custom breadcrumb list items to match the built-in "Canada.ca" item
* Fix wrong breadcrumb link destinations:
  * ``docs/release/*.html``: "../index-\*.html" to "docs/index.html"
  * ``docs/release/v5.0-fr.html``: "../../index-en.html" to "index-fr.html"
  * ``templates/localnav/index-*.html``: "theme-\*.html" to "templates/theme-\*.html"
  * ``templates/localnav/task*/*-*.html``: "../../institution-\*.html" to "templates/institutional/institution-\*.html"
  * ``templates/search/test-pagination.html``: "index-en.html" to "templates/search/api.html"
  * ``templates/service-*.html``:
    * "./institutional/institution-\*.html" to "templates/institutional/institution-\*.html"
    * "./topic-\*.html" to "templates/topic/topic-\*.html"
  * ``templates/theme-topic/theme-topic-*.md``: "theme-topic-en.html" to nothing (removed breadcrumbs - page was linking to itself)
  * ``templates/topic/topic-*.html``: "theme-\*.html" to "templates/theme-\*.html"
  * ``templates/topic/topic-testcase-1-*.html``: "theme-testcase-1-\*.html" to "templates/theme-\*.html"
* Fix wrong language toggle link destinations:
  * ``components/wb-suggest/suggest-fr.html``: "suggest-fr.html" to "suggest-en.html"
  * ``docs/developing-fr.md``: "developing-fr.html" to "developing-en.html"
  * ``templates/search/results-filters-en.html``: "search-fr.html" to "results-filters-fr.html"
  * ``sites/helpers/colour-*.html``: "" to "colour-\*.html"

Partially addresses #1943.