### PR TITLE
Implementation guide page - Fix redirect

### DIFF
--- a/docs/implementing.html
+++ b/docs/implementing.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en" dir="ltr">
-<head>
-<meta charset="utf-8">
-<!-- Quick implementation guide - GCWeb theme / Guide d’implémentation rapide – thème GCWeb
-		/GCWeb/docs/implementing-en.html /GCWeb/docs/implementing-fr.html 
-		This is a temporary redirect and will be removed in September 2023-->
-<title>Quick implementation guide - GCWeb theme
-</title>
-<meta http-equiv="refresh" content="0;https://wet-boew.github.io/GCWeb/docs/implementing.html" />
-</head>
-<body>
-<p>This page has moved to <a href="/GCWeb/docs/implementing-en.html">https://wet-boew.github.io/GCWeb/docs/implementing-en.html</a>.</p>
-</body>
+	<head>
+		<meta charset="utf-8">
+		<!-- Quick implementation guide - GCWeb theme / Guide d’implémentation rapide – thème GCWeb
+				/GCWeb/docs/implementing-en.html /GCWeb/docs/implementing-fr.html 
+				This is a temporary redirect and will be removed in September 2023-->
+		<title>Quick implementation guide - GCWeb theme
+		</title>
+		<meta http-equiv="refresh" content="0;https://wet-boew.github.io/GCWeb/docs/implementing-en.html" />
+	</head>
+	<body>
+	<p>This page has moved to <a href="/GCWeb/docs/implementing-en.html">https://wet-boew.github.io/GCWeb/docs/implementing-en.html</a>.</p>
+	</body>
 </html>


### PR DESCRIPTION
Content change: Fix redirect link for previous landing page of the Quick Implementation Guide - GCWeb