### PR TITLE
Forms: Increase required asterisk variable's width

### DIFF
--- a/sites/_variables.scss
+++ b/sites/_variables.scss
@@ -51,6 +51,9 @@ $wb-bc-separator-content: ">"; // GCWeb v5
 $wb-bc-separator-content-rtl: "<"; // GCWeb v5
 $wb-bc-separator-font-size: .7em; // GCWeb v5
 
+// Forms
+$wb-forms-asterisk-width: .87em; // Asterisk offset for required field labels.
+
 //Heading links on landing pages
 $heading-link: 20px; // same as h5
 $heading-link-mrgn-tp: 23px;


### PR DESCRIPTION
* Necessary due to GCWeb using a wider font face than WET
* Prevents the asterisk from appearing on a separate line in Chromium/Firefox when a required standalone checkbox uses a multi-line label
* Fixes label/legend offsetting issues in Chromium/Firefox:
  * The first line of required labels/legends was previously getting shifted rightwards, which made the first line look misaligned compared to nearby field controls and subsequent lines in multi-line labels/legends
* Increases space between asterisks and required labels/legends in IE11 due to CSS bugs involving pseudo-elements in that browser
* Follow-up to wet-boew/wet-boew#9371

**Screenshots:**
* **Firefox (Chromium is virtually identical)...**
  * **Required text field with multi-line label:**
    * **Before:**
![firefox-text-before](https://user-images.githubusercontent.com/1907279/175120317-154d0c7e-0357-4488-9467-ea49306b2c70.png)
    * **After:**
![firefox-text-after](https://user-images.githubusercontent.com/1907279/175098382-9e923218-f6e9-4779-9a84-27598061d4d4.png)
  * **Required standalone checkbox with multi-line label:**
    * **Before:**
![firefox-checkbox-before](https://user-images.githubusercontent.com/1907279/175136341-cbc86a1b-50f5-4223-8d95-a0b00d9e9e3f.png)
    * **After:**
![firefox-checkbox-after](https://user-images.githubusercontent.com/1907279/175331015-f1962d27-ced6-4d99-80bf-0f0f9a185dde.png)
  * **Horizontal checkboxes:**
    * **Before:**
![firefox-horizontal-checkboxes-before](https://user-images.githubusercontent.com/1907279/175098358-e12d9f5a-3069-4ac2-8405-b053e83470a9.png)
    * **After:**
![firefox-horizontal-checkboxes-after](https://user-images.githubusercontent.com/1907279/175098368-1e9d1c73-1157-4d62-9c95-3f30c1e30357.png)
* **Internet Explorer 11 (looks slightly inferior)...**
  * **Required text field with multi-line label:**
    * **Before:**
![ie11-text-before](https://user-images.githubusercontent.com/1907279/175099049-618e7291-fc3f-4650-abbc-63e6cc92b3f4.png)
    * **After:**
![ie11-text-after](https://user-images.githubusercontent.com/1907279/175099076-e59b782a-364a-4ff6-b593-6089f870c10b.png)
  * **Required standalone checkbox with multi-line label:**
    * **Before:**
![ie11-checkbox-before](https://user-images.githubusercontent.com/1907279/175136535-4d3a35c2-f1df-48f0-9217-81509661debe.png)
    * **After:**
![ie11-checkbox-after](https://user-images.githubusercontent.com/1907279/175136559-b42f1416-8929-491e-8e1c-170b4513eeb8.png)
  * **Horizontal checkboxes:**
    * **Before:**
![ie11-horizontal-checkboxes-before](https://user-images.githubusercontent.com/1907279/175099161-e879e3c2-a509-44c7-8971-bfba89264f4e.png)
    * **After:**
![ie11-horizontal-checkboxes-after](https://user-images.githubusercontent.com/1907279/175099181-55af29a1-a907-45da-a0cd-90a7e4d83739.png)