### PR TITLE
GC Features: JS equalheight to CSS equalheight

### DIFF
--- a/components/gc-features/gc-features-en.html
+++ b/components/gc-features/gc-features-en.html
@@ -33,7 +33,18 @@ share: "true"
 	</dd>
 
 	<dt>Component version</dt>
-	<dd>Version 4.0</dd>
+	<dd>Version 5.0</dd>
+
+	<dt>Supported working versions</dt>
+	<dd>
+		<ul>
+			<li>Version 5</li>
+			<li>Version 4</li>
+			<li>Version 3 (deprecated)</li>
+			<li>Version 2 (deprecated)</li>
+			<li>Version 1 (deprecated)</li>
+		</ul>
+	</dd>
 </dl>
 
 <h2>Working example</h2>
@@ -41,12 +52,12 @@ share: "true"
 <h3>Context-specific features - v9.5.0</h3>
 <section class="gc-features">
 	<h2>Features</h2>
-	<div class="row wb-eqht">
+	<div class="row wb-eqht-grd">
 		<div class="col-lg-4 col-sm-6">
 			<div class="well well-sm eqht-trgt">
 				<img src="img/feature-360x203.png" alt="">
 				<h3><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-				<p>Brief description of the feature being promoted.</p>
+				<p>Brief description of the feature being promoted. Brief description of the feature being promoted.</p>
 			</div>
 		</div>
 		<div class="col-lg-4 col-sm-6">
@@ -68,7 +79,7 @@ share: "true"
 <h3>GC activities and initiatives - v9.5.0</h3>
 <section class="gc-features">
 	<h2>Government initiatives</h2>
-	<div class="row wb-eqht">
+	<div class="row wb-eqht-grd">
 		<div class="col-sm-6">
 			<div class="well well-sm eqht-trgt">
 				<img src="img/initiative-520x200.png" alt=""/>
@@ -183,7 +194,6 @@ share: "true"
 	</section>
 </details>
 
-
 <details>
 	<summary>GC activities and initiatives - Removal - v4.0.28</summary>
 	<aside class="gc-nttvs">
@@ -239,7 +249,7 @@ share: "true"
 <h2>Evaluation and report</h2>
 <p>There is no evaluation and report available for this component.</p>
 
-<h2>API (Component version 4.0)</h2>
+<h2>API (Component version 5.0)</h2>
 <table class="table table-bordered">
 	<tr>
 		<th>CSS Class</th>
@@ -249,7 +259,7 @@ share: "true"
 	</tr>
 	<tr>
 		<td>Version 3.0</td>
-		<td>Version 4.0</td>
+		<td>Version 5.0</td>
 		<td>Version 3.0</td>
 		<td>Version 1.0</td>
 	</tr>
@@ -299,8 +309,9 @@ share: "true"
 </details>
 
 
-<h3>Template (v3.1)</h3>
+<h3>Template (v5.0)</h3>
 
+<p>Note v5.0: The class <code>wb-eqht</code> was replaced with <code>wb-eqht-grd</code> to take advantage of CSS when possible, but <code>wb-eqht</code> is still supported.</p>
 <p>Note v3.1: The <em>Cohabit</em> design pattern for feature tile was introduced to support the theme/topic beta template.</p>
 
 <h4>gc-features component</h4>
@@ -329,7 +340,7 @@ share: "true"
 <h5>Two or three feature tiles layout</h5>
 <pre><code>&lt;section class="gc-features"&gt;
 	&lt;h2&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
-	&lt;div class="row wb-eqht"&gt;
+	&lt;div class="row wb-eqht-grd"&gt;
 
 		&lt;!-- Column one --&gt;
 		&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
