### PR TITLE
Footer: Update top of page link's destination

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -250,6 +250,16 @@
 				"path": "deprecated/footers-v1-fr.html"
 			},
 			{
+				"title": "Complete footer version 2.0 (deprecated)",
+				"language": "en",
+				"path": "deprecated/footers-v2-en.html"
+			},
+			{
+				"title": "Pied de page complet version 2.0 (dépréciée)",
+				"language": "fr",
+				"path": "deprecated/footers-v2-fr.html"
+			},
+			{
 				"title": "Hide 'About government' from footer",
 				"language": "en",
 				"path": "no-footer-about-en.html"

--- a/docs/static-header-footer/bootstrap-3.html
+++ b/docs/static-header-footer/bootstrap-3.html
@@ -173,7 +173,7 @@
 		<dl id="wb-dtmd">
 			<dt>Date modified:</dt>
 			<dd>
-				<time>2022-05-18</time>
+				<time>2022-05-25</time>
 			</dd>
 		</dl>
 	</div>
@@ -210,7 +210,7 @@
 						<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
 					</ul>
 				</nav>
-				<div class="col-xs-6 visible-sm visible-xs tofpg"> <a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a> </div>
+				<div class="col-xs-6 visible-sm visible-xs tofpg"> <a href="#wb-tphp">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a> </div>
 				<div class="col-xs-6 col-md-3 col-lg-2 text-right"> <img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"> </div>
 			</div>
 		</div>

--- a/sites/footers/deprecated/footers-v2-en.html
+++ b/sites/footers/deprecated/footers-v2-en.html
@@ -1,3 +1,44 @@
+---
+{
+	"layout": false,
+	"title": "Content page including complete footer version 2.0 (deprecated)",
+	"language": "en",
+	"altLangPage": "footers-v1-fr.html",
+	"secondlevel": false,
+	"dateModified": "2022-05-25",
+	"share": "true"
+}
+---
+{%- include variable-core.liquid -%}
+{%- capture page-title -%}
+	{%- if page.title -%}
+		{{ page.title }}
+	{%- else -%}
+		Page untitled
+	{%- endif -%}
+{%- endcapture -%}
+<!DOCTYPE html>
+<html class="no-js" lang="{{ i18nText-lang | default: 'en' }}" dir="{{ i18nText-langDir | default: 'ltr' }}">
+<head>
+<meta charset="utf-8">
+{% include license.html %}
+<title>{{ page-title }} - {{ i18nText-siteTitle }}</title>
+<meta content="width=device-width, initial-scale=1" name="viewport">
+{% include metadata.html %}
+{% include resources-inc/head.html %}
+</head>
+<body {% if page.pageclass %}class="{{ page.pageclass }}" {% endif %}vocab="http://schema.org/" typeof="WebPage">
+{%- if page.archived -%}
+	{% include headers-includes/archive.html %}
+{%- endif -%}
+{% include sites/inc-skiplinks.html %}
+{% include header/header.html %}
+<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+<h1 id="wb-cont" property="name">{{ page-title }}</h1>
+<p>This is version 2.0 (deprecated) of the page footer.</p>
+<p>Its "Top of page" link points to <code>#wb-cont</code> (top of the content area). As of version 3.0, the link's destination has changed to <code>#wb-tphp</code> (top of the page).</p>
+{% include page-details/footer.html %}
+</main>
 <footer id="wb-info">
 {% unless page.noFooterAbout %}
 	<div class="landscape">
@@ -66,3 +107,6 @@
 	</div>
 </div>
 </footer>
+{% include resources-inc/footer.html %}
+</body>
+</html>

--- a/sites/footers/deprecated/footers-v2-fr.html
+++ b/sites/footers/deprecated/footers-v2-fr.html
@@ -1,3 +1,44 @@
+---
+{
+	"layout": false,
+	"title": "Page de contenu incluant le pied de page complet version 2.0 (dépréciée)",
+	"language":	"fr",
+	"altLangPage": "footers-v1-en.html",
+	"secondlevel": false,
+	"dateModified": "2022-05-25",
+	"share": "true"
+}
+---
+{%- include variable-core.liquid -%}
+{%- capture page-title -%}
+	{%- if page.title -%}
+		{{ page.title }}
+	{%- else -%}
+		Page untitled
+	{%- endif -%}
+{%- endcapture -%}
+<!DOCTYPE html>
+<html class="no-js" lang="{{ i18nText-lang | default: 'en' }}" dir="{{ i18nText-langDir | default: 'ltr' }}">
+<head>
+<meta charset="utf-8">
+{% include license.html %}
+<title>{{ page-title }} - {{ i18nText-siteTitle }}</title>
+<meta content="width=device-width, initial-scale=1" name="viewport">
+{% include metadata.html %}
+{% include resources-inc/head.html %}
+</head>
+<body {% if page.pageclass %}class="{{ page.pageclass }}" {% endif %}vocab="http://schema.org/" typeof="WebPage">
+{%- if page.archived -%}
+	{% include headers-includes/archive.html %}
+{%- endif -%}
+{% include sites/inc-skiplinks.html %}
+{% include header/header.html %}
+<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+<h1 id="wb-cont" property="name">{{ page-title }}</h1>
+<p>Voici la version 2.0 (dépréciée) du pied de page.</p>
+<p>Il utilise un lien nommé «&#160;Haut de la page&#160;» qui pointe vers <code>#wb-cont</code> (haut du contenu). À partir de la version 3.0, la destination du lien a changé à <code>#wb-tphp</code> (haut de la page).</p>
+{% include page-details/footer.html %}
+</main>
 <footer id="wb-info">
 {% unless page.noFooterAbout %}
 	<div class="landscape">
@@ -66,3 +107,6 @@
 	</div>
 </div>
 </footer>
+{% include resources-inc/footer.html %}
+</body>
+</html>

--- a/sites/footers/footers-en.html
+++ b/sites/footers/footers-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "footers-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-05-18",
+	"dateModified": "2022-05-25",
 	"share": "true"
 }
 ---
