### PR TITLE
Méli-mélo: Major edits to documentation

### DIFF
--- a/méli-mélo/méli-mélo-en.html
+++ b/méli-mélo/méli-mélo-en.html
@@ -3,105 +3,164 @@ title: Méli-mélo features
 description: Reusable features that are into a preliminary state of experimentation.
 lang: en
 altLangPage: méli-mélo-fr.html
-dateModified": 2021-06-22
+dateModified": 2022-04-21
+css:
+- href: https://use.fontawesome.com/releases/v5.8.1/css/all.css
+  integrity: sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf
 ---
 
-<p>Reusable <strong>features</strong> that are into a preliminary state of experimentation. Features are built from custom CSS and/or Javascript code. Check out the <a href="#mli-mlo-list">list of mélis-mélos below</a>.</p> 
+<p>Reusable features that are into a preliminary state of experimentation. Features are built from custom CSS and/or Javascript code. Once a feature is developed and minimum requirements are met, a méli-mélo can be deployed and ready for use within one week on Canada.ca. Check out <a href="#mli-mlo-list">existing mélis-mélos</a>.</p>
 
-<p class="alert alert-info"><strong>Support is provided during the <a href="https://github.com/wet-boew/wet-boew/wiki/WET-BOEW-Code-sprint">wet-boew weekly code sprint</a> happening remotely every Tuesday afternoon.</strong></p>
-
-<h2>Requirements for a proper méli-mélo feature</h2>
-
-<ul>
-	<li>Be reusable;</li>
-	<li>Be sponsored by a department and by an active representative of that department;</li>
-	<li>Must include an implementation plan that explains the steps taken by the sponsored department on how they will actively work the feature to get it integrated into GCWeb;</li>
-	<li>Must not contain any interference with wet-boew and GCWeb, meaning no component override nor extention (such thing should customization be contributed in the <a href="../components/provisional-en.html">provisional</a> or stable GCWeb or wet-boew component instead);</li>
-	<li>Each individual sub-feature and style must be demoed, for instance each CSS classes or JS configurations;</li>
-	<li>Working demo must be published using the <a href="https://github.com/wet-boew/gcweb-jekyll">GCWeb Jekyll template</a>;</li>
-	<li>Feature name must be in this format: Year and month of the time of the feature's publication followed by a short name identifying the feature (<a href="#feature-name">feature name example shown below</a>).</li>
-</ul>
-
-<h2>Contribution instructions</h2>
-
-<ul>
-	<li>Code and/or reorganize the feature by levering GCWeb Jekyll theme.</li>
-	<li>Create a feature folder in the <code>méli-mélo</code> GCWeb root folder.</li>
-	<li>Loading features must not change the state of any generic page. Features must be explicitly activated through HTML by the web publisher, like <a href="https://wet-boew.github.io/wet-boew/demos/helloworld/helloworld-en.html">wet-boew plugins</a> or by using a CSS class to hook onto an HTML element.</li>
-	<li id="feature-name">Feature's name must follow this notation: year-month-featureName. The year and month must correspond to the feature's initial publication date. For example "2021-05-steps".</li>
-	<li>Implementation plan should be published along with the feature's web pages. Each item of the implementation plan must be dated because we are going to use it to measure the integration progress into GCWeb. The expectation is to get the méli-mélo feature fully integrated into GCWeb within less than one (1) year. See an <a href="2021-05-steps/détails-en.html">example of an implementation plan</a></li>
-	<li>Test your code and submission by <a href="../index-en.html#refresh-your-github-pages-with-the-latest-theme-changes">using your GitHub pages</a>.</li>
-	<li>Submit the méli-mélo feature through a new GitHub PR in the <a href="https://github.com/wet-boew/GCWeb">GCWeb project</a>.</li>
-	<li>Once approved by the technical review, it will be assigned to a <a href="#mli-mlo-comp">méli-mélo compilation</a> and released on Canada.ca at the next release windows between 1 to 3 weeks.</li>
-	<li>Update the méli-mélo feature code by executing the implementation plan and addressing all TODO's identified by the wet-boew technical review team.</li>
-	<li>Participate at the weekly wet-boew Tuesday afternoon code sprint.</li>
-	<li>Create the GCWeb provisional/stable feature aligned with our enterprise design approach.</li>
-</ul>
-
-<h2>Technical review checklist</h2>
-
-<p>This list contains the steps that the wet-boew technical review team uses to approve new méli-mélo features.</p>
-<ul>
-	<li>Ensure the project sponsor is clearly identified;</li>
-	<li>Project folder name follows the naming convention explained above;</li>
-	<li>Each JavaScript feature and each style are demoed;</li>
-	<li>Perform a code review to ensure there are no overrides nor conflict with GCWEb and/or wet-boew;</li>
-	<li>Quickly check if we don't notice any major or obvious web accessibility and security issue. However, the accessibility conformance remains the responsibility of the publisher when implementing the feature into a web page;</li>
-	<li>Ensure the feature doesn't automatically change the state of a generic page when loaded. It must not impact any content unless the feature is explicitly activated through the HTML code, like through the use of a CSS class or the presence of a data attribute;</li>
-	<li>Review the implementation plan to ensure it contains a reasonable due date and deliverable. It must include:
-		<ul>
-			<li>Engagement with the Digital Transformation Office (DTO) at Treasury Board Secretariat;</li>
-			<li>Review and perform the identification of the feature transformation requirement to be able to complete the integration progress into GCWeb;</li>
-			<li>Produce accessibility conformance report and attach usability report, if any;</li>
-			<li>Transformation of the méli-mélo functionality into a GCWeb provisional feature;</li>
-			<li>Complete feature stabilisation task, like working example translation, writing guidance, publishing ACRs, feature API documentation, etc.</li>
-		</ul>
-	</li>
-</ul>
-
-<h2 id="mli-mlo-comp">Méli-mélo compilations</h2>
-
-<div class="well">
-	<p>Features are grouped into <strong>compilations</strong> in order to quickly:</p>
-	<ul>
-		<li>initiate usability research;</li>
-		<li>initiate preliminary discussion with key organisation; and</li>
-		<li>transforming the feature into a high quality produit adapted for GCWeb.</li>
-	</ul>
+<div class="alert alert-info">
+	<p><strong>Did you know?</strong> Support for méli-mélo is provided during weekly <a href="https://github.com/wet-boew/wet-boew/wiki/WET-Office-hours,-Heures-de-service-de-la-BOEW">WET Office hours</a> hold remotely every Tuesday afternoon.</p>
 </div>
 
