### PR TITLE
Avoid translation - Language toggle + Splash page language selection buttons

### DIFF
--- a/sites/header/header-docs-en.html
+++ b/sites/header/header-docs-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "header-docs-fr.html",
 	"secondlevel": false,
-	"dateModified": "2022-10-11",
+	"dateModified": "2022-11-01",
 	"share": "true"
 }
 ---
@@ -29,8 +29,8 @@
 
 <h2>Working example</h2>
 <ul>
-	<li><a href="/templates/content-en.html">Content page including Header v4.0</a></li>
-	<li><a href="/sites/authentication/contextual-signin-en.html">Content page including Header v4.0 and Authentication section</a></li>
+	<li><a href="../../templates/content-en.html">Content page including Header v4.0</a></li>
+	<li><a href="../authentication/contextual-signin-en.html">Content page including Header v4.0 and Authentication section</a></li>
 </ul>
 
 <h2>How to implement</h2>
@@ -103,7 +103,7 @@
 		<pre><code>&lt;header&gt;
 	&lt;div id=&quot;wb-bnr&quot; class=&quot;container&quot;&gt;
 		&lt;div class=&quot;row&quot;&gt;
-			&lt;!-- Language toggle [version 1.0] --&gt;
+			&lt;!-- Language toggle [version 1.1] --&gt;
 			&lt;!-- Branding [version 1.0] --&gt;
 			&lt;!-- Search [version 1.0] --&gt;
 		&lt;/div&gt;
@@ -124,7 +124,7 @@
 		<pre><code>&lt;header&gt;
 	&lt;div id=&quot;wb-bnr&quot; class=&quot;container&quot;&gt;
 		&lt;div class=&quot;row&quot;&gt;
-			&lt;!-- Language toggle [version 1.0] --&gt;
+			&lt;!-- Language toggle [version 1.1] --&gt;
 			&lt;!-- Branding [version 1.0] --&gt;
 			&lt;!-- Search [version 1.0] --&gt;
 		&lt;/div&gt;

--- a/sites/header/header-docs-fr.html
+++ b/sites/header/header-docs-fr.html
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"altLangPage": "header-docs-en.html",
 	"secondlevel": false,
-	"dateModified": "2022-10-11",
+	"dateModified": "2022-11-01",
 	"share": "true"
 }
 ---
@@ -29,8 +29,8 @@
 
 <h2>Example pratique</h2>
 <ul>
-	<li><a href="/templates/content-fr.html">Page de contenu incluant l'en-tête v4.0</a></li>
-	<li><a href="/sites/authentication/contextual-signin-fr.html">Page de contenu incluant l'en-tête v4.0 ainsi que la section d'authentification.</a></li>
+	<li><a href="../../templates/content-fr.html">Page de contenu incluant l'en-tête v4.0</a></li>
+	<li><a href="../authentication/contextual-signin-fr.html">Page de contenu incluant l'en-tête v4.0 ainsi que la section d'authentification.</a></li>
 </ul>
 
 <h2>Comment mettre en œuvre</h2>
@@ -102,7 +102,7 @@
 		<pre><code>&lt;header&gt;
 	&lt;div id=&quot;wb-bnr&quot; class=&quot;container&quot;&gt;
 		&lt;div class=&quot;row&quot;&gt;
-			&lt;!-- Changer de langue [version 1.0] --&gt;
+			&lt;!-- Changer de langue [version 1.1] --&gt;
 			&lt;!-- Image de marque [version 1.0] --&gt;
 			&lt;!-- Recherche [version 1.0] --&gt;
 		&lt;/div&gt;
@@ -123,7 +123,7 @@
 		<pre><code>&lt;header&gt;
 	&lt;div id=&quot;wb-bnr&quot; class=&quot;container&quot;&gt;
 		&lt;div class=&quot;row&quot;&gt;
-			&lt;!-- Changer de langue [version 1.0] --&gt;
+			&lt;!-- Changer de langue [version 1.1] --&gt;
 			&lt;!-- Image de marque [version 1.0] --&gt;
 			&lt;!-- Recherche [version 1.0] --&gt;
 		&lt;/div&gt;

--- a/sites/language/includes/languagetoggle.html
+++ b/sites/language/includes/languagetoggle.html
@@ -3,8 +3,8 @@
 	<ul class="list-inline mrgn-bttm-0">
 		<li>
 			<a lang="{{ i18nText-altLang }}" hreflang="{{ i18nText-altLang }}" href="{{ page.altLangPage }}">
-				<span class="hidden-xs">{{ i18nText-altLanguage }}</span>
-				<abbr title="{{ i18nText-altLanguage }}" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">{{ i18nText-altLang }}</abbr>
+				<span class="hidden-xs" translate="no">{{ i18nText-altLanguage }}</span>
+				<abbr title="{{ i18nText-altLanguage }}" translate="no" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">{{ i18nText-altLang }}</abbr>
 			</a>
 		</li>
 	</ul>

