### PR TITLE
Footer: editorial changes

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -254,22 +254,22 @@
 			{
 				"title": "Hide 'About government' section from the footer",
 				"language": "en",
-				"path": "no-footer-about-en.html"
+				"path": "no-footer-about-gov-en.html"
 			},
 			{
 				"title": "Masquer la section 'Au sujet du gouvernement' du pied de page",
 				"language": "fr",
-				"path": "no-footer-about-fr.html"
+				"path": "no-footer-about-gov-fr.html"
 			},
 			{
 				"title": "Hide some links from the 'Support links' section from the footer",
 				"language": "en",
-				"path": "no-footer-site-en.html"
+				"path": "no-footer-support-links-en.html"
 			},
 			{
 				"title": "Masquer certains liens de la section 'Liens d'assistance' du pied de page",
 				"language": "fr",
-				"path": "no-footer-site-fr.html"
+				"path": "no-footer-support-links-fr.html"
 			},
 			{
 				"title": "Hide 'About government' section and some links from the 'Support links' section from the footer",
@@ -284,12 +284,12 @@
 			{
 				"title": "Hide 'Contextual' section and some links from the 'Support links' section from the footer",
 				"language": "en",
-				"path": "only-footer-about-en.html"
+				"path": "only-footer-about-gov-en.html"
 			},
 			{
 				"title": "Masquer la section 'Contextuel' et certains liens de la section 'Liens d'assitance' du pied de page",
 				"language": "fr",
-				"path": "only-footer-about-fr.html"
+				"path": "only-footer-about-gov-fr.html"
 			},
 			{
 				"title": "Hide 'Contextual' and 'About government' sections from the footer",
@@ -498,6 +498,40 @@
 				"title": "Détails de la page version 1.0 (obsolète)",
 				"language": "fr",
 				"path": "deprecated/page-details-v1-fr.html"
+			}
+		]
+	}
+}
+,{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Skip links",
+		"fr": "Liens de saut de page"
+	},
+	"description": {
+		"en": "Documentation and working example on how to use the skiplinks.",
+		"fr": "Documentation et example pratique sur l'utilisation des liens de saut de page."
+	},
+	"modified": "2022-01-12",
+	"componentName": "skiplinks",
+	"status": "stable",
+	"pages": {
+		"docs": [
+			{
+				"title": "Skip links",
+				"language": "en",
+				"path": "skiplinks-en.html"
+			},
+			{
+				"title": "Liens de saut de page",
+				"language": "fr",
+				"path": "skiplinks-fr.html"
 			}
 		]
 	}

--- a/sites/footers/deprecated/footers-v1-en.html
+++ b/sites/footers/deprecated/footers-v1-en.html
@@ -40,7 +40,7 @@
 {% include page-details/footer.html %}
 </main>
 <footer id="wb-info">
-{% unless page.noFooterAbout %}
+{% unless page.noFooterAboutGov %}
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="wb-inv">About government</h2>
@@ -73,7 +73,7 @@
 	<div class="brand">
 	<div class="container">
 		<div class="row ">
-{% unless page.noFooterSite %}
+{% unless page.noFooterSupportLinks %}
 			<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
 				<h2 class="wb-inv">{{ i18nText-footerSite }}</h2>
 				<ul>
@@ -96,7 +96,7 @@
 			<div class="col-xs-6 visible-sm visible-xs tofpg">
 				<a href="#wb-cont">Top of page <span class="glyphicon glyphicon-chevron-up"></span></a>
 			</div>
-{%- if page.noFooterSite == "true" -%}
+{%- if page.noFooterSupportLinks == "true" -%}
 			<div class="col-xs-6 col-md-12 text-right">
 {%- else -%}
 			<div class="col-xs-6 col-md-3 col-lg-2 text-right">

--- a/sites/footers/deprecated/footers-v1-fr.html
+++ b/sites/footers/deprecated/footers-v1-fr.html
@@ -40,7 +40,7 @@
 {% include page-details/footer.html %}
 </main>
 <footer id="wb-info">
-{% unless page.noFooterAbout %}
+{% unless page.noFooterAboutGov %}
 	<div class="landscape">
 		<nav class="container wb-navcurr">
 			<h2 class="wb-inv">Au sujet du gouvernement</h2>
@@ -73,7 +73,7 @@
 	<div class="brand">
 	<div class="container">
 		<div class="row ">
-{% unless page.noFooterSite %}
+{% unless page.noFooterSupportLinks %}
 			<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
 				<h2 class="wb-inv">{{ i18nText-footerSite }}</h2>
 				<ul>
@@ -96,7 +96,7 @@
 			<div class="col-xs-6 visible-sm visible-xs tofpg">
 				<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
 			</div>
-{%- if page.noFooterSite == "true" -%}
+{%- if page.noFooterSupportLinks == "true" -%}
 			<div class="col-xs-6 col-md-12 text-right">
 {%- else -%}
 			<div class="col-xs-6 col-md-3 col-lg-2 text-right">

--- a/sites/footers/deprecated/footers-v2-en.html
+++ b/sites/footers/deprecated/footers-v2-en.html
@@ -46,7 +46,7 @@ Page untitled
 		{% include page-details/footer.html %}
 	</main>
 	<footer id="wb-info">
-		{% unless page.noFooterAbout %}
+		{% unless page.noFooterAboutGov %}
 		<div class="landscape">
 			<nav class="container wb-navcurr">
 				<h2 class="wb-inv">About government</h2>
@@ -79,7 +79,7 @@ Page untitled
 		<div class="brand">
 			<div class="container">
 				<div class="row ">
-					{% unless page.noFooterSite %}
+					{% unless page.noFooterSupportLinks %}
 					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
 						<h2 class="wb-inv">{{ i18nText-footerSite }}</h2>
 						<ul>
