### PR TITLE
Filter: Increase input height to match adjacent button

### DIFF
--- a/components/wb-fieldflow/_base.scss
+++ b/components/wb-fieldflow/_base.scss
@@ -10,8 +10,5 @@
 		.form-control:last-child {
 			border-radius: 4px 0 0 4px;
 		}
-		input[type=submit] {
-			padding-bottom: 7px;
-		}
 	}
 }

--- a/sites/baseline/_forms.scss
+++ b/sites/baseline/_forms.scss
@@ -14,6 +14,15 @@ input[placeholder],
 	color: $input-color-placeholder;
 }
 
+// Increase likelyhood of side-by-side input/button having same height
+.input-group {
+	.form-control,
+	.input-group-addon,
+	.input-group-btn input,
+	.input-group-btn button {
+		min-height: 39px;
+	}
+}
 
 /* Exclude temporary the form element from the font update, keep same style as before
  * - Rational: More testing and various adjustment need to be completed before to apply it

--- a/sites/theme.scss
+++ b/sites/theme.scss
@@ -240,6 +240,7 @@
 	@import "gcweb-menu/screen-xs-max";
 	@import "main-footer/screen-xs-max";
 
+	@import "wet-boew/src/plugins/eqht-css/screen-xs-max";
 	@import "../components/header-rwd/screen-xs-max";
 	@import "../components/pagination/screen-xs-max";
 	@import "../components/toc/screen-xs-max";


### PR DESCRIPTION
Padding bottom was useless for inline fieldflow pattern.

This PR can be tested on the GCWeb page with WET-BOEW compiled demos: https://wet-boew.github.io/gcweb-compiled-demos/wetboew-demos/filter/filter-en.html

Plus, it can be tested on the index page and on Fieldflow main working example page (inline pattern). 

Furthermore, as an additional test you can add the following blurb of HTML in the inspector:
```
<div class="input-group">
      <div class="input-group-addon">$</div>
      <input type="text" class="form-control" id="exampleInputAmount" placeholder="Amount">
      <div class="input-group-addon">.00</div>
</div>
```


**In addition to this, I added css include recent fix for Equal height CSS component.**