--- a/sites/language/index.json-ld
+++ b/sites/language/index.json-ld
@@ -1,0 +1,34 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Language toggle link",
+		"fr": "Lien pour changer de langue"
+	},
+	"description": {
+		"en": "Documentation on how to use language toogle link.",
+		"fr": "Documentation sur l'utilisation lien pour changer de langue."
+	},
+	"modified": "2022-11-01",
+	"componentName": "language",
+	"status": "stable",
+	"pages": {
+		"docs": [
+			{
+				"title": "Language toggle link",
+				"language": "en",
+				"path": "language-en.html"
+			},
+			{
+				"title": "Lien pour changer de langue",
+				"language": "fr",
+				"path": "language-fr.html"
+			}
+		]
+	}
+}

--- a/sites/language/language-en.html
+++ b/sites/language/language-en.html
@@ -1,0 +1,63 @@
+---
+{
+	"altLangPage": "language-fr.html",
+	"dateModified": "2022-11-01",
+	"description": "Documentation and working example on how to use language toggle link.",
+	"language": "en",
+	"title": "Language toggle link"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+<dl class="horizontal">
+	<dt>Status</dt>
+	<dd>Stable</dd>
+	<dt>Type</dt>
+	<dd>Canada.ca site functionality</dd>
+	<dt>Last review</dt>
+	<dd>2022-11-01</dd>
+	<dt>Component version</dt>
+	<dd>Version 1.1</dd>
+</dl>
+
+<h2>Purpose</h2>
+<p>The language toggle link always leads people to the equivalent page in the other official language, ensuring that people are able to switch between languages without losing track of where they were before </p>
+
+<h2>How to implement</h2>
+<ul>
+	<li>The language toggle link consists of only one element—a simple text link indicating either “English” or “Français”</li>
+	<li>The link is always presented in the top right corner of the global header area, regardless of the screen size</li>
+</ul>
+
+<h2>Before and After</h2>
+<div class="row">
+	<div class="col-md-6">
+		<h2 id="v2">Version 1.1</h2>
+
+		<p>List of change since version 1.0: Addition the <code>translation="no"</code> attribute.</p>
+
+		<pre><code>&lt;ul class="list-inline mrgn-bttm-0"&gt;
+				&lt;li&gt;
+					&lt;a href="/fr.html" lang="fr"&gt;
+						&lt;span class="hidden-xs"&gt;Français&lt;/span&gt;
+						&lt;abbr title="Français" <ins>translate="no"</ins> class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase"&gt;fr&lt;/abbr&gt;
+					&lt;/a&gt;
+				&lt;/li&gt;
+			&lt;/ul&gt;</code></pre>
+	</div>
+	<div class="col-md-6">
+<h2>Version 1.0 (deprecated)</h2>
+
+<p>The language toggle version 1.0 is deprecated but still supported.</p>
+
+<pre><code>&lt;ul class="list-inline mrgn-bttm-0"&gt;
+				&lt;li&gt;
+					&lt;a href="/fr.html" lang="fr"&gt;
+						&lt;span class="hidden-xs"&gt;Français&lt;/span&gt;
+						&lt;abbr title="Français" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase"&gt;fr&lt;/abbr&gt;
+					&lt;/a&gt;
+				&lt;/li&gt;
+			&lt;/ul&gt;</code></pre>
+
+	</div>
+</div>

--- a/sites/language/language-fr.html
+++ b/sites/language/language-fr.html
@@ -1,0 +1,62 @@
+---
+{
+	"altLangPage": "language-en.html",
+	"dateModified": "2022-11-01",
+	"description": "Documentation et exemple pratique sur l'utilisation du lien pour changer de langue.",
+	"language": "fr",
+	"title": "Lien pour changer de langue"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<dl class="horizontal">
+	<dt>Statut</dt>
+	<dd>Stable</dd>
+	<dt>Type</dt>
+	<dd>Fonctionnalité du site Canada.ca</dd>
+	<dt>Dernière révision</dt>
+	<dd>2022-11-01</dd>
+	<dt>Version de la composante</dt>
+	<dd>Version 1.1</dd>
+</dl>
+
+<h2>Objectif</h2>
+<p>Le lien permettant de changer de langue dirige systématiquement la personne vers la page équivalente dans l’autre langue officielle, ce qui fait en sorte qu’il peut passer d’une langue à l’autre sans perdre l’endroit où il se trouvait auparavant.</p>
+
+<h2>Comment mettre en œuvre</h2>
+<ul>
+	<li>Le lien permettant de changer de langue ne consiste qu’en un seul élément : il s’agit d’un simple lien textuel indiquant «&nbsp;English&nbsp;» ou «&nbsp;Français&nbsp;».</li>
+	<li>Le lien est toujours affiché dans le coin supérieur droit de l’en-tête général, peu importe la taille de l'écran.</li>
+</ul>
+
+<h2>Avant et après</h2>
+<div class="row">
+	<div class="col-md-6">
+		<h2 id="v2">Version 1.1</h2>
+
+		<p>Liste des changements depuis la version 1.0 : Ajout de l'attribut <code>translation="no"</code>.</p>
+
+		<pre><code>&lt;ul class="list-inline mrgn-bttm-0"&gt;
+						&lt;li&gt;
+							&lt;a href="/en.html" lang="en"&gt;
+								&lt;span class="hidden-xs"&gt;English&lt;/span&gt;
+								&lt;abbr title="English" <ins>translate="no"</ins> class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase"&gt;en&lt;/abbr&gt;
+							&lt;/a&gt;
+						&lt;/li&gt;
+					&lt;/ul&gt;</code></pre>
+	</div>
+	<div class="col-md-6">
+		<h2>Version 1.0 (obsolète)</h2>
+
+		<p>La version 1.0 du lien pour changer de langue est obsolète mais toujours supportée.</p>
+
+		<pre><code>&lt;ul class="list-inline mrgn-bttm-0"&gt;
+						&lt;li&gt;
+							&lt;a href="/en.html" lang="en"&gt;
+								&lt;span class="hidden-xs"&gt;English&lt;/span&gt;
+								&lt;abbr title="English" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase"&gt;en&lt;/abbr&gt;
+							&lt;/a&gt;
+						&lt;/li&gt;
+					&lt;/ul&gt;</code></pre>
+	</div>
+</div>

--- a/templates/splash/api-en.html
+++ b/templates/splash/api-en.html
@@ -7,7 +7,7 @@
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2022-10-05",
+	"dateModified": "2022-10-31",
 	"share": "false"
 }
 ---
@@ -18,10 +18,11 @@
 	<dt>Type</dt>
 	<dd>Canada.ca template</dd>
 	<dt>Last review</dt>
-	<dd>2022-10-05</dd>
-
+	<dd>2022-10-31</dd>
 	<dt>Specification</dt>
 	<dd>There is no specification yet</dd>
+	<dt>Template version</dt>
+	<dd>Version 2.2</dd>
 </dl>
 
 <h2>Working Examples</h2>
@@ -40,6 +41,8 @@
 
 <h2>Version history</h2>
 <dl>
+	<dt>Version v2.2 - 2022-10-31</dt>
+	<dd>Addition of the <code>translate</code> attribute set to "no" to each language selection buttons: English and Français</dd>
 	<dt>Version v2.1 - 2022-10-06</dt>
 	<dd>Creation and addition of a blilingual variant that present the subtitle</dd>
 	<dt>Version v2.0 - 2022-09-28</dt>

--- a/templates/splash/api-fr.html
+++ b/templates/splash/api-fr.html
@@ -7,7 +7,7 @@
 		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
 	],
 	"secondlevel": false,