@@ -102,7 +102,7 @@ Page untitled
 					<div class="col-xs-6 visible-sm visible-xs tofpg">
 						<a href="#wb-cont">Top of page <span class="glyphicon glyphicon-chevron-up"></span></a>
 					</div>
-					{%- if page.noFooterSite == "true" -%}
+					{%- if page.noFooterSupportLinks == "true" -%}
 					<div class="col-xs-6 col-md-12 text-right">
 						{%- else -%}
 						<div class="col-xs-6 col-md-3 col-lg-2 text-right">

--- a/sites/footers/deprecated/footers-v2-fr.html
+++ b/sites/footers/deprecated/footers-v2-fr.html
@@ -46,7 +46,7 @@ Page untitled
 		{% include page-details/footer.html %}
 	</main>
 	<footer id="wb-info">
-		{% unless page.noFooterAbout %}
+		{% unless page.noFooterAboutGov %}
 		<div class="landscape">
 			<nav class="container wb-navcurr">
 				<h2 class="wb-inv">Au sujet du gouvernement</h2>
@@ -79,7 +79,7 @@ Page untitled
 		<div class="brand">
 			<div class="container">
 				<div class="row ">
-					{% unless page.noFooterSite %}
+					{% unless page.noFooterSupportLinks %}
 					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
 						<h2 class="wb-inv">{{ i18nText-footerSite }}</h2>
 						<ul>
@@ -102,7 +102,7 @@ Page untitled
 					<div class="col-xs-6 visible-sm visible-xs tofpg">
 						<a href="#wb-cont">Haut de la page <span class="glyphicon glyphicon-chevron-up"></span></a>
 					</div>
-					{%- if page.noFooterSite == "true" -%}
+					{%- if page.noFooterSupportLinks == "true" -%}
 					<div class="col-xs-6 col-md-12 text-right">
 						{%- else -%}
 						<div class="col-xs-6 col-md-3 col-lg-2 text-right">

--- a/sites/footers/footers-en.html
+++ b/sites/footers/footers-en.html
@@ -49,7 +49,7 @@
 	</li>
 	<li>Removed "Top of page" anchor.</li>
 	<li>Complete rework of the footer's headings for accessibility.</li>
-	<li>GCWeb Jekyll specific: Footer skip link should remain when only the contextual footer is displayed.</li>
+	<li>GCWeb Jekyll specific: Footer skip link should always remain.</li>
 </ul>
 <p>Working example: <a href="#wb-info">Scroll to the bottom of this page</a></p>
 
@@ -129,66 +129,39 @@
 <p>Working example: <a href="deprecated/footers-v2-en.html">Footer version 2.0 (deprecated)</a></p>
 <h3>Expected output code</h3>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;
-	&lt;h2 class=&quot;wb-inv&quot;&gt;About this site&lt;/h2&gt;
-	&lt;div class=&quot;gc-contextual&quot;&gt;
-		&lt;nav class=&quot;container&quot;&gt;
-			&lt;h3&gt;[Contextual footer title]&lt;/h3&gt;
-			&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
-				&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;Page-specific Link 1&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;Page-specific Link 2&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;Page-specific Link 3&lt;/a&gt;&lt;/li&gt;
-			&lt;/ul&gt;
-		&lt;/nav&gt;
-	&lt;/div&gt;
-
 	&lt;div class=&quot;landscape&quot;&gt;
-		&lt;nav class=&quot;container&quot;&gt;
-			&lt;h3&gt;Government of Canada&lt;/h3&gt;
-			&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/contact.html&quot;&gt;All Contacts&lt;/a&gt;&lt;/li&gt;
+		&lt;nav class=&quot;container wb-navcurr&quot;&gt;
+			&lt;h2 class=&quot;wb-inv&quot;&gt;About government&lt;/h2&gt;
+			&lt;ul class=&quot;list-unstyled colcount-xs-2 colcount-md-3&quot;&gt;
+				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/contact.html&quot;&gt;Contact us&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/government/dept.html&quot;&gt;Departments and agencies&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/government/system.html&quot;&gt;About government&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
-			&lt;h4 class=&quot;wb-inv&quot;&gt;Theme links&lt;/h4&gt;
-			&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/jobs.html&quot;&gt;Jobs and the workplace&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/immigration-citizenship.html&quot;&gt;Immigration and citizenship&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://travel.gc.ca/&quot;&gt;Travel and tourism&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/business.html&quot;&gt;Business and industry&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/benefits.html&quot;&gt;Benefits&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/health.html&quot;&gt;Health&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/taxes.html&quot;&gt;Taxes&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/environment.html&quot;&gt;Environment and natural resources&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/defence.html&quot;&gt;National security and defence&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/culture.html&quot;&gt;Culture, history and sport&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/policing.html&quot;&gt;Policing, justice and emergencies&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/transport.html&quot;&gt;Transport and infrastructure&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://international.gc.ca/world-monde/index.aspx?lang=eng&quot;&gt;Canada and the world&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/finance.html&quot;&gt;Money and finances&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/science.html&quot;&gt;Science and innovation&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/indigenous-peoples.html&quot;&gt;Indigenous peoples&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/veterans.html&quot;&gt;Veterans&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/services/youth.html&quot;&gt;Youth&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/government/publicservice.html&quot;&gt;Public service and military&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/news.html&quot;&gt;News&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/government/system/laws.html&quot;&gt;Treaties, laws and regulations&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/transparency/reporting.html&quot;&gt;Government-wide reporting&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://pm.gc.ca/eng&quot;&gt;Prime Minister&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/government/system.html&quot;&gt;How government works&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;https://open.canada.ca/en/&quot;&gt;Open government&lt;/a&gt;&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/nav&gt;
 	&lt;/div&gt;