-<p>Every compilations life expectancy is less than one (1) year. That should provide a feature's <strong>sponsor department</strong> enough time to find resources to make their feature progressing as an official GCWeb feature. A <a href="compilation-gelé/index.html" hreflang="fr">frozen (expired) méli-mélo compilation</a> should not be used into any web page.</p>
+<h2 id="mli-mlo-comp">Compilations</h2>
 
-<p>This framework for méli-mélo compilations and features are excluded from the <a href="https://wet-boew.github.io/wet-boew-documentation/decision/3.html">GCWeb public API</a>. Any change or removal would only trigger a patch release of GCWeb. That means the author are fully responsible but not required to documents any subsequent change they would make at their méli-mélo feature.</p>
+<p><strong>Every compilation's life expectancy is estimated to be approximately one (1) year</strong>, after which point it becomes "frozen" (deprecated). This should provide a feature's sponsor enough time to find resources to make their feature progressing towards an official GCWeb feature. Using a <a href="compilation-gelé/index.html" hreflang="fr">frozen méli-mélo compilation</a> into any web page is not strongly discouraged. It must be replaced by the corresponding GCWeb feature, another méli-mélo compilation or simply removed.</p>
 
-<h3 id="mli-mlo-list">List of active méli-mélo compilations</h3>
-
+<p>Features are grouped into compilations in order to quickly:</p>
 <ul>
+	<li>initiate usability research;</li>
+	<li>initiate preliminary discussion with key organisation; and</li>
+	<li>transforming the feature into a high quality reusable product adapted for GCWeb;</li>
+	<li>regroup and ease a central coordination for new innovations.</li>
+</ul>
+
+<h3 id="mli-mlo-list">Active méli-mélo compilations and their features</h3>
+
+<ul class="row list-unstyled wb-eqht-grd mrgn-tp-md">
+
 {% for item in site.data[ "mli-mlo" ].packages %}
-	<li>{{ item.nom }}
-		<ul>
-		{% for pack in item.libs %}
-			{% assign indexPage = site.data[ "mli-mlo" ].subProjects | where: "nom", pack | first %}
-			<li><a href="/gcweb-compiled-demos/méli-mélo-demos/{{ item.nom }}/{{ pack }}/{{ indexPage.mainpage }}">{{ pack }}</a></li>
-		{% endfor %}
-		</ul>
+	<li class="col-xs-12 col-md-4 mrgn-tp-md mrgn-bttm-md">
+		<div class="brdr-tp brdr-rght brdr-bttm brdr-lft hght-inhrt">
+			<h4 class="mrgn-tp-md mrgn-rght-md mrgn-bttm-md mrgn-lft-md">{{ item.nom }}</h4>
+			<div class="mrgn-rght-md mrgn-bttm-md mrgn-lft-md">
+				<ul class="mrgn-bttm-lg mrgn-lft-md">
+				{% for pack in item.libs %}
+					{% assign indexPage = site.data[ "mli-mlo" ].subProjects | where: "nom", pack | first %}
+					<li><a href="/gcweb-compiled-demos/méli-mélo-demos/{{ item.nom }}/{{ pack }}/{{ indexPage.mainpage }}">{{ pack }}</a></li>
+				{% endfor %}
+				</ul>
+			</div>
+		</div>
 	</li>
 {% endfor %}
 </ul>
 
-<p><small>(<a href="compilation-gelé/index.html" hreflang="fr">View the frozen and deprecated méli-mélo compilations (in French only)</a>.)</small></p>
+<p><small>(<a href="compilation-gelé/index.html" hreflang="fr">View frozen and deprecated méli-mélo compilations (in French only)</a>.)</small></p>
 
-<h3>List of méli-mélo sub-compilations (features)</h3>
+<h2>Creating a Méli-mélo feature</h2>
 