-	"dateModified": "2022-10-05",
+	"dateModified": "2022-10-31",
 	"share": "false"
 }
 ---
@@ -18,9 +18,11 @@
 	<dt>Type</dt>
 	<dd>Gabarit de Canada.ca</dd>
 	<dt>Dernière revue</dt>
-	<dd>2022-10-05</dd>
+	<dd>2022-10-31</dd>
 	<dt>Specification</dt>
 	<dd>Aucune spécifications</dd>
+	<dt>Version du gabarit</dt>
+	<dd>Version 2.2</dd>
 </dl>
 
 <h2>Exemples pratiques</h2>
@@ -39,6 +41,8 @@
 
 <h2>Historique des versions</h2>
 <dl>
+	<dt>Version v2.2 - 2022-10-31</dt>
+	<dd>Ajout de l'attribut <code>translate</code> avec la valeur "no" à chacun des boutons de selection de langues: English et Français.</dd>
 	<dt>Version v2.1 - 2022-10-06</dt>
 	<dd>Création et ajout d'une variante blilingue qui présente le sous-titre</dd>
 	<dt>Version v2.0 - 2022-09-28</dt>

--- a/templates/splash/splashpage-contextual-en.md
+++ b/templates/splash/splashpage-contextual-en.md
@@ -9,7 +9,7 @@ creator-fr: Gouvernement du Canada
 subject-en: GV Government and Politics
 subject-fr: GV Gouvernement et vie politique
 dateIssued: 2022-10-05
-dateModified: 2022-10-06
+dateModified: 2022-10-31
 
 images:
   - https://www.canada.ca/content/dam/canada/splash/sp-bg-1.jpg