-
 	&lt;div class=&quot;brand&quot;&gt;
 		&lt;div class=&quot;container&quot;&gt;
-			&lt;div class=&quot;row&quot;&gt;
+			&lt;div class=&quot;row &quot;&gt;
 				&lt;nav class=&quot;col-md-9 col-lg-10 ftr-urlt-lnk&quot;&gt;
-					&lt;h3 class=&quot;wb-inv&quot;&gt;Support links&lt;/h3&gt;
-					&lt;ul class=&quot;spprt-lnks&quot;&gt;
+					&lt;h2 class=&quot;wb-inv&quot;&gt;About this site&lt;/h2&gt;
+					&lt;ul&gt;
 						&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/social.html&quot;&gt;Social media&lt;/a&gt;&lt;/li&gt;
 						&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/mobile.html&quot;&gt;Mobile applications&lt;/a&gt;&lt;/li&gt;
 						&lt;li&gt;&lt;a href=&quot;https://www1.canada.ca/en/newsite.html&quot;&gt;About Canada.ca&lt;/a&gt;&lt;/li&gt;
-					&lt;/ul&gt;
-					&lt;h4 class=&quot;wb-inv&quot;&gt;Transparency&lt;/h4&gt;
-					&lt;ul class=&quot;trnsprncy-lnks&quot;&gt;
 						&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/transparency/terms.html&quot;&gt;Terms and conditions&lt;/a&gt;&lt;/li&gt;
 						&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/en/transparency/privacy.html&quot;&gt;Privacy&lt;/a&gt;&lt;/li&gt;
 					&lt;/ul&gt;
 				&lt;/nav&gt;
-				&lt;div class=&quot;col-md-3 col-lg-2 text-right&quot;&gt;
-					&lt;img src=&quot;/dist/GCWeb/assets/wmms-blk.svg&quot; alt=&quot;Symbol of the Government of Canada&quot;&gt;
+				&lt;div class=&quot;col-xs-6 visible-sm visible-xs tofpg&quot;&gt;
+					&lt;a href=&quot;#wb-cont&quot;&gt;Top of page &lt;span class=&quot;glyphicon glyphicon-chevron-up&quot;&gt;&lt;/span&gt;&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class=&quot;col-xs-6 col-md-3 col-lg-2 text-right&quot;&gt;&lt;img src=&quot;/dist/GCWeb/assets/wmms-blk.svg&quot; alt=&quot;Symbol of the Government of Canada&quot;&gt;
 				&lt;/div&gt;
 			&lt;/div&gt;
 		&lt;/div&gt;

--- a/sites/footers/footers-fr.html
+++ b/sites/footers/footers-fr.html
@@ -49,7 +49,7 @@
 		</li>
 		<li>Suppression de l'ancre «&nbsp;Haut de page&nbsp;».</li>
 		<li>Refonte complète des titres du pied de page pour l'accessibilité.</li>
-	<li>Spécifique à GCWeb Jekyll : le lien de saut de pied de page doit rester lorsque seul le pied de page contextuel est affiché.</li>
+	<li>Spécifique à GCWeb Jekyll : le lien de saut vers le pied de page doit demeurer en tout temps.</li>
 </ul>
 <p>Exemple pratique: <a href="#wb-info">Faire défiler jusqu'au bas de la page</a></p>
 
@@ -176,7 +176,7 @@
 	&lt;div class=&quot;landscape&quot;&gt;
 		&lt;nav class=&quot;container wb-navcurr&quot;&gt;
 			&lt;h2 class=&quot;wb-inv&quot;&gt;Au sujet du gouvernement&lt;/h2&gt;
-			&lt;ul class=&quot;list-unstyled colcount-xs-2 colcount-md-3&quot;&gt;
+			&lt;ul class=&quot;list-unstyled colcount-sm-2 colcount-md-3&quot;&gt;
 				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/fr/contact.html&quot;&gt;Contactez-nous&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/fr/gouvernement/min.html&quot;&gt;Minist&egrave;res et organismes&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href=&quot;https://www.canada.ca/fr/gouvernement/fonctionpublique.html&quot;&gt;Fonction publique et force militaire&lt;/a&gt;&lt;/li&gt;

--- a/sites/footers/includes/footer.html
+++ b/sites/footers/includes/footer.html
@@ -51,7 +51,7 @@
 {%- endif -%}
 {% endunless %}
 
-{% unless page.noFooterAbout %}
+{% unless page.noFooterAboutGov %}
 	<div class="landscape">
 		<div class="container">
 			<nav>
@@ -117,7 +117,7 @@
 		<div class="container d-flex align-items-center">
 			<nav>
 				<h3 class="wb-inv">{{ i18nText-supportLinks }}</h3>
-				{% unless page.noFooterSite %}
+				{% unless page.noFooterSupportLinks %}
 				<ul>
 					{%- if i18nText-lang == "fr" -%}
 					<li><a href="https://www.canada.ca/fr/sociaux.html">Médias sociaux</a></li>