-{% assign melimelo_pages = site.pages | where: "output", "false" | where: "feature", "méli-mélo" | sort: "componentName" %}
+<p>Have a feature ready to be submitted as a méli-mélo? Here are the things you need to know.</p>
+
+<fieldset class="gc-chckbxrdio">
+	<legend id="requirements">Minimum requirements for a new feature are:</legend>
+	<ul class="list-unstyled lst-spcd-2">
+		<li class="checkbox">
+			<input type="checkbox" id="req1">
+			<label for="req1">Must be reusable;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req2">
+			<label for="req2">Must not contain any interference with WET-BOEW &amp; GCWeb, meaning no component override nor conflict. When possible, component extension should be contributed in the <a href="../components/provisional-en.html">provisional</a> or stable component instead;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req3">
+			<label for="req3">Must be built with accessibility and security in mind. Accessibility conformance remains the responsibility of the publisher when implementing the feature into a web page;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req4">
+			<label for="req4">Must not impact any content by default on page load by leveraging closure technique unless the feature is explicitly activated through the HTML, either by using a CSS class or data attribute, for example <a href="https://wet-boew.github.io/wet-boew/demos/helloworld/helloworld-en.html">sample WET-BOEW plugin</a>;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req5">
+			<label for="req5">Must have its name in the right format (see <a href="#feature-name">feature name example below</a>).</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req6">
+			<label for="req6">Must be <a href="#sponsor" rel="help">sponsored<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a> by a department, with an active representative of that department;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req7">
+			<label for="req7">Must include an <a href="#implementation-plan" rel="help">implementation plan<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a>;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req8">
+			<label for="req8">Must have a demo / working example published for each individual sub-features and styles, meaning each JS configurations and CSS classes respectively;</label>
+		</li>
+	</ul>
+</fieldset>
+
+<h3>Get started</h3>
+
+<p>Below are instructions on how to create a new méli-mélo feature in GCWeb.</p>
+
+<div class="panel panel-info">
+    <div class="panel-heading">
+		<h4 class="panel-title">Tip to quickly get started!</h4>
+	</div>
+	<div class="panel-body">
+		<p>Start by coding and/or exposing your feature and its demo(s) by leveraging <a href="https://github.com/wet-boew/gcweb-jekyll">GCWeb Jekyll theme</a> before your contribution to GCWeb.</p>
+	</div>
+</div>
+
+<ol class="lst-spcd-2">
+	<li>Ensure your feature code is all included in one (1) JavaScript file and/or on (1) CSS file.</li>
+	<li>Create a new feature folder inside the <a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo"><code>/méli-mélo</code></a> GCWeb root folder.</li>
+	<li id="feature-name">Name your feature and its folder by following this notation: <code>YYYY-MM-[FeatureName]</code>. The year and month must correspond to the feature's initial publication date. For example "2021-05-steps".</li>
+	<li>Create and publish your demo / working example for each individual sub-features and styles, meaning each JS configurations and CSS classes respectively, either using the <a href="https://github.com/wet-boew/gcweb-jekyll">GCWeb Jekyll theme</a> or GCWeb itself.</li>
+	<li>Designate a <a href="#sponsor" rel="help">sponsor<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a> for the feature.</li>
+	<li>Build and publish an <a href="#implementation-plan" rel="help">implementation plan<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a>.</li>
+	<li>Ensure all <a href="#requirements">minimum requirements listed above</a> are met.</li>
+	<li><strong>Optional:</strong> Test your code by following the instructions on <a href="../docs/developing-en.html">developing for GCWeb</a>.</li>
+	<li>Submit your new feature through a GitHub Pull request (PR) in the GCWeb repository; please consult <a href="https://github.com/wet-boew/GCWeb/blob/master/CONTRIBUTING.md">contribution guidelines</a>.</li>
+	<li>If changes are requested on your PR after technical review (as per <a href="#tech-checklist">checklist below</a>), collaborate with the WET-BOEW team to get it approved. For reference, first-time contribution usually requires 3+ rounds of back-and-forth code review taking a week each time.</li>
+	<li>Once your PR is approved, your feature will be assigned to a <a href="#mli-mlo-comp">méli-mélo compilation</a> and released on Canada.ca at the next release window one (1) week after code is merged.</li>
+	<li><strong>Strongly recommended:</strong> After release, update the méli-mélo feature code by executing the implementation plan and addressing all TODO's identified by the WET-BOEW team.</li>
+	<li><strong>Recommended:</strong> Whenever possible, participate at the weekly <a href="https://github.com/wet-boew/wet-boew/wiki/WET-Office-hours,-Heures-de-service-de-la-BOEW">WET Office hours</a> on Tuesday afternoon. The WET-BOEW team will be able to help you progress in your contribution and execute your implementation plan by finding ways to remove any technical or procedural barriers you may encounter.</li>
+</ol>
+
+<p class="mrgn-tp-lg">See <a href="2021-05-steps/index.html">2021-05-steps</a> and its <a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">folder on GitHub</a> as a complete example of a méli-mélo feature containing all the required information.</p>
+
+<details id="tech-checklist" class="mrgn-tp-lg mrgn-bttm-lg">
+	<summary>Technical review checklist</summary>
+
+	<p>This list contains the steps that the WET-BOEW team uses to approve new méli-mélo features.</p>
+	<ul>
+		<li>Ensure the <a href="#sponsor">project sponsor</a> is clearly identified;</li>
+		<li>Project folder name follows the proper naming convention: <code>YYYY-MM-[FeatureName]</code>;</li>
+		<li>Ensure each JavaScript feature and each CSS style comes with a demo / working example;</li>
+		<li>Perform a code review to ensure there are no overrides nor conflict with GCWeb and/or WET-BOEW;</li>
+		<li>Perform a quick check for any major or obvious web accessibility and security issue;</li>
+		<li>Ensure the feature doesn't impact any content by default on page load by leveraging closure technique unless the feature is explicitly activated through the HTML, either through the use of a CSS class or data attribute;</li>
+		<li>Review the <a href="#implementation-plan">implementation plan</a> to ensure it contains reasonable due dates and deliverables.</li>
+	</ul>
+</details>
+
+<h4 id="sponsor">Sponsor</h4>
+
+<p>A sponsor is an entity responsible for ensuring a méli-mélo feature progresses towards a stable &amp; widely reusable feature as per the implementation plan. The sponsor will most likely be the author of a feature, representing their department.</p>
+
+<h4 id="implementation-plan">Implementation plan</h4>
+
+<p>The implementation plan, also known as a planning horizon, is meant to set milestones in order to get a méli-mélo feature stabilized into the WET-BOEW / GCWeb code base. It must contain the following milestones:</p>
 
 <ul>
