### PR TITLE
Components example - addition of navigation buttons

### DIFF
--- a/components/gc-servinfo/gc-srvinfo-examples.html
+++ b/components/gc-servinfo/gc-srvinfo-examples.html
@@ -17,6 +17,11 @@
 	<p>The following working examples are based on the <a href="gc-srvinfo.html">services and information technical specification</a>. The content and structure of this page might not consistant with the rest of this site.</p>
 </div>
 
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="gc-srvinfo.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-srvinfo">Questions ou commentaires?</a></li>
+</ul>
+
 <h2 id="eg1">Example 1: Doormat links in 2 columns pattern</h2>
 <section class="gc-srvinfo">
 	<h2>Services and information</h2>

--- a/components/gc-subway/gc-subway-en.html
+++ b/components/gc-subway/gc-subway-en.html
@@ -5,11 +5,16 @@
 	"altLangPage": "gc-subway-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"dateModified": "2021-10-15",
+	"dateModified": "2022-08-25",
 	"share": "true"
 }
 ---
 {% include alert-provisional.html provisionaldir="../" %}
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-subway">Questions or comments?</a></li>
+</ul>
 
 <nav class="provisional gc-subway">
 	<h1 id="gc-document-nav">[Service name]</h1>

--- a/components/gc-subway/gc-subway-fr.html
+++ b/components/gc-subway/gc-subway-fr.html
@@ -5,11 +5,16 @@
 	"altLangPage": "gc-subway-en.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"dateModified": "2021-10-15",
+	"dateModified": "2022-08-25",
 	"share": "true"
 }
 ---
 {% include alert-provisional.html provisionaldir="../" %}
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-subway">Questions ou commentaires?</a></li>
+</ul>
 
 <nav class="provisional gc-subway">
 	<h1 id="gc-document-nav">[Nom du service]</h1>

--- a/components/gc-subway/index-en.html
+++ b/components/gc-subway/index-en.html
@@ -6,7 +6,7 @@
 	"parentdir": "gc-subway",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"dateModified": "2020-12-07",
+	"dateModified": "2022-08-25",
 	"share": "true"
 }
 ---
@@ -14,6 +14,11 @@
 {% include alert-provisional.html provisionaldir="../" %}
 
 <h1 property="name" id="wb-cont" class="gc-thickline">GC Subway Index</h1>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-subway">Questions or comments?</a></li>
+</ul>
 
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
 	ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation

--- a/components/gc-subway/index-fr.html
+++ b/components/gc-subway/index-fr.html
@@ -6,7 +6,7 @@
 	"parentdir": "gc-subway",
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
-	"dateModified": "2020-12-07",
+	"dateModified": "2022-08-25",
 	"share": "true"
 }
 ---
@@ -14,6 +14,11 @@
 {% include alert-provisional.html provisionaldir="../" %}
 
 <h1 property="name" id="wb-cont" class="gc-thickline">Page d'introduction de navigation par carte de métro</h1>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-subway">Questions ou commentaires?</a></li>
+</ul>
 
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
 	ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation

--- a/components/gc-subway/page2-en.html
+++ b/components/gc-subway/page2-en.html
@@ -6,11 +6,16 @@
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
 	"secondlevel": false,
-	"dateModified": "2021-10-15",
+	"dateModified": "2022-08-25",
 	"share": "true"
 }
 ---
 {% include alert-provisional.html provisionaldir="../" %}
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-subway">Questions or comments?</a></li>
+</ul>
 
 <nav class="provisional gc-subway">
 	<h1 id="gc-document-nav">[Service name]</h1>

--- a/components/gc-subway/page2-fr.html
+++ b/components/gc-subway/page2-fr.html
@@ -6,11 +6,16 @@
 	"pageclass": "cnt-wdth-lmtd",
 	"layout": "without-h1",
 	"secondlevel": false,
