### PR TITLE
Theme: Use 2 columns for first footer list in xs view

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -7,14 +7,14 @@
 		"modified": "dct:modified"
 	},
 	"title": {
-		"en": "Site wide demoed feature",
-		"fr": "Démonstration de fonctionalité applicable à l'ensemble du site"
+		"en": "Archived - template",
+		"fr": "Archivé - Gabarit"
 	},
 	"description": {
 		"en": "Gobal demoed feature included but need to move in its own folder.",
 		"fr": "Fonctionalité globale inclus mais qu'il nécessite qu'ils soit déplacé dans son propre dossier."
 	},
-	"modified": "2021-02-12",
+	"modified": "2022-05-03",
 	"componentName": "archived",
 	"status": "stable",
 	"pages": {
@@ -96,6 +96,16 @@
 				"title": "Pied de page complet",
 				"language": "fr",
 				"path": "footers-fr.html"
+			},
+			{
+				"title": "Complete footer version 1.0 (deprecated)",
+				"language": "en",
+				"path": "deprecated/footers-v1-en.html"
+			},
+			{
+				"title": "Pied de page complet version 1.0 (dépréciée)",
+				"language": "fr",
+				"path": "deprecated/footers-v1-fr.html"
 			},
 			{
 				"title": "Hide 'About government' from footer",

--- a/docs/static-header-footer/bootstrap-3.html
+++ b/docs/static-header-footer/bootstrap-3.html
@@ -173,7 +173,7 @@
 		<dl id="wb-dtmd">
 			<dt>Date modified:</dt>
 			<dd>
-				<time>2019-09-12</time>
+				<time>2022-05-18</time>
 			</dd>
 		</dl>
 	</div>
@@ -184,7 +184,7 @@
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="wb-inv">About government</h2>
-			<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+			<ul class="list-unstyled colcount-xs-2 colcount-md-3">
 				<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
 				<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
 				<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>

--- a/docs/static-header-footer/bootstrap-4.html
+++ b/docs/static-header-footer/bootstrap-4.html
@@ -74,7 +74,7 @@
 	<div class="pagedetails">
 		<dl id="wb-dtmd">
 				<dt>Date modified:</dt>
-				<dd><time>2019-09-12</time></dd>
+				<dd><time>2022-05-18</time></dd>
 		</dl>
 	</div>
 </main>
@@ -84,7 +84,7 @@
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="sr-only">About government</h2>
-			<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+			<ul class="list-unstyled colcount-xs-2 colcount-md-3">
 				<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
 				<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
 				<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>

--- a/docs/static-header-footer/site-assets/x-bootstrap-4.css
+++ b/docs/static-header-footer/site-assets/x-bootstrap-4.css
@@ -263,6 +263,12 @@ a.btn, .nav a {
 	margin-top: 20px;
 	width: auto;
 }
+@media screen and (min-width: 480px) {
+	.colcount-xs-2 {
+		-webkit-column-count: 2;
+		column-count: 2;
+	}
+}
 @media screen and (min-width: 768px) {
 	.colcount-sm-2 {
 		-webkit-column-count: 2;

--- a/sites/footers/deprecated/footers-v1-en.html
+++ b/sites/footers/deprecated/footers-v1-en.html
@@ -1,9 +1,50 @@
+---
+{
+	"layout": false,
+	"title": "Content page including complete footer version 1.0 (deprecated)",
+	"language": "en",
+	"altLangPage": "footers-v1-fr.html",
+	"secondlevel": false,
+	"dateModified": "2022-05-18",
+	"share": "true"
+}
+---
+{%- include variable-core.liquid -%}
+{%- capture page-title -%}
+	{%- if page.title -%}
+		{{ page.title }}
+	{%- else -%}
+		Page untitled
+	{%- endif -%}
+{%- endcapture -%}
+<!DOCTYPE html>
+<html class="no-js" lang="{{ i18nText-lang | default: 'en' }}" dir="{{ i18nText-langDir | default: 'ltr' }}">
+<head>
+<meta charset="utf-8">
+{% include license.html %}
+<title>{{ page-title }} - {{ i18nText-siteTitle }}</title>
+<meta content="width=device-width, initial-scale=1" name="viewport">
+{% include metadata.html %}
+{% include resources-inc/head.html %}
+</head>
+<body {% if page.pageclass %}class="{{ page.pageclass }}" {% endif %}vocab="http://schema.org/" typeof="WebPage">
+{%- if page.archived -%}
+	{% include headers-includes/archive.html %}
+{%- endif -%}
+{% include sites/inc-skiplinks.html %}
+{% include headers-includes/header.html %}
+<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+<h1 id="wb-cont" property="name">{{ page-title }}</h1>
+<p>This is version 1.0 (deprecated) of the page footer.</p>
+<p>It uses the <code>colcount-sm-2</code> class in the "About government" section. As of version 2.0, the class has been replaced with <code>colcount-xs-2</code> to match the "About this site" section.</p>
+{% include main-footer/inc-footer.html %}
+</main>
 <footer id="wb-info">
 {% unless page.noFooterAbout %}
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="wb-inv">{{ i18nText-footerAbout }}</h2>
-			<ul class="list-unstyled colcount-xs-2 colcount-md-3">
+			<ul class="list-unstyled colcount-sm-2 colcount-md-3">
 {%- if i18nText-lang == "fr" -%}
 				<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
 				<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
@@ -66,3 +107,6 @@
 	</div>
 </div>
 </footer>
+{% include resources-inc/footer.html %}
+</body>
+</html>

--- a/sites/footers/deprecated/footers-v1-fr.html
+++ b/sites/footers/deprecated/footers-v1-fr.html
@@ -1,9 +1,50 @@
+---
+{
+	"layout": false,
+	"title": "Page de contenu incluant le pied de page complet version 1.0 (dépréciée)",
+	"language":	"fr",
+	"altLangPage": "footers-v1-en.html",
+	"secondlevel": false,
+	"dateModified": "2022-05-18",
+	"share": "true"
+}
+---
+{%- include variable-core.liquid -%}
+{%- capture page-title -%}
+	{%- if page.title -%}
+		{{ page.title }}
+	{%- else -%}
+		Page untitled
+	{%- endif -%}
+{%- endcapture -%}
+<!DOCTYPE html>
+<html class="no-js" lang="{{ i18nText-lang | default: 'en' }}" dir="{{ i18nText-langDir | default: 'ltr' }}">
+<head>
+<meta charset="utf-8">
+{% include license.html %}
+<title>{{ page-title }} - {{ i18nText-siteTitle }}</title>
+<meta content="width=device-width, initial-scale=1" name="viewport">
+{% include metadata.html %}
+{% include resources-inc/head.html %}
+</head>
+<body {% if page.pageclass %}class="{{ page.pageclass }}" {% endif %}vocab="http://schema.org/" typeof="WebPage">
+{%- if page.archived -%}
+	{% include headers-includes/archive.html %}
+{%- endif -%}
+{% include sites/inc-skiplinks.html %}
+{% include headers-includes/header.html %}
+<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+<h1 id="wb-cont" property="name">{{ page-title }}</h1>
+<p>Voici la version 1.0 (dépréciée) du pied de page.</p>
+<p>Ça utilise la classe <code>colcount-sm-2</code> dans la section «&#160;Au sujet du gouvernement&#160;». À partir de la version 2.0, la classe a été remplacé avec <code>colcount-xs-2</code> pour correspondre à la section «&#160;Au sujet de ce site&#160;».</p>
+{% include main-footer/inc-footer.html %}
+</main>
 <footer id="wb-info">
 {% unless page.noFooterAbout %}
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="wb-inv">{{ i18nText-footerAbout }}</h2>
-			<ul class="list-unstyled colcount-xs-2 colcount-md-3">
+			<ul class="list-unstyled colcount-sm-2 colcount-md-3">
 {%- if i18nText-lang == "fr" -%}
 				<li><a href="https://www.canada.ca/fr/contact.html">Contactez-nous</a></li>
 				<li><a href="https://www.canada.ca/fr/gouvernement/min.html">Ministères et organismes</a></li>
@@ -66,3 +107,6 @@
 	</div>
 </div>
 </footer>
+{% include resources-inc/footer.html %}
+</body>
+</html>

--- a/sites/footers/footers-en.html
+++ b/sites/footers/footers-en.html
@@ -4,18 +4,19 @@
 	"language": "en",
 	"altLangPage": "footers-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-18",
 	"share": "true"
 }
 ---
 <p>Content page presenting complete default footer including the "About gvernment" section and all utility links from "About this site" section.</p>
+<p>Updated to use the <code>colcount-xs-2</code> class instead of <code>colcount-sm-2</code>.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id="wb-info"&gt;
 	&lt;div class="landscape"&gt;
 		&lt;nav class="container wb-navcurr"&gt;
 			&lt;h2 class="wb-inv"&gt;About government&lt;/h2&gt;
-			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/contact.html"&gt;Contact us&lt;/a&gt;&lt;/li&gt;
+			&lt;ul class="list-unstyled colcount-xs-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/contact.html"&gt;Contact us&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/dept.html"&gt;Departments and agencies&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/publicservice.html"&gt;Public service and military&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/en/news.html"&gt;News&lt;/a&gt;&lt;/li&gt;

--- a/sites/footers/footers-fr.html
+++ b/sites/footers/footers-fr.html
@@ -4,18 +4,19 @@
 	"language":	"fr",
 	"altLangPage": "footers-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-18",
 	"share": "true"
 }
 ---
 <p>Page de contenu préstant le pied de page complet par défaut incluant la section "Au sujet du gouvernement" et les liens de la section "Au sujet de ce site".</p>
+<p>Mise à jour pour utiliser la classe <code>colcount-xs-2</code> au lieu de <code>colcount-sm-2</code>.</p>
 
 <h2>Code de final attendu</h2>
 <pre><code>&lt;footer id="wb-info"&gt;
 	&lt;div class="landscape"&gt;
 		&lt;nav class="container wb-navcurr"&gt;
 			&lt;h2 class="wb-inv"&gt;Au sujet du gouvernement&lt;/h2&gt;
-			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/contact.html"&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
+			&lt;ul class="list-unstyled colcount-xs-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/contact.html"&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/min.html"&gt;Ministères et organismes&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html"&gt;Fonction publique et force militaire&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/nouvelles.html"&gt;Nouvelles&lt;/a&gt;&lt;/li&gt;

--- a/sites/footers/index.json-ld
+++ b/sites/footers/index.json-ld
@@ -30,6 +30,16 @@
 				"path": "footers-fr.html"
 			},
 			{
+				"title": "Complete footer version 1.0 (deprecated)",
+				"language": "en",
+				"path": "deprecated/footers-v1-en.html"
+			},
+			{
+				"title": "Pied de page complet version 1.0 (dépréciée)",
+				"language": "fr",
+				"path": "deprecated/footers-v1-fr.html"
+			},
+			{
 				"title": "Hide 'About government' from footer",
 				"language": "en",
 				"path": "no-footer-about-en.html"

--- a/sites/footers/no-footer-site-en.html
+++ b/sites/footers/no-footer-site-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "no-footer-site-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-18",
 	"share": "true",
 	"noFooterSite": "true"
 }