-{% for feature in melimelo_pages %}
-	{% assign featBasePath = feature.path | slice: 0, 10 %}
-	{% if featBasePath == "méli-mélo/" %}
-	<li><a href="{{ feature.componentName }}/détails-en.html">{{ feature.componentName }}</a></li>
-	{% endif %}
-{% endfor %}
+	<li>Engagement with the Digital Transformation Office (DTO) at Treasury Board Secretariat;</li>
+	<li>Review and perform the identification of the feature transformation requirement to be able to complete the integration progress into GCWeb;</li>
+	<li>Produce accessibility conformance report and attach usability report (if any);</li>
+	<li>Transformation of the méli-mélo functionality into a GCWeb provisional feature;</li>
+	<li>Complete feature stabilisation task, including amongst other things working example translation, writing guidance, publishing <abbr title="Accessibility Conformance Reports">ACR</abbr>s, feature API documentation, etc.</li>
 </ul>
 
-<p class="mrgn-tp-lg"><strong>See also:</strong> <a href="../thématique/gc-thématique-en.html">GC promotional thematics</a> for custom code that is explicitly for promotional content and that affects a respectable set of pages.</p>
+<p>Each item of the plan must have an <strong>estimated due date</strong> as an indicator to measure integration progress into GCWeb. The expectation is to get the méli-mélo feature fully integrated into GCWeb within its lifespan of approximatively one (1) year. See an <a href="https://raw.githubusercontent.com/wet-boew/GCWeb/master/m%C3%A9li-m%C3%A9lo/2021-05-steps/meta.md">example of an implementation plan</a>.</p>
+
+<h4>Versioning</h4>
+
+<p>This framework for méli-mélo compilations and features are excluded from the <a href="https://wet-boew.github.io/wet-boew-documentation/decision/3.html">GCWeb public API</a>. Any change or removal would only trigger a patch release of GCWeb. This means developers are fully responsible (but not required) to document any subsequent change they make to their méli-mélo feature.</p>
+
+<div class="well mrgn-tp-lg">
+	<h2 class="h4 mrgn-tp-sm">See also:</h2>
+	<p><a href="../thématique/gc-thématique-en.html">GC promotional thematics</a> for custom code explicitly dedicated to promotional content that affects a set of pages.</p>
+</div>

--- a/méli-mélo/méli-mélo-fr.html
+++ b/méli-mélo/méli-mélo-fr.html
@@ -3,109 +3,164 @@ title: Fonctionalités méli-mélo
 description: Fonctionalités réutilisables étant dans un stade préliminaire d'expérimentation.
 lang: fr
 altLangPage: méli-mélo-en.html
-dateModified": 2021-06-22
+dateModified": 2022-04-21
+css:
+- href: https://use.fontawesome.com/releases/v5.8.1/css/all.css
+  integrity: sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf
 ---
 
-<p><strong>Fonctionalités</strong> réutilisables étant dans un stade préliminaire d'expérimentation. Les fonctionnalités sont composées de code CSS et/ou Javascript personnalisé. Voir la <a href="#mli-mlo-liste">liste des mélis-mélos ci-dessous</a>.</p>
+<p>Fonctionalités réutilisables étant dans un stade préliminaire d'expérimentation. Les fonctionnalités sont composées de code personnalisé CSS et/ou Javascript. Dès qu'une fonctionnalité est développée et que les exigences minimales sont rencontrées, un méli-mélo peut être déployé et prêt à être utilisé à l'intérieur d'une semaine sur Canada.ca. Voir les <a href="#mli-mlo-liste">mélis-mélos existants</a>.</p>
 