-	"dateModified": "2021-10-15",
+	"dateModified": "2022-08-25",
 	"share": "true"
 }
 ---
 {% include alert-provisional.html provisionaldir="../" %}
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=gc-subway">Questions ou commentaires?</a></li>
+</ul>
 
 <nav class="provisional gc-subway">
 	<h1 id="gc-document-nav">[Nom du service]</h1>

--- a/components/wb-chtwzrd/chatwizard-en.html
+++ b/components/wb-chtwzrd/chatwizard-en.html
@@ -6,10 +6,15 @@ description: "Working example - provisional feature"
 tag: "chatwizard"
 parentdir: "chatwizard"
 altLangPage: "chatwizard-fr.html"
-dateModified: "2020-04-16"
+dateModified: "2022-08-25"
 ---
 
 {% include alert-provisional.html provisionaldir="../" %}
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=chat-wizard">Questions or comments?</a></li>
+</ul>
 
 <ul>
 	<li><a href="chatwizard-en.html">Chat wizard</a></li>

--- a/components/wb-chtwzrd/chatwizard-fr.html
+++ b/components/wb-chtwzrd/chatwizard-fr.html
@@ -6,11 +6,17 @@ description: "Example pratique d'utilisation du chat wizard"
 tag: "chatwizard"
 parentdir: "chatwizard"
 altLangPage: "chatwizard-en.html"
-dateModified: "2020-04-16"
+dateModified: "2022-08-25"
 ---
 {% include alert-provisional.html provisionaldir="../" %}
 
 <div class="wb-prettify all-pre"></div>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=chat-wizard">Questions ou commentaires?</a></li>
+</ul>
+
 <div lang="en">
 <p><strong>Need translation</strong></p>
 

--- a/components/wb-chtwzrd/chatwizard-json-en.html
+++ b/components/wb-chtwzrd/chatwizard-json-en.html
@@ -6,9 +6,14 @@ description: "Working example - provisional feature"
 tag: "chatwizard"
 parentdir: "chatwizard"
 altLangPage: "chatwizard-json-fr.html"
-dateModified: "2020-04-16"
+dateModified: "2022-08-25"
 ---
 {% include alert-provisional.html provisionaldir="../" %}
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=chat-wizard">Questions or comments?</a></li>
+</ul>
 
 <ul>
 	<li><a href="chatwizard-en.html">Chat wizard</a></li>

--- a/components/wb-chtwzrd/chatwizard-json-fr.html
+++ b/components/wb-chtwzrd/chatwizard-json-fr.html
@@ -6,11 +6,17 @@ description: "Example pratique d'utilisation du chat wizard"
 tag: "chatwizard"
 parentdir: "chatwizard"
 altLangPage: "chatwizard-json-en.html"
-dateModified: "2020-04-16"
+dateModified: "2022-08-25"
 ---
 {% include alert-provisional.html provisionaldir="../" %}
 
 <div class="wb-prettify all-pre"></div>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="docs.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=chat-wizard">Questions ou commentaires?</a></li>
+</ul>
+
 <div lang="en">
 <p><strong>Need translation</strong></p>
 

--- a/components/wb-data-json/index.json-ld
+++ b/components/wb-data-json/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "Insert content extracted from a JSON file.",
 		"fr": "Insertion de contenu extrait d'un fichier JSON"
 	},
-	"modified": "2019-09-05",
+	"modified": "2022-08-25",
 	"componentName": "wb-data-json",
 	"status": "stable",
 	"pages": {
@@ -22,12 +22,12 @@
 			{
 				"title": "Data JSON",
 				"language": "en",
-				"url": "https://wet-boew.github.io/gcweb-compiled-demos/wetboew-demos/wb-data-json/data-json-en.html"
+				"url": "https://wet-boew.github.io/wet-boew/demos/wb-data-json/data-json-en.html"
 			},
 			{
 				"title": "Data JSON",
 				"language": "fr",
-				"url": "https://wet-boew.github.io/gcweb-compiled-demos/wetboew-demos/wb-data-json/data-json-fr.html"
+				"url": "https://wet-boew.github.io/wet-boew/demos/wb-data-json/data-json-fr.html"
 			},
 			{
 				"title": "Template HTML 5",
@@ -49,7 +49,7 @@
 			{
 				"title": "Data JSON",
 				"language": "fr",
-				"url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-data-json/wb-data-json-fr.html"
+				"url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-data-json/wb-data-json-en.html"
 			}
 		]
 	}