--- a/sites/footers/index.json-ld
+++ b/sites/footers/index.json-ld
@@ -44,22 +44,22 @@
 			{
 				"title": "Hide 'About government' section from the footer",
 				"language": "en",
-				"path": "no-footer-about-en.html"
+				"path": "no-footer-about-gov-en.html"
 			},
 			{
 				"title": "Masquer la section 'Au sujet du gouvernement' du pied de page",
 				"language": "fr",
-				"path": "no-footer-about-fr.html"
+				"path": "no-footer-about-gov-fr.html"
 			},
 			{
 				"title": "Hide some links from the 'Support links' section from the footer",
 				"language": "en",
-				"path": "no-footer-site-en.html"
+				"path": "no-footer-support-links-en.html"
 			},
 			{
 				"title": "Masquer certains liens de la section 'Liens d'assistance' du pied de page",
 				"language": "fr",
-				"path": "no-footer-site-fr.html"
+				"path": "no-footer-support-links-fr.html"
 			},
 			{
 				"title": "Hide 'About government' section and some links from the 'Support links' section from the footer",
@@ -74,12 +74,12 @@
 			{
 				"title": "Hide 'Contextual' section and some links from the 'Support links' section from the footer",
 				"language": "en",
-				"path": "only-footer-about-en.html"
+				"path": "only-footer-about-gov-en.html"
 			},
 			{
 				"title": "Masquer la section 'Contextuel' et certains liens de la section 'Liens d'assitance' du pied de page",
 				"language": "fr",
-				"path": "only-footer-about-fr.html"
+				"path": "only-footer-about-gov-fr.html"
 			},
 			{
 				"title": "Hide 'Contextual' and 'About government' sections from the footer",

--- a/sites/footers/no-footer-about-gov-en.html
+++ b/sites/footers/no-footer-about-gov-en.html
@@ -3,21 +3,21 @@
 "title": "Hide 'About government' section from the footer",
 "language": "en",
 "breadcrumbs": [
-{ "title": "Footer", "link": "sites/footers/footers-en.html" }
+	{ "title": "Footer", "link": "sites/footers/footers-en.html" }
 ],
-"altLangPage": "no-footer-about-fr.html",
-"secondlevel": false,
-"dateModified": "2022-01-12",
-"share": "true",
-"noFooterAbout": "true",
-"includes": { "footer": "edge" }
+	"altLangPage": "no-footer-about-gov-fr.html",
+	"secondlevel": false,
+	"dateModified": "2022-01-12",
+	"share": "true",
+	"noFooterAboutGov": "true",
+	"includes": { "footer": "edge" }
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
 
 {% include alert-softlaunch.html component="site footer" version="3" %}
 
-<p>By setting the <code>noFooterAbout</code> variable to "true", the "About government" section will will be hidden on page load.</p>
+<p>By setting the <code>noFooterAboutGov</code> variable to "true", the "About government" section will will be hidden on page load.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/footers/no-footer-about-gov-fr.html
+++ b/sites/footers/no-footer-about-gov-fr.html
@@ -5,11 +5,11 @@
 	"breadcrumbs": [
 		{ "title": "Footer", "link": "sites/footers/footers-fr.html" }
 	],
-	"altLangPage": "no-footer-about-en.html",
+	"altLangPage": "no-footer-about-gov-en.html",
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",
-	"noFooterAbout": "true",
+	"noFooterAboutGov": "true",
 	"includes": { "footer": "edge" }
 }
 ---
@@ -17,7 +17,7 @@
 
 {% include alert-softlaunch.html component="pied de page" version="3" %}
 
-<p>En définissant la variable <code>noFooterAbout</code> à "true", la section «&nbsp;Au sujet du gouvernement&nbsp;» sera masquée au chargement de la page.</p>
+<p>En définissant la variable <code>noFooterAboutGov</code> à "true", la section «&nbsp;Au sujet du gouvernement&nbsp;» sera masquée au chargement de la page.</p>
 
 <h2>Code final attendu</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/footers/no-footer-support-links-en.html
+++ b/sites/footers/no-footer-support-links-en.html
@@ -1,16 +1,15 @@
 ---
 {
-	"title": "Hide 'Contextual' section and some links from the 'Support links' section from the footer",
-	"language": "en",
-	"breadcrumbs": [
-		{ "title": "Footer", "link": "sites/footers/footers-en.html" }
-	],
-	"altLangPage": "only-footer-about-fr.html",
+"title": "Hide some links from the 'Support links' section from the footer",
+"language": "en",
+"breadcrumbs": [
+	{ "title": "Footer", "link": "sites/footers/footers-en.html" }
+],
+	"altLangPage": "no-footer-support-links-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-07-12",
+	"dateModified": "2022-06-20",
 	"share": "true",
-	"noFooterContextual": "true",
-	"noFooterSite": "true",
+	"noFooterSupportLinks": "true",
 	"includes": { "footer": "edge" }
 }
 ---
@@ -18,11 +17,23 @@
 
 {% include alert-softlaunch.html component="site footer" version="3" %}
 
-<p>By setting the <code>noFooterContextual</code> and <code>noFooterSite</code> variables to "true", the "Contextual" section and some links from the "Support links" section will be hidden on page load but the "About government" section will remain.</p>
+<p>By setting the <code>noFooterSupportLinks</code> variable to "true", some links from the "Support links" section will be hidden on page load.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;
 	&lt;h2 class=&quot;wb-inv&quot;&gt;About this site&lt;/h2&gt;
+	&lt;div class=&quot;gc-contextual&quot;&gt;
+		&lt;div class=&quot;container&quot;&gt;
+			&lt;nav&gt;
+				&lt;h3&gt;[Contextual footer title]&lt;/h3&gt;
+				&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
+					&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;[Contextual Link 1]&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;[Contextual Link 2]&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;[Contextual Link 3]&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/nav&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
 	&lt;div class=&quot;landscape&quot;&gt;
 		&lt;div class=&quot;container&quot;&gt;
 			&lt;nav&gt;

--- a/sites/footers/no-footer-support-links-fr.html
+++ b/sites/footers/no-footer-support-links-fr.html
@@ -1,16 +1,15 @@
 ---
 {
-	"title": "Masquer la section 'Contextuel' et certains liens de la section 'Liens d'assitance' du pied de page",
+	"title": "Masquer certains liens de la section 'Liens d'assistance' du pied de page",
 	"language":	"fr",
 	"breadcrumbs": [
 		{ "title": "Footer", "link": "sites/footers/footers-fr.html" }
 	],
-	"altLangPage": "only-footer-about-en.html",
+	"altLangPage": "no-footer-support-links-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-07-12",
+	"dateModified": "2022-06-20",
 	"share": "true",
-	"noFooterContextual": "true",
-	"noFooterSite": "true",
+	"noFooterSupportLinks": "true",
 	"includes": { "footer": "edge" }
 }
 ---
@@ -18,11 +17,23 @@
 
 {% include alert-softlaunch.html component="pied de page" version="3" %}
 
-<p>En définissant les variables <code>noFooterContextual</code> et <code>noFooterSite</code> à «&nbsp;true&nbsp;», la section «&nbsp;Contextuel&nbsp;» et certains liens de la section «&nbsp;Liens d'assistance&nbsp;» seront masqués au chargement de la page mais la section «&nbsp;Au sujet du gouvernement&nbsp;» restera affichée.</p>
+<p>En définissant la variable <code>noFooterSupportLinks</code> à "true", certains liens de la section «&nbsp;Liens d'assitance&nbsp;» seront masqués au chargement de la page.</p>
 
-<h2>Code final attendu</h2>
+<h2>Code de final attendu</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;
 	&lt;h2 class=&quot;wb-inv&quot;&gt;À propos de ce site&lt;/h2&gt;
+	&lt;div class=&quot;gc-contextual&quot;&gt;
+		&lt;div class=&quot;container&quot;&gt;
+			&lt;nav&gt;
+				&lt;h3&gt;[Titre du menu contextuel]&lt;/h3&gt;
+				&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
+					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 1]&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 2]&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 3]&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/nav&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
 	&lt;div class=&quot;landscape&quot;&gt;
 		&lt;div class=&quot;container&quot;&gt;
 			&lt;nav&gt;

