### PR TITLE
keeping stacked "and" design same as side-by-side

### DIFF
--- a/méli-mélo/2021-05-conjunction/and-or.css
+++ b/méli-mélo/2021-05-conjunction/and-or.css
@@ -60,7 +60,7 @@ ul[class*=cnjnctn-type-] {
 	border-radius: 50%;
 	border-width: 3px;
 }
-.cnjnctn-type-and [class*=cnjnctn-col]:not(:first-child):before {
+.cnjnctn-type-and>[class*=cnjnctn-col]:not(:first-child):before {
 	border-width: 3px 0px 3px 0px;
 }
 html:lang(en) .cnjnctn-type-and>[class*=cnjnctn-col]:not(:first-child):before {

--- a/méli-mélo/2021-05-conjunction/and-or.css
+++ b/méli-mélo/2021-05-conjunction/and-or.css
@@ -61,7 +61,7 @@ ul[class*=cnjnctn-type-] {
 	border-width: 3px;
 }
 .cnjnctn-type-and [class*=cnjnctn-col]:not(:first-child):before {
-	border-width: 0px 3px 0px 3px;
+	border-width: 3px 0px 3px 0px;
 }
 html:lang(en) .cnjnctn-type-and [class*=cnjnctn-col]:not(:first-child):before {
 	content: "and";


### PR DESCRIPTION
Avoiding a "double line" look when stacked, making the "and" design borders the same as side-by-side (top/bottom rather than left/right)