### PR TITLE
Footer: Add a page details i18n variable

### DIFF
--- a/sites/includes/i18n.liquid
+++ b/sites/includes/i18n.liquid
@@ -25,6 +25,8 @@
 
 	{% assign i18nText-menuAjax = "https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-fr.html" %}
 
+	{% assign i18nText-pageDetails = "Détails de la page" %}
+
 	{% assign i18nText-feedback = "Signaler un problème ou une erreur sur cette page" %}
 	{% assign i18nText-feedbackLink = "https://www.canada.ca/fr/signaler-probleme.html" %}
 
@@ -46,6 +48,8 @@
 	{% assign i18nText-archived-desc = "You can use it for research or reference." %}
 
 	{% assign i18nText-menuAjax = "https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html" %}
+
+	{% assign i18nText-pageDetails = "Page details" %}
 
 	{% assign i18nText-feedback = "Report a problem on this page" %}
 	{% assign i18nText-feedbackLink = "https://www.canada.ca/en/report-problem.html" %}

--- a/sites/page-details/includes/footer.html
+++ b/sites/page-details/includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="pagedetails{% if include.addContainer %} container{% endif %}">
-	<h2 class="wb-inv">Page details</h2>
+	<h2 class="wb-inv">{{ i18nText-pageDetails }}</h2>
 
 	{%- if page.noReportProblem -%}
 		{%- if page.share -%}


### PR DESCRIPTION
"Page details" was previously hardcoded into the footer include's visually-hidden ``H2`` heading. As a result, French pages were using the English version of that heading.

This resolves it by adding an ``i18nText-pageDetails`` variable and using it in place of the English heading content.