--- a/sites/footers/no-footers-en.html
+++ b/sites/footers/no-footers-en.html
@@ -9,8 +9,8 @@
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",
-	"noFooterAbout": "true",
-	"noFooterSite": "true",
+	"noFooterAboutGov": "true",
+	"noFooterSupportLinks": "true",
 	"noFooterContextual": "true",
 	"includes": { "footer": "edge" }
 }
@@ -19,7 +19,7 @@
 
 {% include alert-softlaunch.html component="site footer" version="3" %}
 
-<p>By setting the <code>noFooterContextual</code>, <code>noFooterAbout</code> and <code>noFooterSite</code> variables to "true", the "Contextual" and "About government" sections and some links from "Support links" section will be hidden on page load.</p>
+<p>By setting the <code>noFooterContextual</code>, <code>noFooterAboutGov</code> and <code>noFooterSupportLinks</code> variables to "true", the "Contextual" and "About government" sections and some links from "Support links" section will be hidden on page load.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/footers/no-footers-fr.html
+++ b/sites/footers/no-footers-fr.html
@@ -9,8 +9,8 @@
 	"secondlevel": false,
 	"dateModified": "2022-01-12",
 	"share": "true",
-	"noFooterAbout": "true",
-	"noFooterSite": "true",
+	"noFooterAboutGov": "true",
+	"noFooterSupportLinks": "true",
 	"noFooterContextual": "true",
 	"includes": { "footer": "edge" }
 }
@@ -19,7 +19,7 @@
 
 {% include alert-softlaunch.html component="pied de page" version="3" %}
 
-<p>En définissant les variables <code>noFooterContextual</code>, <code>noFooterAbout</code> et <code>noFooterSite</code> à «&nbsp;true&nbsp;», les sections «&nbsp;Contextuel&nbsp;» et «&nbsp;Au sujet du gouvernement&nbsp;» ainsi que certains liens de la section «&nbsp;Liens d'assistance&nbsp;» seront masqués au chargement de la page.</p>
+<p>En définissant les variables <code>noFooterContextual</code>, <code>noFooterAboutGov</code> et <code>noFooterSupportLinks</code> à «&nbsp;true&nbsp;», les sections «&nbsp;Contextuel&nbsp;» et «&nbsp;Au sujet du gouvernement&nbsp;» ainsi que certains liens de la section «&nbsp;Liens d'assistance&nbsp;» seront masqués au chargement de la page.</p>
 
 <h2>Code final attendu</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/footers/only-footer-about-gov-en.html