@@ -39,7 +39,7 @@
 						&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/privacy.html"&gt;Privacy&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
 				&lt;/nav&gt;
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;
 				&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;
 					&lt;img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;

--- a/sites/footers/footers-fr.html
+++ b/sites/footers/footers-fr.html
@@ -4,7 +4,7 @@
 	"language":	"fr",
 	"altLangPage": "footers-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-05-18",
+	"dateModified": "2022-05-25",
 	"share": "true"
 }
 ---
@@ -39,7 +39,7 @@
 						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/confidentialite.html"&gt;Confidentialité&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
 				&lt;/nav&gt;
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;
 				&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;
 					&lt;img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;

--- a/sites/footers/index.json-ld
+++ b/sites/footers/index.json-ld
@@ -40,6 +40,16 @@
 				"path": "deprecated/footers-v1-fr.html"
 			},
 			{
+				"title": "Complete footer version 2.0 (deprecated)",
+				"language": "en",
+				"path": "deprecated/footers-v2-en.html"
+			},
+			{
+				"title": "Pied de page complet version 2.0 (dépréciée)",
+				"language": "fr",
+				"path": "deprecated/footers-v2-fr.html"
+			},
+			{
 				"title": "Hide 'About government' from footer",
 				"language": "en",
 				"path": "no-footer-about-en.html"

--- a/sites/footers/no-footer-about-en.html
+++ b/sites/footers/no-footer-about-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "no-footer-about-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-25",
 	"share": "true",
 	"noFooterAbout": "true"
 }
@@ -25,7 +25,7 @@
 						&lt;li&gt;&lt;a href="https://www.canada.ca/en/transparency/privacy.html"&gt;Privacy&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
 				&lt;/nav&gt;
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;

--- a/sites/footers/no-footer-about-fr.html
+++ b/sites/footers/no-footer-about-fr.html
@@ -4,7 +4,7 @@
 	"language":	"fr",
 	"altLangPage": "no-footer-about-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-25",
 	"share": "true",
 	"noFooterAbout": "true"
 }
@@ -25,7 +25,7 @@
 						&lt;li&gt;&lt;a href="https://www.canada.ca/fr/transparence/confidentialite.html"&gt;Confidentialité&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
 				&lt;/nav&gt;
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;&lt;div class="col-xs-6 col-md-3 col-lg-2 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;

--- a/sites/footers/no-footer-site-en.html
+++ b/sites/footers/no-footer-site-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "no-footer-site-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-05-18",
+	"dateModified": "2022-05-25",
 	"share": "true",
 	"noFooterSite": "true"
 }
@@ -32,7 +32,7 @@
 			&lt;div class="row "&gt;
 
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;

--- a/sites/footers/no-footer-site-fr.html
+++ b/sites/footers/no-footer-site-fr.html
@@ -4,7 +4,7 @@
 	"language":	"fr",
 	"altLangPage": "no-footer-site-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-05-18",
+	"dateModified": "2022-05-25",
 	"share": "true",
 	"noFooterSite": "true"
 }
@@ -32,7 +32,7 @@
 			&lt;div class="row "&gt;
 
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;

--- a/sites/footers/no-footers-en.html
+++ b/sites/footers/no-footers-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "no-footers-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-25",
 	"share": "true",
 	"noFooterAbout": "true",
 	"noFooterSite": "true"
@@ -20,7 +20,7 @@
 		&lt;div class="container"&gt;
 			&lt;div class="row "&gt;
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Top of Page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbol of the Government of Canada"&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;

--- a/sites/footers/no-footers-fr.html
+++ b/sites/footers/no-footers-fr.html
@@ -4,7 +4,7 @@
 	"language":	"fr",
 	"altLangPage": "no-footers-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-01-12",
+	"dateModified": "2022-05-25",
 	"share": "true",
 	"noFooterAbout": "true",
 	"noFooterSite": "true"
@@ -20,7 +20,7 @@
 		&lt;div class="container"&gt;
 			&lt;div class="row "&gt;
 				&lt;div class="col-xs-6 visible-sm visible-xs tofpg"&gt;
-					&lt;a href="#wb-cont"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#wb-tphp"&gt;Haut de la page &lt;span class="glyphicon glyphicon-chevron-up"&gt;&lt;/span&gt;&lt;/a&gt;
 				&lt;/div&gt;&lt;div class="col-xs-6 col-md-12 text-right"&gt;&lt;img src="/dist/GCWeb/assets/wmms-blk.svg" alt="Symbole du gouvernement du Canada"&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;


### PR DESCRIPTION
GCWeb's "Top of page"/"Haut de la page" link was previously pointing to ``#wb-cont``. That's the primary H1 heading's ID (usually top of the content area). The link text was misleading since it didn't actually go to the top of the page.

This resolves it by changing the link's destination to ``#wb-tphp``. That ID is fit for purpose. Older versions of WET also used top of page links that pointed to that ID.