@@ -16,7 +16,7 @@
 	&lt;div class="landscape"&gt;
 		&lt;nav class="container wb-navcurr"&gt;
 			&lt;h2 class="wb-inv"&gt;About government&lt;/h2&gt;
-			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/contact.html"&gt;Contact us&lt;/a&gt;&lt;/li&gt;
+			&lt;ul class="list-unstyled colcount-xs-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/en/contact.html"&gt;Contact us&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/dept.html"&gt;Departments and agencies&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/en/government/publicservice.html"&gt;Public service and military&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/en/news.html"&gt;News&lt;/a&gt;&lt;/li&gt;

--- a/sites/footers/no-footer-site-fr.html
+++ b/sites/footers/no-footer-site-fr.html
@@ -4,7 +4,7 @@
 	"language":	"fr",
 	"altLangPage": "no-footer-site-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-18",
 	"share": "true",
 	"noFooterSite": "true"
 }
@@ -16,7 +16,7 @@
 	&lt;div class="landscape"&gt;
 		&lt;nav class="container wb-navcurr"&gt;
 			&lt;h2 class="wb-inv"&gt;Au sujet du gouvernement&lt;/h2&gt;
-			&lt;ul class="list-unstyled colcount-sm-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/contact.html"&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
+			&lt;ul class="list-unstyled colcount-xs-2 colcount-md-3"&gt;&lt;li&gt;&lt;a href="https://www.canada.ca/fr/contact.html"&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/min.html"&gt;Ministères et organismes&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/gouvernement/fonctionpublique.html"&gt;Fonction publique et force militaire&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href="https://www.canada.ca/fr/nouvelles.html"&gt;Nouvelles&lt;/a&gt;&lt;/li&gt;