@@ -360,6 +371,42 @@ share: "true"
 
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
+<details>
+	<summary>Previous version (v4.0)</summary>
+	<pre><code>&lt;section class="gc-features"&gt;
+		&lt;h2&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
+		&lt;div class="row wb-eqht"&gt;
+
+			&lt;!-- Column one --&gt;
+			&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
+				&lt;div class="well well-sm eqht-trgt"&gt;
+					&lt;img src="[[comp:FeatureItem html:img-src]]" alt="[[comp:FeatureItem html:img-alt]]"/&gt;
+					&lt;h3&gt;&lt;a class="stretched-link" data-bind="(href = comp:FeatureItem foaf:page)"&gt;[[comp:FeatureItem dct:title]]&lt;/a&gt;&lt;/h3&gt;
+					&lt;p&gt;[[comp:FeatureItem dct:description]]&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;!-- Column two --&gt;
+			&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
+				&lt;div class="well well-sm eqht-trgt"&gt;
+					&lt;img src="[[comp:FeatureItem html:img-src]]" alt="[[comp:FeatureItem html:img-alt]]"/&gt;
+					&lt;h3&gt;&lt;a class="stretched-link" data-bind="(href = comp:FeatureItem foaf:page)"&gt;[[comp:FeatureItem dct:title]]&lt;/a&gt;&lt;/h3&gt;
+					&lt;p&gt;[[comp:FeatureItem dct:description]]&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;!-- Column three [default] --&gt;
+			&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
+				&lt;div class="well well-sm eqht-trgt"&gt;
+					&lt;img src="[[comp:FeatureItem html:img-src]]" alt="[[comp:FeatureItem html:img-alt]]"/&gt;
+					&lt;h3&gt;&lt;a class="stretched-link" data-bind="(href = comp:FeatureItem foaf:page)"&gt;[[comp:FeatureItem dct:title]]&lt;/a&gt;&lt;/h3&gt;
+					&lt;p&gt;[[comp:FeatureItem dct:description]]&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+		&lt;/div&gt;
+	&lt;/section&gt;</code></pre>
+</details>
 
 <h5>Cohabit design pattern</h5>
 
@@ -408,7 +455,7 @@ share: "true"
 
 		&lt;section class="gc-features"&gt;
 			&lt;h2 class="wb-inv"&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
-			&lt;div class="row wb-eqht"&gt;
+			&lt;div class="row wb-eqht-grd"&gt;
 
 				&lt;!-- Two column --&gt;
 				&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-md-6"&gt;
@@ -430,7 +477,7 @@ share: "true"
 <p>The <code>.gc-initiatives</code> class was deprecated at version v9.5.0 (as mentioned above in the Class section of the API) and since it had no style nor behaviour attached, no side effects are to be expected by this removal.</p>
 <pre><code>&lt;section class="gc-features"&gt;
 	&lt;h2&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
-	&lt;div class="row wb-eqht"&gt;
+	&lt;div class="row wb-eqht-grd"&gt;
 
 		&lt;!-- Column one --&gt;
 		&lt;div data-if="comp:Feature comp:featureType == 'gc-initiatives'" data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-sm-6"&gt;
@@ -452,9 +499,16 @@ share: "true"
 &lt;/section&gt;</code></pre>
 
 <details>
-	<summary>Previous version</summary>
+	<summary>Version notes</summary>
 
 	<dl class="dl-horizontal">
+		<dt>Version 4.0 (GCWeb v11.3.1)</dt>
+		<dd>
+			<ul>
+				<li>Added: <code>.wb-eqht-grd</code></li>
+				<li>Removed: <code>.wb-eqht</code></li>
+			</ul>
+		</dd>
 		<dt>Version 3.1 (GCWeb v9.1)</dt>
 		<dd>
 			<ul>

--- a/components/gc-features/gc-features-fr.html
+++ b/components/gc-features/gc-features-fr.html
@@ -35,14 +35,14 @@ share: "true"
 	<dt>Component version</dt>
 	<dd>Version 5.0</dd>
 
-	<dt>Supported working versions</dt>
+	<dt>Version  compatible et fonctionnelle</dt>
 	<dd>
 		<ul>
 			<li>Version 5</li>
 			<li>Version 4</li>
