### PR TITLE
Page details: Fix links to report a problem's AJAX fragment

### DIFF
--- a/sites/feedback/includes/feedback.html
+++ b/sites/feedback/includes/feedback.html
@@ -2,7 +2,7 @@
 	{%- if page.feedbackPath -%}
 		{{ page.feedbackPath }}
 	{%- elsif site.global.feedbackPath and site.global.feedbackPath.first -%}
-		{{ site.global.feedbackPath[ i18nText-lang ] }}
+		{{ site.global.feedbackPath[ i18nText-lang ] | relative_url }}
 	{%- endif -%}
 {%- endcapture -%}
 

--- a/sites/page-details/page-details-docs-en.html
+++ b/sites/page-details/page-details-docs-en.html
@@ -7,9 +7,9 @@
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2022-04-25",
+	"dateModified": "2022-06-30",
 	"share": true,
-	"feedbackPath": "/sites/feedback/ajax/report-problem-en.html"
+	"feedbackPath": "../feedback/ajax/report-problem-en.html"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -20,7 +20,7 @@
 	<dt>Type</dt>
 	<dd>Canada.ca site functionality</dd>
 	<dt>Last review</dt>
-	<dd>2022-04-25</dd>
+	<dd>2022-06-30</dd>
 </dl>
 
 <h2>Purpose</h2>
@@ -212,7 +212,7 @@
 	&lt;h2 class="wb-inv"&gt;Page details&lt;/h2&gt;
 	&lt;div class="row"&gt;
 		&lt;div class="col-sm-8 col-md-9 col-lg-9"&gt;
-			&lt;/sites/feedback/ajax/report-problem-en.html" &gt;
+			&lt;div data-ajax-replace="../feedback/ajax/report-problem-en.html" &gt;
 				&lt;div class=&quot;row row-no-gutters&quot;&gt;
 					&lt;div class=&quot;col-sm-9 col-md-6 col-lg-5&quot;&gt;
 						&lt;a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html"&gt;Report a problem on this page&lt;/a&gt;

--- a/sites/page-details/page-details-docs-fr.html
+++ b/sites/page-details/page-details-docs-fr.html
@@ -7,7 +7,7 @@
 		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2022-04-25",
+	"dateModified": "2022-06-30",
 	"share": "true",
 	"feedbackPath": "../feedback/ajax/report-problem-en.html"
 }
@@ -20,7 +20,7 @@
 	<dt>Type</dt>
 	<dd>Fonctionnalité du site Canada.ca</dd>
 	<dt>Dernière révision</dt>
-	<dd>2022-04-25</dd>
+	<dd>2022-06-30</dd>
 </dl>
 
 <h2>Objectif</h2>
@@ -89,7 +89,7 @@
 	&lt;h2 class="wb-inv"&gt;Détails de la page&lt;/h2&gt;
 	&lt;div class="row"&gt;
 		&lt;div class="col-sm-8 col-md-9 col-lg-9"&gt;
-			&lt;div data-ajax-replace="../feedback/ajax/report-problem-fr.html">
+			&lt;div data-ajax-replace="../feedback/ajax/report-problem-fr.html"&gt;
 				&lt;div class=&quot;row row-no-gutters&quot;&gt;
 					&lt;div class=&quot;col-sm-11 col-md-7 col-lg-6&quot;&gt;
 						&lt;a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html"&gt;Signaler un problème <ins>ou une erreur</ins> sur cette page &lt;/a&gt;
@@ -213,7 +213,7 @@
 	&lt;h2 class="wb-inv"&gt;Détails de la page&lt;/h2&gt;
 	&lt;div class="row"&gt;
 		&lt;div class="col-sm-8 col-md-9 col-lg-9"&gt;
-			&lt;div data-ajax-replace="../feedback/ajax/report-problem-fr.html">
+			&lt;div data-ajax-replace="../feedback/ajax/report-problem-fr.html"&gt;
 				&lt;div class=&quot;row row-no-gutters&quot;&gt;
 					&lt;div class=&quot;col-sm-11 col-md-7 col-lg-6&quot;&gt;
 						&lt;a class="btn btn-default btn-block" href="https://www.canada.ca/fr/signaler-probleme.html"&gt;Signaler un problème <ins>ou une erreur</ins> sur cette page &lt;/a&gt;


### PR DESCRIPTION
On GitHub Pages, most of the repo's pages are currently unable to load the report a problem widget's AJAX fragment due to the ``feedbackPath`` variable beginning with "/sites/...". It probably works fine in local instances of Jekyll, but fails on GH Pages. Why? Because GCWeb's GH Pages site uses "/GCWeb/" as its top-level folder.

This fixes it by adding Liquid's ``relative_url`` filter in the Data Ajax plugin's default reference to ``feedbackPath``. Using it causes ``site.baseurl`` to be prepended to ``feedbackPath``. That should produce "/sites/..." in local Jekyll instances and "/GCWeb/sites/..." in GH Pages.

The ``relative_url`` filter isn't applied to pages that override the ``feedbackPath`` variable. Therefore, overrides must use paths that are relative to the current page.

Related changes:
* Page details documentation:
  * English version:
    * Fix custom path for ``feedbackPath`` that wasn't relative to the page
    * Add missing ``data-ajax-replace`` attribute in the "Page details without 'Share this page' button" code sample
  * French version:
    * Fix greater than signs (``>``) that weren't coded as named entities

Supersedes part of #1975.