+++ b/sites/footers/only-footer-about-gov-en.html
@@ -1,39 +1,28 @@
 ---
 {
-"title": "Hide some links from the 'Support links' section from the footer",
-"language": "en",
-"breadcrumbs": [
-{ "title": "Footer", "link": "sites/footers/footers-en.html" }
-],
-"altLangPage": "no-footer-site-fr.html",
-"secondlevel": false,
-"dateModified": "2022-06-20",
-"share": "true",
-"noFooterSite": "true",
-"includes": { "footer": "edge" }
+	"title": "Hide 'Contextual' section and some links from the 'Support links' section from the footer",
+	"language": "en",
+	"breadcrumbs": [
+		{ "title": "Footer", "link": "sites/footers/footers-en.html" }
+	],
+	"altLangPage": "only-footer-about-gov-fr.html",
+	"secondlevel": false,
+	"dateModified": "2022-07-12",
+	"share": "true",
+	"noFooterContextual": "true",
+	"noFooterSupportLinks": "true",
+	"includes": { "footer": "edge" }
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
 
 {% include alert-softlaunch.html component="site footer" version="3" %}
 
-<p>By setting the <code>noFooterSite</code> variable to "true", some links from the "Support links" section will be hidden on page load.</p>
+<p>By setting the <code>noFooterContextual</code> and <code>noFooterSupportLinks</code> variables to "true", the "Contextual" section and some links from the "Support links" section will be hidden on page load but the "About government" section will remain.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;
 	&lt;h2 class=&quot;wb-inv&quot;&gt;About this site&lt;/h2&gt;
-	&lt;div class=&quot;gc-contextual&quot;&gt;
-		&lt;div class=&quot;container&quot;&gt;
-			&lt;nav&gt;
-				&lt;h3&gt;[Contextual footer title]&lt;/h3&gt;
-				&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
-					&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;[Contextual Link 1]&lt;/a&gt;&lt;/li&gt;
-					&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;[Contextual Link 2]&lt;/a&gt;&lt;/li&gt;
-					&lt;li&gt;&lt;a href=&quot;http://canada.ca/en&quot;&gt;[Contextual Link 3]&lt;/a&gt;&lt;/li&gt;
-				&lt;/ul&gt;
-			&lt;/nav&gt;
-		&lt;/div&gt;
-	&lt;/div&gt;
 	&lt;div class=&quot;landscape&quot;&gt;
 		&lt;div class=&quot;container&quot;&gt;
 			&lt;nav&gt;

--- a/sites/footers/only-footer-about-gov-fr.html
+++ b/sites/footers/only-footer-about-gov-fr.html
@@ -1,15 +1,16 @@
 ---
 {
-	"title": "Masquer certains liens de la section 'Liens d'assistance' du pied de page",
+	"title": "Masquer la section 'Contextuel' et certains liens de la section 'Liens d'assitance' du pied de page",
 	"language":	"fr",
 	"breadcrumbs": [
 		{ "title": "Footer", "link": "sites/footers/footers-fr.html" }
 	],
-	"altLangPage": "no-footer-site-en.html",
+	"altLangPage": "only-footer-about-gov-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-06-20",
+	"dateModified": "2022-07-12",
 	"share": "true",
-	"noFooterSite": "true",
+	"noFooterContextual": "true",
+	"noFooterSupportLinks": "true",
 	"includes": { "footer": "edge" }
 }
 ---
@@ -17,23 +18,11 @@
 
 {% include alert-softlaunch.html component="pied de page" version="3" %}
 
-<p>En définissant la variable <code>noFooterSite</code> à "true", certains liens de la section «&nbsp;Liens d'assitance&nbsp;» seront masqués au chargement de la page.</p>
+<p>En définissant les variables <code>noFooterContextual</code> et <code>noFooterSupportLinks</code> à «&nbsp;true&nbsp;», la section «&nbsp;Contextuel&nbsp;» et certains liens de la section «&nbsp;Liens d'assistance&nbsp;» seront masqués au chargement de la page mais la section «&nbsp;Au sujet du gouvernement&nbsp;» restera affichée.</p>
 
-<h2>Code de final attendu</h2>
+<h2>Code final attendu</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;
 	&lt;h2 class=&quot;wb-inv&quot;&gt;À propos de ce site&lt;/h2&gt;
-	&lt;div class=&quot;gc-contextual&quot;&gt;
-		&lt;div class=&quot;container&quot;&gt;
-			&lt;nav&gt;
-				&lt;h3&gt;[Titre du menu contextuel]&lt;/h3&gt;
-				&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
-					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 1]&lt;/a&gt;&lt;/li&gt;
-					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 2]&lt;/a&gt;&lt;/li&gt;
-					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 3]&lt;/a&gt;&lt;/li&gt;
-				&lt;/ul&gt;
-			&lt;/nav&gt;
-		&lt;/div&gt;
-	&lt;/div&gt;
 	&lt;div class=&quot;landscape&quot;&gt;
 		&lt;div class=&quot;container&quot;&gt;
 			&lt;nav&gt;

--- a/sites/footers/only-footer-contextual-en.html
+++ b/sites/footers/only-footer-contextual-en.html
@@ -9,8 +9,16 @@
 	"secondlevel": false,
 	"dateModified": "2022-07-12",
 	"share": "true",
-	"noFooterAbout": "true",
-	"noFooterSite": "true",
+	"noFooterAboutGov": "true",
+	"noFooterSupportLinks": "true",
+	"contextualFooter": {
+		"title": "[Contextual footer title]",
+		"links": [
+			{ "url": "http://canada.ca/en", "text": "Contextual Link 1"},
+			{ "url": "http://canada.ca/en", "text": "Contextual Link 2"},
+			{ "url": "http://canada.ca/en", "text": "Contextual Link 3"}
+		]
+	},
 	"includes": { "footer": "edge" }
 }
 ---
@@ -18,7 +26,7 @@
 
 {% include alert-softlaunch.html component="site footer" version="3" %}
 
-<p>By setting the <code>noFooterAbout</code> and <code>noFooterSite</code> variables to "true", the "About government" section and some links from the "Support links" secion will be hidden on page load but the "Contextual" section will remain.</p>
+<p>By setting the <code>noFooterAboutGov</code> and <code>noFooterSupportLinks</code> variables to "true", the "About government" section and some links from the "Support links" secion will be hidden on page load but the "Contextual" section will remain.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/footers/only-footer-contextual-fr.html
+++ b/sites/footers/only-footer-contextual-fr.html
@@ -9,8 +9,16 @@
 	"secondlevel": false,
 	"dateModified": "2022-07-12",
 	"share": "true",
-	"noFooterAbout": "true",
-	"noFooterSite": "true",
+	"noFooterAboutGov": "true",
+	"noFooterSupportLinks": "true",
+	"contextualFooter": {
+		"title": "[Titre du pied de page contextuel]",
+		"links": [
+			{ "url": "http://canada.ca/fr", "text": "Lien contextuel 1"},
+			{ "url": "http://canada.ca/fr", "text": "Lien contextuel 2"},
+			{ "url": "http://canada.ca/fr", "text": "Lien contextuel 3"}
+		]
+	},
 	"includes": { "footer": "edge" }
 }
 ---