-<p class="alert alert-info"><strong>Du support est offert durant les <a href="https://github.com/wet-boew/wet-boew/wiki/WET-BOEW-Code-sprint">"code sprint" hebdomadaire de wet-boew</a> qui ont lieu à distance tous les mardis après-midis.</strong></p>
-
-<p><strong>Le contenu qui suit doit être traduit.</strong></p>
-<div lang="en">
-
-<h2>Requirements for a proper méli-mélo feature</h2>
-
-<ul>
-	<li>Be reusable;</li>
-	<li>Be sponsored by a department and by an active representative of that department;</li>
-	<li>Must include an implementation plan that explains the steps taken by the sponsored department on how they will actively work the feature to get it integrated into GCWeb;</li>
-	<li>Must not contain any interference with wet-boew and GCWeb, meaning no component override nor extention (such thing should customization be contributed in the <a href="../components/provisional-en.html">provisional</a> or stable GCWeb or wet-boew component instead);</li>
-	<li>Each individual sub-feature and style must be demoed, for instance each CSS classes or JS configurations;</li>
-	<li>Working demo must be published using the <a href="https://github.com/wet-boew/gcweb-jekyll">GCWeb Jekyll template</a>;</li>
-	<li>Feature name must be in this format: Year and month of the time of the feature's publication followed by a short name identifying the feature (<a href="#feature-name">feature name example shown below</a>).</li>
-</ul>
-
-<h2>Contribution instructions</h2>
-
-<ul>
-	<li>Code and/or reorganize the feature by levering GCWeb Jekyll theme.</li>
-	<li>Create a feature folder in the <code>méli-mélo</code> GCWeb root folder.</li>
-	<li>Loading features must not change the state of any generic page. Features must be explicitly activated through HTML by the web publisher, like <a href="https://wet-boew.github.io/wet-boew/demos/helloworld/helloworld-en.html">wet-boew plugins</a> or by using a CSS class to hook onto an HTML element.</li>
-	<li id="feature-name">Feature's name must follow this notation: year-month-featureName. The year and month must correspond to the feature's initial publication date. For example "2021-05-steps".</li>
-	<li>Implementation plan should be published along with the feature's web pages. Each item of the implementation plan must be dated because we are going to use it to measure the integration progress into GCWeb. The expectation is to get the méli-mélo feature fully integrated into GCWeb within less than one (1) year. See an <a href="2021-05-steps/détails-en.html">example of an implementation plan</a></li>
-	<li>Test your code and submission by <a href="../index-en.html#refresh-your-github-pages-with-the-latest-theme-changes">using your GitHub pages</a>.</li>
-	<li>Submit the méli-mélo feature through a new GitHub PR in the <a href="https://github.com/wet-boew/GCWeb">GCWeb project</a>.</li>
-	<li>Once approved by the technical review, it will be assigned to a <a href="#mli-mlo-comp">méli-mélo compilation</a> and released on Canada.ca at the next release windows between 1 to 3 weeks.</li>
-	<li>Update the méli-mélo feature code by executing the implementation plan and addressing all TODO's identified by the wet-boew technical review team.</li>
-	<li>Participate at the weekly wet-boew Tuesday afternoon code sprint.</li>
-	<li>Create the GCWeb provisional/stable feature aligned with our enterprise design approach.</li>
-</ul>
-
-<h2>Technical review checklist</h2>
-
-<p>This list contains the steps that the wet-boew technical review team uses to approve new méli-mélo features.</p>
-<ul>
-	<li>Ensure the project sponsor is clearly identified;</li>
-	<li>Project folder name follows the naming convention explained above;</li>
-	<li>Each JavaScript feature and each style are demoed;</li>
-	<li>Perform a code review to ensure there are no overrides nor conflict with GCWEb and/or wet-boew;</li>
-	<li>Quickly check if we don't notice any major or obvious web accessibility and security issue. However, the accessibility conformance remains the responsibility of the publisher when implementing the feature into a web page;</li>
-	<li>Ensure the feature doesn't automatically change the state of a generic page when loaded. It must not impact any content unless the feature is explicitly activated through the HTML code, like through the use of a CSS class or the presence of a data attribute;</li>
-	<li>Review the implementation plan to ensure it contains a reasonable due date and deliverable. It must include:
-		<ul>
-			<li>Engagement with the Digital Transformation Office (DTO) at Treasury Board Secretariat;</li>
-			<li>Review and perform the identification of the feature transformation requirement to be able to complete the integration progress into GCWeb;</li>
-			<li>Produce accessibility conformance report and attach usability report, if any;</li>
-			<li>Transformation of the méli-mélo functionality into a GCWeb provisional feature;</li>
-			<li>Complete feature stabilisation task, like working example translation, writing guidance, publishing ACRs, feature API documentation, etc.</li>
-		</ul>
-	</li>
-</ul>
-
+<div class="alert alert-info">
+	<p><strong>Saviez-vous que&nbsp;?</strong> Du support est offert durant les <a href="https://github.com/wet-boew/wet-boew/wiki/WET-Office-hours,-Heures-de-service-de-la-BOEW">Heures de service de la BOEW</a> qui ont lieu à distance tous les mardis après-midis.</p>
 </div>
 
-<h2 id="mli-mlo-comp">Compilations méli-mélo</h2>
+<h2 id="mli-mlo-comp">Compilations</h2>
 
-<div class="well">
-	<p>Les fonctionalités sont regroupées sous forme de <strong>compilations</strong> afin de rapidement&nbsp;:</p>
-	<ul>
-		<li>amorcer des recherches de convivialité;
-		<li>amorcer les discussions préliminaires avec les organismes organismes clef; et</li>
-		<li>transformer les fonctionnalités en produits de qualité adaptées pour GCWeb.</li>
-	</ul>
-</div>
+<p><strong>La durée de vie approximative de chaque compilation est d'environ un (1) an</strong>, après quoi il devient "gelé" (obsolette). Cela devrait donner assez de temps au département parrain de trouver les ressources nécessaires afin de faire progresser leur fonctionnalité expérimentale vers une fonctionnalité officelle de GCWeb. Utiliser une <a href="compilation-gelé/index.html" hreflang="fr">compilation méli-mélo gelée</a> sur une page web est fortement déconseillé. Ce doit être remplacé soit par la fonctionnalité GCWeb correspondante, par une autre compilation méli-mélo ou bien simplement être retiré.</p>
 