--- a/components/wb-jsonmanager/index.json-ld
+++ b/components/wb-jsonmanager/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "Manage dataset and apply JSON Patch",
 		"fr": "Gérer des jeux de données et applique des correctifs JSON."
 	},
-	"modified": "2020-10-13",
+	"modified": "2022-08-25",
 	"componentName": "wb-jsonmanager",
 	"status": "stable",
 	"pages": {
@@ -22,12 +22,12 @@
 			{
 				"title": "JSON Manager",
 				"language": "en",
-				"url": "https://wet-boew.github.io/gcweb-compiled-demos/wetboew-demos/wb-jsonmanager/jsonmanager-en.html"
+				"url": "https://wet-boew.github.io/wet-boew/demos/wb-jsonmanager/jsonmanager-en.html"
 			},
 			{
 				"title": "Gestionnaire JSON",
 				"language": "fr",
-				"url": "https://wet-boew.github.io/gcweb-compiled-demos/wetboew-demos/wb-jsonmanager/jsonmanager-fr.html"
+				"url": "https://wet-boew.github.io/wet-boew/demos/wb-jsonmanager/jsonmanager-fr.html"
 			},
 			{
 				"title": "with Do Action patches",

--- a/components/wb-urlmapping/ajax-en.html
+++ b/components/wb-urlmapping/ajax-en.html
@@ -7,9 +7,14 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "ajax-fr.html",
-	"dateModified": "2017-02-03"
+	"dateModified": "2022-08-25"
 }
 ---
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=UrlMapping+ajax">Questions or comments?</a></li>
+</ul>
+
 <p>Execute pre-configured ajax action based on url query string.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/components/wb-urlmapping/ajax-fr.html
+++ b/components/wb-urlmapping/ajax-fr.html
@@ -7,9 +7,14 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "ajax-en.html",
-	"dateModified": "2017-02-03"
+	"dateModified": "2022-08-25"
 }
 ---
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=UrlMapping+ajax">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Exécute des requête ajax pré-établis selon la correspondance des paramètres de l'URL.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/components/wb-urlmapping/geomap-en.html
+++ b/components/wb-urlmapping/geomap-en.html
@@ -7,7 +7,7 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "geomap-fr.html",
-	"dateModified": "2019-03-20"
+	"dateModified": "2022-08-25"
 }
 ---
 <ul class="list-inline">

--- a/components/wb-urlmapping/geomap-fr.html
+++ b/components/wb-urlmapping/geomap-fr.html
@@ -7,7 +7,7 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "geomap-en.html",
-	"dateModified": "2019-03-20"
+	"dateModified": "2022-08-25"
 }
 ---
 <ul class="list-inline">

--- a/components/wb-urlmapping/patches-en.html
+++ b/components/wb-urlmapping/patches-en.html
@@ -7,9 +7,14 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "patches-fr.html",
-	"dateModified": "2017-02-03"
+	"dateModified": "2022-08-25"
 }
 ---
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=UrlMapping+patches">Questions or comments?</a></li>
+</ul>
+
 <p>Execute pre-configured JSON patches action based on url query string.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/components/wb-urlmapping/patches-fr.html
+++ b/components/wb-urlmapping/patches-fr.html
@@ -7,9 +7,14 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "patches-en.html",
-	"dateModified": "2017-02-03"
+	"dateModified": "2022-08-25"
 }
 ---
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=UrlMapping+patches">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Exécute des requête d'application de correctifs JSON pré-établis selon la correspondance des paramètres de l'URL.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/components/wb-urlmapping/tblfilter-en.html
+++ b/components/wb-urlmapping/tblfilter-en.html
@@ -7,9 +7,14 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "tblfilter-fr.html",
-	"dateModified": "2017-02-03"
+	"dateModified": "2022-08-25"
 }
 ---
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=UrlMapping+tblFilter">Questions or comments?</a></li>
+</ul>
+
 <p>Execute pre-configured table filtering action based on url query string.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/components/wb-urlmapping/tblfilter-fr.html