@@ -18,7 +26,7 @@
 
 {% include alert-softlaunch.html component="pied de page" version="3" %}
 
-<p>En définissant les variables <code>noFooterAbout</code> et <code>noFooterSite</code> à «&nbsp;true&nbsp;», la section «&nbsp;Au sujet du gouvernement&nbsp;» et certains liens de la section «&nbsp;Liens d'assistance&nbsp;» seront masqués au chargement de la page mais la section «&nbsp;Contextuel&nbsp;» restera affichée.</p>
+<p>En définissant les variables <code>noFooterAboutGov</code> et <code>noFooterSupportLinks</code> à «&nbsp;true&nbsp;», la section «&nbsp;Au sujet du gouvernement&nbsp;» et certains liens de la section «&nbsp;Liens d'assistance&nbsp;» seront masqués au chargement de la page mais la section «&nbsp;Contextuel&nbsp;» restera affichée.</p>
 
 <h2>Code final attendu</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;
@@ -26,7 +34,7 @@
 	&lt;div class=&quot;gc-contextual&quot;&gt;
 		&lt;div class=&quot;container&quot;&gt;
 			&lt;nav&gt;
-				&lt;h3&gt;[Titre du menu contextuel]&lt;/h3&gt;
+				&lt;h3&gt;[Titre du pied de page contextuel]&lt;/h3&gt;
 				&lt;ul class=&quot;list-col-xs-1 list-col-sm-2 list-col-md-3&quot;&gt;
 					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 1]&lt;/a&gt;&lt;/li&gt;
 					&lt;li&gt;&lt;a href=&quot;http://canada.ca/fr&quot;&gt;[Lien contextuel 2]&lt;/a&gt;&lt;/li&gt;

--- a/sites/footers/only-footer-site-en.html
+++ b/sites/footers/only-footer-site-en.html
@@ -10,7 +10,7 @@
 	"dateModified": "2022-06-20",
 	"share": "true",
 	"noFooterContextual": "true",
-	"noFooterAbout": "true",
+	"noFooterAboutGov": "true",
 	"includes": { "footer": "edge" }
 }
 ---
@@ -18,7 +18,7 @@
 
 {% include alert-softlaunch.html component="site footer" version="3" %}
 
-<p>By setting the <code>noFooterContextual</code> and <code>noFooterAbout</code> variables to "true", the "Contextual" and "About government" sections will be hidden on page load.</p>
+<p>By setting the <code>noFooterContextual</code> and <code>noFooterAboutGov</code> variables to "true", the "Contextual" and "About government" sections will be hidden on page load.</p>
 
 <h2>Expected output code</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/footers/only-footer-site-fr.html
+++ b/sites/footers/only-footer-site-fr.html
@@ -10,7 +10,7 @@
 	"dateModified": "2022-06-20",
 	"share": "true",
 	"noFooterContextual": "true",
-	"noFooterAbout": "true",
+	"noFooterAboutGov": "true",
 	"includes": { "footer": "edge" }
 }
 ---
@@ -18,7 +18,7 @@
 
 {% include alert-softlaunch.html component="pied de page" version="3" %}
 
-<p>En définissant les variables <code>noFooterContextual</code> et <code>noFooterAbout</code> à "true", les sections «&nbsp;Contextuel&nbsp;» et «&nbsp;Au sujet du gouvernement&nbsp;» seront masquées au chargement de la page.</p>
+<p>En définissant les variables <code>noFooterContextual</code> et <code>noFooterAboutGov</code> à "true", les sections «&nbsp;Contextuel&nbsp;» et «&nbsp;Au sujet du gouvernement&nbsp;» seront masquées au chargement de la page.</p>
 
 <h2>Code final attendu</h2>
 <pre><code>&lt;footer id=&quot;wb-info&quot;&gt;

--- a/sites/includes/i18n-core.liquid
+++ b/sites/includes/i18n-core.liquid
@@ -32,9 +32,6 @@
 	{% assign i18nText-signAccount = "Mon compte" %}
 
 	{% assign i18nText-footerSite = "À propos de ce site" %}
-	{% assign i18nText-themeLinks = "Liens thématiques" %}
-	{% assign i18nText-supportLinks = "Liens d'assistance" %}
-	{% assign i18nText-transparency = "Transparence" %}
 
 	{% assign i18nText-dateModified = "Date de modification&#160;:" %}
 
@@ -63,9 +60,6 @@
 	{% assign i18nText-signAccount = "My account" %}
 
 	{% assign i18nText-footerSite = "About this site" %}
-	{% assign i18nText-themeLinks = "Theme links" %}
-	{% assign i18nText-supportLinks = "Support links" %}
-	{% assign i18nText-transparency = "Transparency" %}
 
 	{% assign i18nText-dateModified = "Date modified:" %}
 

--- a/sites/includes/i18n.liquid
+++ b/sites/includes/i18n.liquid
@@ -33,6 +33,10 @@
 	{% assign i18nText-wmms = "Symbole du gouvernement du Canada" %}
 	{% assign i18nText-wmmsAltLang = "<span lang="en">Symbol of the Government of Canada</span>" %}
 
+	{% assign i18nText-themeLinks = "Liens thématiques" %}
+	{% assign i18nText-supportLinks = "Liens d'assistance" %}
+	{% assign i18nText-transparency = "Transparence" %}
+
 {%- elsif i18nText-lang == "en" -%}
 
 	{% assign i18nText-homePage = "https://www.canada.ca/en.html" %}
@@ -56,5 +60,8 @@
 	{% assign i18nText-wmms = "Symbol of the Government of Canada" %}
 	{% assign i18nText-wmmsAltLang = "<span lang="fr">Symbole du gouvernement du Canada</span>" %}
 