@@ -28,10 +28,10 @@ images:
 <div class="row wb-eqht-grd">
 	<section class="col-sm-6 text-sm-right">
 		<h2 class="hght-inhrt h4">[Contextual title]</h2>
-		<p><a href="../home/home-en.html" class="btn btn-primary">English</a></p>
+		<p><a href="../home/home-en.html" class="btn btn-primary" translate="no">English</a></p>
 	</section>
 		<section class="col-sm-6" lang="fr">
 		<h2 class="hght-inhrt h4">[Titre contextuel]</h2>
-		<p><a href="../home/home-fr.html" class="btn btn-primary">Français</a></p>
+		<p><a href="../home/home-fr.html" class="btn btn-primary" translate="no">Français</a></p>
 	</section>
 </div>

--- a/templates/splash/splashpage-contextual-fr.md
+++ b/templates/splash/splashpage-contextual-fr.md
@@ -9,7 +9,7 @@ creator-fr: Gouvernement du Canada
 subject-en: GV Government and Politics
 subject-fr: GV Gouvernement et vie politique
 dateIssued: 2022-10-05
-dateModified: 2022-10-06
+dateModified: 2022-10-31
 
 images:
   - https://www.canada.ca/content/dam/canada/splash/sp-bg-1.jpg
@@ -28,10 +28,10 @@ images:
 <div class="row wb-eqht-grd">
 	<section class="col-sm-6 text-sm-right">
 		<h2 class="hght-inhrt h4">[Titre contextuel]</h2>
-		<p><a href="../home/home-fr.html" class="btn btn-primary">Français</a></p>
+		<p><a href="../home/home-fr.html" class="btn btn-primary" translate="no">Français</a></p>
 	</section>
 	<section class="col-sm-6" lang="en">
 		<h2 class="hght-inhrt h4">[Contextual title]</h2>
-		<p><a href="../home/home-en.html " class="btn btn-primary">English</a></p>
+		<p><a href="../home/home-en.html " class="btn btn-primary" translate="no">English</a></p>
 	</section>
 </div>

--- a/templates/splash/splashpage-en.md
+++ b/templates/splash/splashpage-en.md
@@ -9,7 +9,7 @@ creator-fr: Gouvernement du Canada
 subject-en: GV Government and Politics
 subject-fr: GV Gouvernement et vie politique
 dateIssued: 2013-12-13
-dateModified: 2021-05-06
+dateModified: 2022-10-31
 
 images:
   - https://www.canada.ca/content/dam/canada/splash/sp-bg-1.jpg
@@ -28,10 +28,10 @@ images:
 <div class="row">
 	<section class="col-xs-6 text-right">
 	  <h2 class="wb-inv">Government of Canada</h2>
-	  <p><a href="../home/home-en.html" class="btn btn-primary">English</a></p>
+	  <p><a href="../home/home-en.html" class="btn btn-primary" translate="no">English</a></p>
 	</section>
 	<section class="col-xs-6" lang="fr">
 	  <h2 class="wb-inv">Gouvernement du Canada</h2>
-	  <p><a href="../home/home-fr.html" class="btn btn-primary">Français</a></p>
+	  <p><a href="../home/home-fr.html" class="btn btn-primary" translate="no">Français</a></p>
 	</section>
 </div>

--- a/templates/splash/splashpage-fr.md
+++ b/templates/splash/splashpage-fr.md
@@ -9,7 +9,7 @@ creator-fr: Gouvernement du Canada
 subject-en: GV Government and Politics
 subject-fr: GV Gouvernement et vie politique
 dateIssued: 2022-09-27
-dateModified: 2022-09-28
+dateModified: 2022-10-31
 
 images:
   - https://www.canada.ca/content/dam/canada/splash/sp-bg-1.jpg
@@ -28,10 +28,10 @@ images:
 <div class="row">
 	<section class="col-xs-6 text-right">
 	  <h2 class="wb-inv">Gouvernement du Canada</h2>
-	  <p><a href="../home/home-fr.html" class="btn btn-primary">Français</a></p>
+	  <p><a href="../home/home-fr.html" class="btn btn-primary" translate="no">Français</a></p>
 	</section>
 	<section class="col-xs-6" lang="en">
 	  <h2 class="wb-inv">Government of Canada</h2>
-	  <p><a href="../home/home-en.html " class="btn btn-primary">English</a></p>
+	  <p><a href="../home/home-en.html " class="btn btn-primary" translate="no">English</a></p>
 	</section>
 </div>


### PR DESCRIPTION
- Creation and addition of the documentation and working example for the Language Toggle link.
- Update the language toggle link and the language selection buttons from the splash page with the `translation="no"` attribute.