-			<li>Version 3 (deprecated)</li>
-			<li>Version 2 (deprecated)</li>
-			<li>Version 1 (deprecated)</li>
+			<li>Version 3 (désuet)</li>
+			<li>Version 2 (désuet)</li>
+			<li>Version 1 (désuet)</li>
 		</ul>
 	</dd>
 </dl>

--- a/components/gc-features/gc-features-fr.html
+++ b/components/gc-features/gc-features-fr.html
@@ -33,7 +33,18 @@ share: "true"
 	</dd>
 
 	<dt>Component version</dt>
-	<dd>Version 4.0</dd>
+	<dd>Version 5.0</dd>
+
+	<dt>Supported working versions</dt>
+	<dd>
+		<ul>
+			<li>Version 5</li>
+			<li>Version 4</li>
+			<li>Version 3 (deprecated)</li>
+			<li>Version 2 (deprecated)</li>
+			<li>Version 1 (deprecated)</li>
+		</ul>
+	</dd>
 </dl>
 
 <div lang="en">
@@ -43,12 +54,12 @@ share: "true"
 <h3>Context-specific features - v9.5.0</h3>
 <section class="gc-features">
 	<h2>Features</h2>
-	<div class="row wb-eqht">
+	<div class="row wb-eqht-grd">
 		<div class="col-lg-4 col-sm-6">
 			<div class="well well-sm eqht-trgt">
 				<img src="img/feature-360x203.png" alt="">
 				<h3><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-				<p>Brief description of the feature being promoted.</p>
+				<p>Brief description of the feature being promoted. Brief description of the feature being promoted.</p>
 			</div>
 		</div>
 		<div class="col-lg-4 col-sm-6">
@@ -70,7 +81,7 @@ share: "true"
 <h3>GC activities and initiatives - v9.5.0</h3>
 <section class="gc-features">
 	<h2>Government initiatives</h2>
-	<div class="row wb-eqht">
+	<div class="row wb-eqht-grd">
 		<div class="col-sm-6">
 			<div class="well well-sm eqht-trgt">
 				<img src="img/initiative-520x200.png" alt=""/>
@@ -185,7 +196,6 @@ share: "true"
 	</section>
 </details>
 
-
 <details>
 	<summary>GC activities and initiatives - Removal - v4.0.28</summary>
 	<aside class="gc-nttvs">
@@ -241,7 +251,7 @@ share: "true"
 <h2>Evaluation and report</h2>
 <p>There is no evaluation and report available for this component.</p>
 
-<h2>API (Component version 4.0)</h2>
+<h2>API (Component version 5.0)</h2>
 <table class="table table-bordered">
 	<tr>
 		<th>CSS Class</th>
@@ -251,7 +261,7 @@ share: "true"
 	</tr>
 	<tr>
 		<td>Version 3.0</td>
-		<td>Version 4.0</td>
+		<td>Version 5.0</td>
 		<td>Version 3.0</td>
 		<td>Version 1.0</td>
 	</tr>
@@ -301,8 +311,9 @@ share: "true"
 </details>
 
 
-<h3>Template (v3.1)</h3>
+<h3>Template (v5.0)</h3>
 
+<p>Note v5.0: The class <code>wb-eqht</code> was replaced with <code>wb-eqht-grd</code> to take advantage of CSS when possible, but <code>wb-eqht</code> is still supported.</p>
 <p>Note v3.1: The <em>Cohabit</em> design pattern for feature tile was introduced to support the theme/topic beta template.</p>
 
 <h4>gc-features component</h4>
@@ -331,7 +342,7 @@ share: "true"
 <h5>Two or three feature tiles layout</h5>
 <pre><code>&lt;section class="gc-features"&gt;
 	&lt;h2&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
-	&lt;div class="row wb-eqht"&gt;
+	&lt;div class="row wb-eqht-grd"&gt;
 
 		&lt;!-- Column one --&gt;
 		&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