+	{% assign i18nText-themeLinks = "Theme links" %}
+	{% assign i18nText-supportLinks = "Support links" %}
+	{% assign i18nText-transparency = "Transparency" %}
 
 {%- endif -%}

--- a/sites/skiplinks/index.json-ld
+++ b/sites/skiplinks/index.json-ld
@@ -1,0 +1,34 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Skip links",
+		"fr": "Liens de saut de page"
+	},
+	"description": {
+		"en": "Documentation and working example on how to use the skiplinks.",
+		"fr": "Documentation et example pratique sur l'utilisation des liens de saut de page."
+	},
+	"modified": "2022-01-12",
+	"componentName": "skiplinks",
+	"status": "stable",
+	"pages": {
+		"docs": [
+			{
+				"title": "Skip links",
+				"language": "en",
+				"path": "skiplinks-en.html"
+			},
+			{
+				"title": "Liens de saut de page",
+				"language": "fr",
+				"path": "skiplinks-fr.html"
+			}
+		]
+	}
+}

--- a/sites/skiplinks/skiplinks-en.html
+++ b/sites/skiplinks/skiplinks-en.html
@@ -1,0 +1,28 @@
+---
+{
+	"title": "Skip links",
+	"language": "en",
+	"altLangPage": "skiplinks-fr.html",
+	"secondlevel": false,
+	"dateModified": "2022-10-26",
+	"share": "true"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>Expected output code</h2>
+<pre><code>&lt;nav&gt;
+	&lt;ul id=&quot;wb-tphp&quot; class=&quot;wb-init wb-disable-inited&quot;&gt;
+		&lt;li class=&quot;wb-slc&quot;&gt;&lt;a class=&quot;wb-sl&quot; href=&quot;#wb-cont&quot;&gt;Skip to main content&lt;/a&gt;&lt;/li&gt;
+		&lt;li class=&quot;wb-slc visible-sm visible-md visible-lg&quot;&gt;&lt;a class=&quot;wb-sl&quot; href=&quot;#wb-info&quot;&gt;Skip to About this site&lt;/a&gt;&lt;/li&gt;
+		&lt;li class=&quot;wb-slc&quot;&gt;&lt;a class=&quot;wb-sl&quot; href=&quot;?wbdisable=true&quot; rel=&quot;alternate&quot;&gt;Switch to basic HTML version&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/nav&gt;</code></pre>
+
+<h2>Version history</h2>
+<dl>
+	<dt>Version v1.0.1 - 2022-10-26</dt>
+	<dd>Skip to footer button now has to always be visible.</dd>
+	<dt>Version v1.0</dt>
+	<dd>Initial version</dd>
+</dl>

--- a/sites/skiplinks/skiplinks-fr.html
+++ b/sites/skiplinks/skiplinks-fr.html
@@ -1,0 +1,28 @@
+---
+{
+	"title": "Liens de saut de page",
+	"language": "fr",
+	"altLangPage": "skiplinks-en.html",
+	"secondlevel": false,
+	"dateModified": "2022-10-26",
+	"share": "true"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>Code final attendu</h2>
+<pre><code>&lt;nav&gt;
+	&lt;ul id=&quot;wb-tphp&quot; class=&quot;wb-init wb-disable-inited&quot;&gt;
+		&lt;li class=&quot;wb-slc&quot;&gt;&lt;a class=&quot;wb-sl&quot; href=&quot;#wb-cont&quot;&gt;Passer au contenu principal&lt;/a&gt;&lt;/li&gt;
+		&lt;li class=&quot;wb-slc visible-sm visible-md visible-lg&quot;&gt;&lt;a class=&quot;wb-sl&quot; href=&quot;#wb-info&quot;&gt;Passer à « À propos de ce site »&lt;/a&gt;&lt;/li&gt;
+		&lt;li class=&quot;wb-slc&quot;&gt;&lt;a class=&quot;wb-sl&quot; href=&quot;?wbdisable=true&quot; rel=&quot;alternate&quot;&gt;Passer à la version HTML simplifiée&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/nav&gt;</code></pre>
+
+<h2>Historique de versions</h2>
+<dl>
+	<dt>Version v1.0.1 - 2022-10-26</dt>
+	<dd>Le lien de saut de page vers le pied de page doit maintenant demeurer visible en tout temps.</dd>
+	<dt>Version v1.0</dt>
+	<dd>Version initiale</dd>
+</dl>


### PR DESCRIPTION
Changes included in this PR: 

- Editorial change - Update code sample for footer version 2 English - The code sample in the "version 2.0 (deprecated)" should match the version 2 of the working example.
- Editorial change - Update code sample for footer version 1 French - The code sample in the "version 1.0 (déprécié)" should match the version 1 of the working example.
- Editorial change - Change the parameter noFooterAbout for the "no-footer-about-en.html" to be replace by "no-footer-about-gov-en.html". (English and French) This to remove the confusion between the h2 heading (About this site) vs only the h3 heading (Government of Canada).
- Editorial change - Change the parameter noFooterSite in "no-footer-site-en.html" for something like "no-footer-support-links-en.html" (English and French)
- Editorial change - Change the other working example which show a combination of the renamed "noFooterSite" and "noFooterAbout".
- Editorial change - The code sample of "only-footer-contextual-en.html" and "only-footer-contextual-fr.html" don't match the self test page. Probably some page property are missing here. Structurally the code match.
- Editorial change - Document the change to the skip-link component. In the footer documentation page and in the skip-link documentation page.
- Rename the page property noFooterAbout for noFooterAboutGov.
- Rename the page property noFooterSite for noFooterSupportLinks.
- Move the new i18nText variable from the core into the overwritable i18n.

Changes related to WET-289