-<p>La durée de vie de chaque compilation est de un (1) an. Cela devrait donner assez de temps au <strong>département parrain</strong> d'une fonctionnalité de trouver les ressources nécessaires afin de la faire progresser vers une fonctionnalité officelle de GCWeb. Une <a href="compilation-gelé/index.html" hreflang="fr">compilation méli-mélo gelée et obselette</a> ne devrait pas être utilisée sur une page web.</p>
-
-<p>Ce système de compilations et fonctionnalités méli-mélo est exlcus de <a href="https://wet-boew.github.io/wet-boew-documentation/decision/3.html" hreflang="en">l'API publique de GCWeb (en anglais seulement)</a>. Tout changement ou retrait déclancherait seulement un déploiement de type "correctif" sur GCWeb. Cela signifie que l'auteur(e) est complètement responsable, mais n'est pas dans l'obligation, de documenter tout changement subséquent qu'il/elle apporterait à sa fonctionnalité méli-mélo.</p>
-
-<h3 id="mli-mlo-liste">Liste des compilations méli-mélo actives</h3>
+<p>Les fonctionalités sont regroupées sous forme de compilations afin de rapidement&nbsp;:</p>
 <ul>
+	<li>amorcer des recherches de convivialité;
+	<li>amorcer les discussions préliminaires avec les organismes organismes clef;</li>
+	<li>transformer les fonctionnalités en produits de qualité adaptées pour GCWeb; et</li>
+	<li>regrouper et facilité une coordination centralisé pour les innovateurs(rices).</li>
+</ul>
+
+<h3 id="mli-mlo-liste">Compilations méli-mélo actives et leurs fonctionnalités</h3>
+
+<ul class="row list-unstyled wb-eqht-grd mrgn-tp-md">
+
 {% for item in site.data[ "mli-mlo" ].packages %}
-	<li>{{ item.nom }}
-		<ul>
-		{% for pack in item.libs %}
-			{% assign indexPage = site.data[ "mli-mlo" ].subProjects | where: "nom", pack | first %}
-			<li><a href="/gcweb-compiled-demos/méli-mélo-demos/{{ item.nom }}/{{ pack }}/{{ indexPage.mainpage }}">{{ pack }}</a></li>
-		{% endfor %}
-		</ul>
-	</li>
+	<li class="col-xs-12 col-md-4 mrgn-tp-md mrgn-bttm-md">
+		<div class="brdr-tp brdr-rght brdr-bttm brdr-lft hght-inhrt">
+			<h4 class="mrgn-tp-md mrgn-rght-md mrgn-bttm-md mrgn-lft-md">{{ item.nom }}</h4>
+			<div class="mrgn-rght-md mrgn-bttm-md mrgn-lft-md">
+				<ul class="mrgn-bttm-lg mrgn-lft-md">
+				{% for pack in item.libs %}
+					{% assign indexPage = site.data[ "mli-mlo" ].subProjects | where: "nom", pack | first %}
+					<li><a href="/gcweb-compiled-demos/méli-mélo-demos/{{ item.nom }}/{{ pack }}/{{ indexPage.mainpage }}">{{ pack }}</a></li>
+				{% endfor %}
+			</ul>
+		</div>
+	</div>
+</li>
 {% endfor %}
 </ul>
 
 <p><small>(<a href="compilation-gelé/index.html">Consulter les compilations méli-mélo gelées et obselettes</a>.)</small></p>
 
-<h3>Liste des sous-compilations méli-mélo (fonctionnalités)</h3>
+<h2>Créer une fonctionnalité méli-mélo</h2>
 
