### PR TITLE
Jekyll: Update templates data file

### DIFF
--- a/_data/templates.json
+++ b/_data/templates.json
@@ -880,7 +880,7 @@
 		"en": "Search templates",
 		"fr": "Gabarit pour les pages de recherche"
 	},
-	"modified": "2020-04-16",
+	"modified": "2022-07-06",
 	"componentName": "search",
 	"status": "stable",
 	"pages": {
@@ -922,7 +922,7 @@
 			{
 				"title": "API documentations",
 				"language": "en",
-				"path": "api.html"
+				"path": "api-en.html"
 			}
 		],
 		"impl-ref": [


### PR DESCRIPTION
Running ``grunt`` on a clean ``master`` branch was polluting the working directory since the repo's version of ``_data/template.json`` was out of date (probably a leftover from #1993).

This commits the aforementioned changes.