@@ -362,6 +373,42 @@ share: "true"
 
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
+<details>
+	<summary>Previous version (v4.0)</summary>
+	<pre><code>&lt;section class="gc-features"&gt;
+		&lt;h2&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
+		&lt;div class="row wb-eqht"&gt;
+
+			&lt;!-- Column one --&gt;
+			&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
+				&lt;div class="well well-sm eqht-trgt"&gt;
+					&lt;img src="[[comp:FeatureItem html:img-src]]" alt="[[comp:FeatureItem html:img-alt]]"/&gt;
+					&lt;h3&gt;&lt;a class="stretched-link" data-bind="(href = comp:FeatureItem foaf:page)"&gt;[[comp:FeatureItem dct:title]]&lt;/a&gt;&lt;/h3&gt;
+					&lt;p&gt;[[comp:FeatureItem dct:description]]&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;!-- Column two --&gt;
+			&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
+				&lt;div class="well well-sm eqht-trgt"&gt;
+					&lt;img src="[[comp:FeatureItem html:img-src]]" alt="[[comp:FeatureItem html:img-alt]]"/&gt;
+					&lt;h3&gt;&lt;a class="stretched-link" data-bind="(href = comp:FeatureItem foaf:page)"&gt;[[comp:FeatureItem dct:title]]&lt;/a&gt;&lt;/h3&gt;
+					&lt;p&gt;[[comp:FeatureItem dct:description]]&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;!-- Column three [default] --&gt;
+			&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-lg-4 col-sm-6"&gt;
+				&lt;div class="well well-sm eqht-trgt"&gt;
+					&lt;img src="[[comp:FeatureItem html:img-src]]" alt="[[comp:FeatureItem html:img-alt]]"/&gt;
+					&lt;h3&gt;&lt;a class="stretched-link" data-bind="(href = comp:FeatureItem foaf:page)"&gt;[[comp:FeatureItem dct:title]]&lt;/a&gt;&lt;/h3&gt;
+					&lt;p&gt;[[comp:FeatureItem dct:description]]&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+		&lt;/div&gt;
+	&lt;/section&gt;</code></pre>
+</details>
 
 <h5>Cohabit design pattern</h5>
 
@@ -410,7 +457,7 @@ share: "true"
 
 		&lt;section class="gc-features"&gt;
 			&lt;h2 class="wb-inv"&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
-			&lt;div class="row wb-eqht"&gt;
+			&lt;div class="row wb-eqht-grd"&gt;
 
 				&lt;!-- Two column --&gt;
 				&lt;div data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-md-6"&gt;
@@ -432,7 +479,7 @@ share: "true"
 <p>The <code>.gc-initiatives</code> class was deprecated at version v9.5.0 (as mentioned above in the Class section of the API) and since it had no style nor behaviour attached, no side effects are to be expected by this removal.</p>
 <pre><code>&lt;section class="gc-features"&gt;
 	&lt;h2&gt;[[comp:Feature dct:title]]&lt;/h2&gt;
-	&lt;div class="row wb-eqht"&gt;
+	&lt;div class="row wb-eqht-grd"&gt;
 
 		&lt;!-- Column one --&gt;
 		&lt;div data-if="comp:Feature comp:featureType == 'gc-initiatives'" data-for="comp:FeatureItem in (comp:Feature comp:features )" class="col-sm-6"&gt;
@@ -454,9 +501,16 @@ share: "true"
 &lt;/section&gt;</code></pre>
 
 <details>
-	<summary>Previous version</summary>
+	<summary>Version notes</summary>
 
 	<dl class="dl-horizontal">
+		<dt>Version 4.0 (GCWeb v11.3.1)</dt>
+		<dd>
+			<ul>
+				<li>Added: <code>.wb-eqht-grd</code></li>
+				<li>Removed: <code>.wb-eqht</code></li>
+			</ul>
+		</dd>
 		<dt>Version 3.1 (GCWeb v9.1)</dt>
 		<dd>
 			<ul>


### PR DESCRIPTION
Changing GC Features component to use CSS equalheight feature instead of its JavaScript equivalent.

Related to WET-269