-{% assign melimelo_pages = site.pages | where: "output", "false" | where: "feature", "méli-mélo" | sort: "componentName" %}
+<p>Vous avez une fonctionnalité prête à être soumisie en tant que méli-mélo? Voici ce que vous devez savoir.</p>
+
+<fieldset class="gc-chckbxrdio">
+	<legend id="exigences">Les exigences minimales pour une nouvelle fonctionnalité sont&nbsp;:</legend>
+	<ul class="list-unstyled lst-spcd-2">
+		<li class="checkbox">
+			<input type="checkbox" id="req1">
+			<label for="req1">Doit être réutilisable;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req2">
+			<label for="req2">Ne doit pas présenter d'interférence avec WET-BOEW &amp; GCWeb, c'est-à-dire aucun chevauchement ou collision. Lorsque possible, l'extension d'une composante devrait être contribuée directement à travers la composante <a href="../components/provisional-fr.html">provisionnelle</a> ou stable;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req3">
+			<label for="req3">Doit être développé avec l'accessibilité et la sécurité en tête. La conformance à l'accessibilité demeure la responsabilité d'un éditeur lorsqu'il ou elle implémente la fonctionnalité sur une page web;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req4">
+			<label for="req4">Ne doit pas affecter de contenu par défaut lors du chargement de la page en utilisant la technique de "closure" sauf si elle est explicitement activée à travers le HTML, soit à travers l'utilisation d'une classe CSS ou d'un attribut "data", tout comme le <a href="https://wet-boew.github.io/wet-boew/demos/helloworld/helloworld-en.html">plugiciel WET-BOEW d'exemple</a>;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req5">
+			<label for="req5">Doit avoir un nom dans le bon format (voir <a href="#feature-name">exemple de nom de fonctionnalité ci-dessous</a>).</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req6">
+			<label for="req6">Doit être <a href="#parrainage" rel="help">parrainé<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a> par un département, avec un représentant actif de celui-ci;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req7">
+			<label for="req7">Doit inclure un <a href="#implementation-plan" rel="help">plan d'implémentation<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a>;</label>
+		</li>
+		<li class="checkbox">
+			<input type="checkbox" id="req8">
+			<label for="req8">Doit avoir un démo / exemple pratique publié pour chaque sous-fonctionnalité et style individuellement, soit chaque configuration JS et chaque classe CSS respectivement;</label>
+		</li>
+	</ul>
+</fieldset>
+
+<h3>Débuter</h3>
+
+<p>Vous trouverez ci-dessous les instructions sur comment créer une nouvelle fonctionnalité méli-mélo dans GCWeb.</p>
+
+<div class="panel panel-info">
+    <div class="panel-heading">
+		<h4 class="panel-title">Astuce pour débuter rapidement&nbsp;!</h4>
+	</div>
+	<div class="panel-body">
+		<p>Commencez par coder et/ou exposer votre fonctionnalité et son ou ses démo(s) grâce au <a href="https://github.com/wet-boew/gcweb-jekyll">thème GCWeb Jekyll</a> avant votre contribution à GCWeb.</p>
+	</div>
+</div>
+
+<ol class="lst-spcd-2">
+	<li>Assurez-vous que le code de votre fonctionnalité est compris dans un seul fichier JavaScript et/our un fichier CSS.</li>
+	<li>Créez un nouveau dossier de fonctionnalité à l'intérieur du dossier <a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo"><code>/méli-mélo</code></a> à la racine de GCWeb.</li>
+	<li id="feature-name">Nommez votre fonctionnalité et son dossier en suivant la nomenclature suivante&nbsp;: <code>AAAA-MM-[NomFonctionnalité]</code>. L'année et le mois doivent correspondent à la date de publication initiale de la fonctionnalité. Par exemple "2021-05-steps".</li>
+	<li>Créez et publiez vos démos / exemples pratiques pour chaque sous-fonctionnalité et style individuellement, soit chaque configuration JS et chaque classe CSS respectivement, soit en utilisant le thème GCWeb Jekyll ou bien GCWeb directement.</li>
+	<li>Désignez un <a href="#parrainage" rel="help">parrain<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a> pour la fonctionnalité.</li>
+	<li>Écrivez et publiez le <a href="#implementation-plan" rel="help">plan d'implémentation<sup aria-hidden="true"><span class="fas fa-info-circle"></span></sup></a>.</li>
+	<li>Assurez-vous que toutes les <a href="#exigences">exigences minimales affiché plus haut</a> sont rencontrées.</li>
+	<li><strong>Optionnel&nbsp;:</strong> Testez votre code en suivant les instructions sur comment <a href="../docs/developing-fr.html">développer pour GCWeb</a>.</li>
+	<li>Soumettez votre nouvelle fonctionnalité à travers une demandes de tirage (Pull Requests) (PR) dans le répertoire GCWeb; veuillez svp consulter les <a href="https://github.com/wet-boew/GCWeb/blob/master/CONTRIBUTING.md">lignes directrices de contribution</a>.</li>
+	<li>Si des changements sont jugées nécessaires après la revue technique de la PR (selon la <a href="#tech-checklist">liste de vérification ci-dessous</a>), collaborez avec l'équipe de la WET-BOEW pour la faire approuver. À titre de référence, une première contribution méli-mélo prend habituellement 3+ rondes de revue de code prenant chacune une semaine.</li>
+	<li>Une fois votre PR approuvée, votre fonctionnalité sera assignée à une <a href="#mli-mlo-comp">compilation méli-mélo</a> et déployée sur Canada.ca lors de la prochaine fenêtre de déploiement une (1) semaine après que le code soit fusionné.</li>
+	<li><strong>Fortement recommandé&nbsp;:</strong> Après le déploiement, mettez à jour le code de la fonctionnalité méli-mélo en exécutant le plan d'implémentation et en adressant tous les items à faire identifiés par l'équipe de la WET-BOEW.</li>
+	<li><strong>Recommandé&nbsp;:</strong> Aussi souvent que possible, participez aux <a href="https://github.com/wet-boew/wet-boew/wiki/WET-Office-hours,-Heures-de-service-de-la-BOEW">Heures de service de la BOEW</a> les mardis après-midis. L'équipe de la WET-BOEW sera en mesure de vous aider à progresser et exécuter votre plan d'implémentation en trouvant des façons d'enlever les barrières techniques ou procédurales que vous rencontrez.</li>
+</ol>
+
+<p class="mrgn-tp-lg">Voyez un exemple complet d'une fonctionnalité méli-mélo contenant toute l'information demandée en consultant <a href="2021-05-steps/index.html">2021-05-steps</a> et son <a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">dossier sur GitHub</a> .</p>
+
+<details id="tech-checklist" class="mrgn-tp-lg mrgn-bttm-lg">
+	<summary>Liste de vérification pour revue technique</summary>
+
+	<p>Cette liste contient les étapes que l'équipe de la WET-BOEW suivent pour approuver les nouvelles fonctionnalités mélis-mélos.</p>
+	<ul>
+		<li>S'assure que le <a href="#parrainage">parrain</a> est clairement identifié;</li>
+		<li>Vérifie que le nom du dossier du projet suit la bonne nomenclature&nbsp;: <code>AAAA-MM-[NomFonctionnalité]</code>;</li>
+		<li>S'assure que chaque sous-fonctionnalité JavaScript et style CSS présente un démo / exemple pratique;</li>
+		<li>Performe une revue du code afin d'assurer qu'il n'y a pas de chevauchement ou de collision avec GCWeb and/or WET-BOEW;</li>
+		<li>Effectue une vérification rapide pour trouver des problèmes majeurs ou évident d'accessibilité ou de sécurité;</li>
+		<li>S'assure que la fonctionnalité n'affecte pas de contenu par défaut lors du chargement de la page en utilisant la technique de "closure" sauf si elle est explicitement activée à travers le HTML, soit à travers l'utilisation d'une classe CSS ou d'un attribut "data";</li>
+		<li>Révise le <a href="#implementation-plan">plan d'implémentation</a> afin d'assurer qu'il contient des livrables et dates butoirs raisonables.</li>
+	</ul>
+</details>
+
+<h4 id="parrainage">Parrainage</h4>
+
+<p>Le parrain est une entité responsable d'assurer qu'une fonctionnalité méli-mélo progresse vers une fonctionnalité stable &amp; largement réutilisable tel que prescrit par le plan d'implémentation. Les chances sont grandes que le parrain d'une fonctionnalité soit l'auteur de celle-ci, puis que cette entité représente son département.</p>
+
+<h4 id="implementation-plan">Plan d'implémentation</h4>
+
+<p>Le plan d'implémentation permet de mettre en place des étapes importantes afin d'arriver à stabiliser une fonctionnalité méli-mélo dans le code de WET-BOEW / GCWeb. Le plan doit contenir les étapes suivantes&nbsp;:</p>
 
 <ul>