+++ b/components/wb-urlmapping/tblfilter-fr.html
@@ -7,9 +7,14 @@
 	"tag": "urlmapping",
 	"parentdir": "urlmapping",
 	"altLangPage": "tblfilter-en.html",
-	"dateModified": "2017-02-03"
+	"dateModified": "2022-08-25"
 }
 ---
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=UrlMapping+tblFilter">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Exécute des requête de filtrage de tableau pré-établis selon la correspondance des paramètres de l'URL.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/components/wb-urlmapping/urlmapping-doc-en.html
+++ b/components/wb-urlmapping/urlmapping-doc-en.html
@@ -10,6 +10,12 @@
 }
 ---
 <div class="wb-prettify all-pre"></div>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="urlmapping-doc-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=url-mapping">Questions or comments?</a></li>
+</ul>
+
 <section>
 	<h2>Purpose</h2>
 	<p>Performing a action base on the url query string after wet-boew is ready.</p>

--- a/components/well-bold/well-bold-en.html
+++ b/components/well-bold/well-bold-en.html
@@ -2,7 +2,7 @@
 breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
 ]
-dateModified: "2022-04-28"
+dateModified: "2022-08-25"
 description: "Working example for the well bold"
 language: "en"
 altLangPage: "well-bold-fr.html"
@@ -10,6 +10,11 @@ title: "Well bold"
 ---
 
 <span class="wb-prettify all-pre hide"></span>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="well-bold-doc-en.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=WellBold">Questions or comments?</a></li>
+</ul>
 
 <p>Well bold (v1.0)</p>
 <div class="well well-bold">

--- a/components/well-bold/well-bold-fr.html
+++ b/components/well-bold/well-bold-fr.html
@@ -2,7 +2,7 @@
 breadcrumbs: [
 	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
 ]
-dateModified: "2022-04-28"
+dateModified: "2022-08-25"
 description: "Documentation et exemple pratique d'une boîte grise en gras"
 language: "fr"
 altLangPage: "well-bold-en.html"
@@ -10,6 +10,11 @@ title: "Boîte grise en gras"
 ---
 
 <span class="wb-prettify all-pre hide"></span>
+
+<ul class="list-inline">
+	<li><a class="btn btn-primary" href="well-bold-doc-fr.html">Documentation</a></li>
+	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=WellBold">Questions ou commentaires?</a></li>
+</ul>
 
 <h2>Objectif</h2>
 <p>Ceci applique un poid de police de caractère gras à chaque élément de texte à l'intérieur d'un composant boite grise et génère un poid de police de caractère normale lorsque l'élément <code>strong </code> est appliqué.</p>

--- a/index-fr.md
+++ b/index-fr.md
@@ -119,7 +119,7 @@ css:
 					Main working example
 					- First working example in the example list where the language match
 					-->
-					{% assign mainExamples = list-pages.examples | where: "language", page.lang | first %}
+					{% assign mainExamples = list-pages.examples | where: "language", page.language | first %}
 					<ul class="list-unstyled mrgn-bttm-lg mrgn-lft-md">
 					{% if mainExamples %}
 					<li>


### PR DESCRIPTION
1. Addition of the following navigation buttons to component example pages:
   * "Documentation" in order to navigate back to the documentation page from the component example page.
   * "Questions or comments?" to navigate to a form on github where you can insert a comment, a question and/or raising an issue related to the component.

2. Fixing French language script on the index page for components example links to point to the French version. Currently, it falls back to the English version.

3. Fixing documentation inks that were still pointing to GCWeb when they were supposed to point to WET-BOEW