### PR TITLE
Site config: Use mixed-case "GCWeb" in website URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Local site settings
 remote_theme: wet-boew/gcweb-jekyll
 title: "GCWeb, the Canada.ca official theme" # Site name or title
-website: "https://wet-boew.github.io/gcweb/" # URL of your public facing website
+website: "https://wet-boew.github.io/GCWeb/" # URL of your public facing website
 site:
   lang: fr
 


### PR DESCRIPTION
It was originally written in lower case... but GitHub Pages' URLs are case-sensitive.

This change also indirectly fixes a broken link in the Canada.ca FIP image in most of GCWeb's page templates. That link points to the ``setting-website`` variable's value, which is sourced from the ``website`` variable.