-{% for feature in melimelo_pages %}
-	{% assign featBasePath = feature.path | slice: 0, 10 %}
-	{% if featBasePath == "méli-mélo/" %}
-	<li><a href="{{ feature.componentName }}/détails-fr.html">{{ feature.componentName }}</a></li>
-	{% endif %}
-{% endfor %}
+	<li>Collaboration avec le Bureau de la transformation numérique (BTN) au Secrétariat du Conseil du Trésor du Canada;</li>
+	<li>Réviser et performer l'identification du changement nécessaire afin de compléter l'intégration à GCWeb;</li>
+	<li>Produire un rapport de conformance à l'accessibilité et attacher un rapport de convivialité (le cas échéant);</li>
+	<li>Transformation de la fonctionnalité méli-mélo en tant que fonctionnalité provisionel dans GCWeb;</li>
+	<li>Compléter la tâche de stabilisation, qui inclue entre autres la traduction des l'exemple pratique, écrire les directives, publier le rapport de conformance à l'accessibilité, la documentation de l'API, etc.</li>
 </ul>
 
-<p class="mrgn-tp-lg"><strong>Voir aussi&nbsp;:</strong> <a href="../thématique/gc-thématique-fr.html">thématiques promotionnelles du GC</a> pour du code personnalisé qui est explicitement dédié au contenu promotionnel et qui affecte un nombre respectable de pages.</p>
+<p>Chaque élément du plan doit avoir une <strong>date butoir estimée</strong> en tant qu'indicateur pour mesurer le progrès de l'intégration à GCWeb. Ce qui est attendu est d'avoir la fonctionnalité méli-mélo intégrée à GCWeb à l'intérieur de sa durée de vie d'environ un (1) an. Voyez un <a href="https://raw.githubusercontent.com/wet-boew/GCWeb/master/m%C3%A9li-m%C3%A9lo/2021-05-steps/meta.md">exemple de plan d'implémentation</a>.</p>
+
+<h4>Version</h4>
+
+<p>Ce système de compilations et fonctionnalités méli-mélo est exlcus de <a href="https://wet-boew.github.io/wet-boew-documentation/decision/3.html" hreflang="en">l'API publique de GCWeb (en anglais seulement)</a>. Tout changement ou retrait déclancherait seulement un déploiement de type "correctif" sur GCWeb. Cela signifie que le développeur est complètement responsable, mais n'est pas dans l'obligation, de documenter tout changement subséquent qu'il/elle apporterait à sa fonctionnalité méli-mélo.</p>
+
+<div class="well mrgn-tp-lg">
+	<h2 class="h4 mrgn-tp-sm">Voir aussi&nbsp;:</h2>
+	<p><a href="../thématique/gc-thématique-fr.html">thématiques promotionnelles du GC</a> pour du code personnalisé qui est explicitement dédié au contenu promotionnel et qui affecte un nombre respectable de pages.</p>
+</div>


### PR DESCRIPTION
Simplify and improve main méli-mélo documentation page for future contributors.

Live example for review here: https://gormfrank.github.io/website-gcweb/meli-melo.html (ignore broken links)