### PR TITLE
Méli-mélo - add 2021-05-steps in 2023-10-mount-revelstoke compilation

### DIFF
--- a/_data/méli-mélo.json
+++ b/_data/méli-mélo.json
@@ -5,7 +5,8 @@
 			"nom": "2023-10-mount-revelstoke",
 			"libs": [
 				"2022-09-svgimagemap",
-				"2021-05-conjunction"
+				"2021-05-conjunction",
+				"2021-05-steps"
 			]
 		},
 		{


### PR DESCRIPTION
As requested by CRA and because it is still an active file for them, we are adding the 2021-05-steps in the current méli-mélo compilation. 

Note: Additional update are on its way for the steps experimentation.