### PR TITLE
Remove Share this page button from Canada.ca home page

### DIFF
--- a/templates/home/home-en.html
+++ b/templates/home/home-en.html
@@ -5,7 +5,6 @@ altLangPage: home-fr.html
 dateModified: 2021-07-07
 layout: home
 noReportProblem: true
-share: true
 ---
 <div class="provisional bg-cover" data-bgimg-srcset="https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner-480w.jpg 479w, https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner.jpg 480w">
 	<div class="container p-0 p-sm-3">

--- a/templates/home/home-fr.html
+++ b/templates/home/home-fr.html
@@ -5,7 +5,6 @@ altLangPage: home-en.html
 dateModified: 2021-07-07
 layout: home
 noReportProblem: true
-share: true
 ---
 <div class="provisional bg-cover" data-bgimg-srcset="https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner-480w.jpg 479w, https://www.canada.ca/content/dam/canada/carousel/bkg-home-banner.jpg 480w">
 	<div class="container p-0 p-sm-3">


### PR DESCRIPTION
modify the home template to Remove Share this page button.
as per WET-237 request.