### PR TITLE
Footer: removing flexbox utility classes

### DIFF
--- a/sites/footers/_base.scss
+++ b/sites/footers/_base.scss
@@ -218,17 +218,3 @@
 		/* END */
 	}
 }
-
-/* START: To be removed once added to WET-BOEW */
-.d-flex {
-	display: flex;
-}
-
-.align-items-center {
-	align-items: center;
-}
-
-.align-self-end {
-	align-self: flex-end;
-}
-/* END */


### PR DESCRIPTION
Removing the following flexbox utility classes:
- `.d-flex`
- `.align-items-center`
- `.align-self-end`

This PR is dependent on: https://github.com/wet-boew/wet-boew/pull/9461

Changes related to WET-289