### PR DESCRIPTION
GCWeb's footer contains two lists of links:
* The first list used to appear as a 1 column list in extra-small view and under.
* The second list used 1 column in extra-extra-small view and 2 columns in extra-small view.

That setup caused the footer to look unusually long and inconsistent on smartphones in landscape orientation.

This resolves it by adjusting the first list to use the ``colcount-xs-2`` class.

Related changes:
* Add deprecated footer pages to demonstrate the old pattern
* Add short explanations to distinguish the old and new patterns

**Screenshots:**

* **Extra-small view...**
  * **Before:**
![gcweb-footer-xs-before](https://user-images.githubusercontent.com/1907279/157304169-133a854c-71ee-42e6-aa29-2adabdf63259.png)
  * **After:**
![gcweb-footer-xs-after](https://user-images.githubusercontent.com/1907279/157304190-3d835971-67e0-4eca-adbe-a42905eceda4.png)

**Bonus screenshots (for reference):**
* **Extra-extra-small view (Before + After)...**
![gcweb-footer-xxs](https://user-images.githubusercontent.com/1907279/157304120-5ec04a83-c5e5-4ec4-bba3-dc7eee5912bc.png)
* **Small view (Before + After)...**
![gcweb-footer-sm](https://user-images.githubusercontent.com/1907279/157304148-b1a129df-769b-4ffe-876c-43004099b63d.png)