### PR TITLE
Méli-mélo 2021-05-conjunction - Add support for no border

### DIFF
--- a/méli-mélo/2021-05-conjunction/and-or.css
+++ b/méli-mélo/2021-05-conjunction/and-or.css
@@ -7,7 +7,6 @@ ul[class*=cnjnctn-type-] {
 	flex-wrap: nowrap;
 	flex-direction: column;
 	margin-bottom: 15px;
-	margin-left: 5px;
 	margin-right: 0px;
 	margin-top: 15px;
 	min-height: 60px;
@@ -137,6 +136,13 @@ html:lang(fr) .cnjnctn-type-or>[class*=cnjnctn-col]:not(:first-child):before {
 }
 .cnjnctn-type-and.cnjnctn-xs>[class*=cnjnctn-col]:not(:first-child):before {
 	border-width: 3px 0px 3px 0px;
+}
+[class*=cnjnctn-type-]:not(:is(.cnjnctn-sm, .cnjnctn-md, .cnjnctn-lg)).brdr-0>[class*=cnjnctn-col]:after {
+ background-image:none;
+}
+ [class*=cnjnctn-type-]:not(:is(.cnjnctn-sm, .cnjnctn-md, .cnjnctn-lg)).brdr-0>[class*=cnjnctn-col] {
+ padding-left: 0px;
+ padding-right: 0px;
 }
 
 @media all and (min-width: 768px) {

--- a/méli-mélo/2021-05-conjunction/edge-cases.html
+++ b/méli-mélo/2021-05-conjunction/edge-cases.html
@@ -1,0 +1,85 @@
+---
+title: Edge cases of And/Or decision points (Conjunctions)
+dateModified: 2022-11-14
+description: "Test of edge cases about conjunctions for stacked or side by side decision points, and/or"
+lang: en
+css:
+- and-or.css
+---
+<p>Test of edge cases about conjunctions for stacked or side by side decision points, and/or.</p>
+
+<nav>
+	<h2 class="h5">Table of content</h2>
+	<ul>
+		<li><a href="index.html">And/Or decision points (Conjunctions)</a></li>
+		<li><a href="index-fr.html" hreflang="fr"><span lang="en">And/Or decision points (Conjunctions)</span> - Français</a></li>
+		<li>Edge cases of And/Or decision points (Conjunctions)</li>
+	</ul>
+</nav>
+
+<h2>No border shall not work for responsive break point</h2>
+
+<p><strong>Test expectation:</strong> The border style <code>.brdr-0</code> is ignored when stack except for "Test 4".</p>
+
+<section>
+	<h3>Test 1 - Stacks on extra small devices, phones (&lt;768px)</h3>
+	<div class="cnjnctn-type-or cnjnctn-sm  brdr-0">
+		<div class="cnjnctn-col">
+			<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of 2</span></h4>
+			<p>This is content for header A </p>
+		</div>
+		<div class="cnjnctn-col">
+			<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of 2</span></h4>
+			<p>This is content for header B</p>
+		</div>
+	</div>
+</section>
+<section>
+	<h3>Test 2 - Stacks on small devices, tablets (768px to 992px)</h3>
+	<div class="cnjnctn-type-or cnjnctn-md  brdr-0">
+		<div class="cnjnctn-col">
+			<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of 2</span></h4>
+			<p>This is content for header A </p>
+		</div>
+		<div class="cnjnctn-col">
+			<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of 2</span></h4>
+			<p>This is content for header B</p>
+		</div>
+	</div>
+</section>
+<section>
+	<h3>Test 3 - Stacks on medium devices (992px to 1200px)</h3>
+	<div class="cnjnctn-type-or cnjnctn-lg  brdr-0">
+		<div class="cnjnctn-col">
+			<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of 2</span></h4>
+			<p>This is content for header A </p>
+		</div>
+		<div class="cnjnctn-col">
+			<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of 2</span></h4>
+			<p>This is content for header B</p>
+		</div>
+	</div>
+</section>
+<h3>Test 4 - Always stacked (mobile first, no side-by-side)</h3>
+<section class="panel panel-default">
+	<header class="panel-heading">
+		<h5 class="panel-title">Heading</h5>
+	</header>
+	<div class="panel-body">
+		<ul class="cnjnctn-type-or brdr-0">
+			<li class="cnjnctn-col">This is content for option A </li>
+			<li class="cnjnctn-col">This is content for option B</li>
+		</ul>
+	</div>
+</section>
+<section class="panel panel-default">
+	<header class="panel-heading">
+		<h5 class="panel-title">Heading</h5>
+	</header>
+	<div class="panel-body">
+		<ul class="cnjnctn-type-and brdr-0">
+			<li class="cnjnctn-col">This is content for part A </li>
+			<li class="cnjnctn-col">This is content for part B</li>
+		</ul>
+	</div>
+</section>

--- a/méli-mélo/2021-05-conjunction/index-fr.html
+++ b/méli-mélo/2021-05-conjunction/index-fr.html
@@ -6,11 +6,18 @@ lang: fr
 css:
 - and-or.css
 ---
-<p><a href="index.html">Lien vers des exemples en anglais</a></p>
+<nav>
+	<h2 class="h5">Table des matières</h2>
+	<ul>
+		<li><a href="index.html" hreflang="en" lang="en">And/Or decision points (Conjunctions)</a></li>
+		<li><span lang="en">And/Or decision points (Conjunctions)</span> - Français</li>
+		<li><a href="edge-cases.html" hreflang="en" lang="en">Edge cases of And/Or decision points (Conjunctions)</a></li>
+	</ul>
+</nav>
 
 <p>le rôle principal: ARC - Christopher Oakes (@christopher-o)</p>
  <h2>Configurations de base</h2>
-     
+
         <h3>Jamais empilé côte à côte </h3>
         <div class="cnjnctn-type-or cnjnctn-xs">
     <div class="cnjnctn-col">
@@ -81,8 +88,8 @@ css:
 &lt;/div&gt;
 
 //Empilé toujours "ou"
-&lt;div class="cnjnctn-type-or"&gt; 
-	&lt;div class="cnjnctn-col"&gt; 
+&lt;div class="cnjnctn-type-or"&gt;
+	&lt;div class="cnjnctn-col"&gt;
 		&lt;h4 class="text-muted"&gt;En-têtes A&lt;span class="wb-inv"&gt;: Option 1 sur 2&lt;/span&gt;&lt;/h4&gt;
 		&lt;p&gt;Ceci est contenu pour la tête A &lt;/p&gt;
 	&lt;/div&gt;
@@ -92,8 +99,8 @@ css:
 	&lt;/div&gt;
 &lt;/div&gt;
 //Empilé toujours  "et"
-&lt;div class="cnjnctn-type-and"&gt; 
-	&lt;div class="cnjnctn-col"&gt; 
+&lt;div class="cnjnctn-type-and"&gt;
+	&lt;div class="cnjnctn-col"&gt;
 		&lt;h4 class="text-muted"&gt;En-têtes A&lt;/h4&gt;
 		&lt;p&gt;Ceci est contenu pour la tête A &lt;/p&gt;
 	&lt;/div&gt;
@@ -104,4 +111,4 @@ css:
 &lt;/div&gt;</code>
   </pre>
   </details>
-      
+

--- a/méli-mélo/2021-05-conjunction/index.html
+++ b/méli-mélo/2021-05-conjunction/index.html
@@ -17,6 +17,7 @@ css:
 	<li>2022-02 - Have this feature as provisional feature in GCWeb and get TBS to publish guidance on how to use it.</li>
 	<li>2022-05 - updated to focus more on using as list items (with or without headers)</li>
 	<li>2022-09 - updated CSS to allow nested decision points</li>
+	<li>2022-11 - updated CSS to allow no border on always stacked items</li>
 	<li>2022-12 - Have this feature as provisional/stable feature in GCWeb and get TBS to publish guidance on how to use it.</li>
 </ul>
 
@@ -82,6 +83,7 @@ css:
 		This is content for part B
 	&lt;/li&gt;
 &lt;/li&gt;
+&lt;/ul&gt;
 
 //Always stacked "or"
 &lt;ul class=&quot;cnjnctn-type-or&quot;&gt;
@@ -100,9 +102,78 @@ css:
 	&lt;li class=&quot;cnjnctn-col&quot;&gt;
 		This is content for part B
 	&lt;/li&gt;
-&lt;/li&gt;</code>
+&lt;/li&gt;
+&lt;/ul&gt;</code>
   </pre>
   </details>
+
+<h3>No border on always stacked <span class="label label-info">New</span></h3>
+<p>This can be used when a border or design (e.g. zebra striping) has already defined the border of the content.</p>
+<h4>Always stacked (mobile first, no side-by-side)</h4>
+<div class="panel panel-default">
+    <header class="panel-heading">
+      <h5 class="panel-title">Heading</h5>
+    </header>
+    <div class="panel-body">
+  <ul class="cnjnctn-type-or brdr-0">
+<li class="cnjnctn-col">This is content for option A </li>
+    <li class="cnjnctn-col">This is content for option B</li>
+          </ul>
+	</div>
+</div>
+ <div class="panel panel-default">
+    <header class="panel-heading">
+      <h5 class="panel-title">Heading</h5>
+    </header>
+    <div class="panel-body">
+        <ul class="cnjnctn-type-and brdr-0">
+    <li class="cnjnctn-col">This is content for part A </li>
+    <li class="cnjnctn-col">This is content for part B</li>
+</ul>
+	 </div>
+</div>
+
+   <details>
+    <summary>
+            <p>Code</p>
+          </summary>
+    <pre><code>//Always stacked "or" with no border
+&lt;div class=&quot;panel panel-default&quot;&gt;
+&lt;header class=&quot;panel-heading&quot;&gt;
+&lt;h5 class=&quot;panel-title&quot;&gt;Heading&lt;/h5&gt;
+&lt;/header&gt;
+&lt;div class=&quot;panel-body&quot;&gt;	
+&lt;ul class=&quot;cnjnctn-type-or brdr-0&quot;&gt;
+	&lt;li class=&quot;cnjnctn-col&quot;&gt;
+		This is content for option A
+	&lt;/li&gt;
+	&lt;li class=&quot;cnjnctn-col&quot;&gt;
+		This is content for option B
+	&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/div&gt;
+&lt;/div&gt;
+
+//Always stacked "and" with no border
+&lt;div class=&quot;panel panel-default&quot;&gt;
+&lt;header class=&quot;panel-heading&quot;&gt;
+&lt;h5 class=&quot;panel-title&quot;&gt;Heading&lt;/h5&gt;
+&lt;/header&gt;
+&lt;div class=&quot;panel-body&quot;&gt;
+&lt;ul class=&quot;cnjnctn-type-and brdr-0&quot;&gt;
+	&lt;li class=&quot;cnjnctn-col&quot;&gt;
+		This is content for  part A
+	&lt;/li&gt;
+	&lt;li class=&quot;cnjnctn-col&quot;&gt;
+		This is content for part B
+	&lt;/li&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/div&gt;
+&lt;/div&gt;</code>
+  </pre>
+  </details>
+
 
 
         <h3>Never stacked (always side-by-side) </h3>

--- a/méli-mélo/2021-05-conjunction/index.html
+++ b/méli-mélo/2021-05-conjunction/index.html
@@ -38,6 +38,7 @@ css:
     <li>Adding the word &quot;or&quot; as part of the last statement in each column (except the last column)</li>
   </ul>
 <h3>Using a simple list (without headers) <span class="label label-info">New</span></h3>
+<section>
 <h4>Never stacked (always side-by-side)</h4>
   <ul class="cnjnctn-type-or cnjnctn-xs">
 <li class="cnjnctn-col">This is content for option A </li>
@@ -48,7 +49,8 @@ css:
     <li class="cnjnctn-col">This is content for part A </li>
     <li class="cnjnctn-col">This is content for part B</li>
 </ul>
-
+</section>
+<section>
 <h4>Always stacked (mobile first, no side-by-side)</h4>
   <ul class="cnjnctn-type-or">
 <li class="cnjnctn-col">This is content for option A </li>
@@ -59,11 +61,11 @@ css:
     <li class="cnjnctn-col">This is content for part A </li>
     <li class="cnjnctn-col">This is content for part B</li>
 </ul>
-
+</section>
 
    <details>
     <summary>
-            <p>Code</p>
+          View code
           </summary>
     <pre><code>//Never stacked "or"
 &lt;ul class=&quot;cnjnctn-type-or cnjnctn-xs&quot;&gt;
@@ -110,7 +112,7 @@ css:
 <h3>No border on always stacked <span class="label label-info">New</span></h3>
 <p>This can be used when a border or design (e.g. zebra striping) has already defined the border of the content.</p>
 <h4>Always stacked (mobile first, no side-by-side)</h4>
-<div class="panel panel-default">
+<section class="panel panel-default">
     <header class="panel-heading">
       <h5 class="panel-title">Heading</h5>
     </header>
@@ -120,8 +122,8 @@ css:
     <li class="cnjnctn-col">This is content for option B</li>
           </ul>
 	</div>
-</div>
- <div class="panel panel-default">
+</section>
+ <section class="panel panel-default">
     <header class="panel-heading">
       <h5 class="panel-title">Heading</h5>
     </header>
@@ -131,14 +133,14 @@ css:
     <li class="cnjnctn-col">This is content for part B</li>
 </ul>
 	 </div>
-</div>
+</section>
 
    <details>
     <summary>
-            <p>Code</p>
+      View code
           </summary>
     <pre><code>//Always stacked "or" with no border
-&lt;div class=&quot;panel panel-default&quot;&gt;
+&lt;section class=&quot;panel panel-default&quot;&gt;
 &lt;header class=&quot;panel-heading&quot;&gt;
 &lt;h5 class=&quot;panel-title&quot;&gt;Heading&lt;/h5&gt;
 &lt;/header&gt;
@@ -152,10 +154,10 @@ css:
 	&lt;/li&gt;
 &lt;/ul&gt;
 &lt;/div&gt;
-&lt;/div&gt;
+&lt;/section&gt;
 
 //Always stacked "and" with no border
-&lt;div class=&quot;panel panel-default&quot;&gt;
+&lt;section class=&quot;panel panel-default&quot;&gt;
 &lt;header class=&quot;panel-heading&quot;&gt;
 &lt;h5 class=&quot;panel-title&quot;&gt;Heading&lt;/h5&gt;
 &lt;/header&gt;
@@ -170,13 +172,14 @@ css:
 &lt;/li&gt;
 &lt;/ul&gt;
 &lt;/div&gt;
-&lt;/div&gt;</code>
+&lt;/section&gt;</code>
   </pre>
   </details>
 
 
-
+<section>
         <h3>Never stacked (always side-by-side) </h3>
+
         <div class="cnjnctn-type-or cnjnctn-xs">
     <div class="cnjnctn-col">
             <h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of 2</span></h4>
@@ -187,6 +190,7 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
+
         <div class="cnjnctn-type-and cnjnctn-xs">
     <div class="cnjnctn-col">
             <h4 class="text-muted">Header A</h4>
@@ -197,6 +201,8 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
+</section>	
+<section>
         <h3>Always stacked (mobile first, no side-by-side)</h3>
         <div class="cnjnctn-type-or">
     <div class="cnjnctn-col">
@@ -218,9 +224,10 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
+</section>	
         <details>
     <summary>
-            <p>Code</p>
+        View code
           </summary>
     <pre><code>//Never stacked "or"
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-xs&quot;&gt;
@@ -271,7 +278,8 @@ css:
   </details>
         <h3>Responsive design</h3>
         <p><strong>Note:</strong> all designs going forward will use the "or" model to simplify the amount of examples.</p>
-        <h4>Stacks on extra small devices, phones (&lt;768px)</h4>
+<section>      
+<h4>Stacks on extra small devices, phones (&lt;768px)</h4>
         <div class="cnjnctn-type-or cnjnctn-sm">
     <div class="cnjnctn-col">
             <h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of 2</span></h5>
@@ -282,6 +290,8 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
+</section>
+<section>
         <h4>Stacks on small devices, tablets (768px to 992px)</h4>
         <div class="cnjnctn-type-or cnjnctn-md">
     <div class="cnjnctn-col">
@@ -293,6 +303,8 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
+</section>
+<section>
         <h4>Stacks on medium devices (992px to 1200px)</h4>
         <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col">
@@ -304,8 +316,9 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
+</section>	
         <details>
-    <summary>Code</summary>
+    <summary>View code</summary>
     <pre><code>//Stacks on extra small devices, phones	
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-sm&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
@@ -343,7 +356,8 @@ css:
         <p>Use the <strong>always stacked</strong> design to stack across all resolutions.</p>
         <h2>Extended configurations</h2>
         <h3>Column count</h3>
-        <h4>Three columns (example stacks on small devices)</h4>
+<section>        
+<h4>Three columns (example stacks on small devices)</h4>
         <div class="cnjnctn-type-or cnjnctn-md">
     <div class="cnjnctn-col">
             <h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of 3</span></h5>
@@ -358,6 +372,8 @@ css:
             <p>This is content for header C</p>
           </div>
   </div>
+</section>
+<section>
         <h4>Four columns (example stacks on medium devices)</h4>
         <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col">
@@ -377,8 +393,9 @@ css:
             <p>This is content for header D</p>
           </div>
   </div>
+</section>
         <details>
-    <summary>Code</summary>
+    <summary>view code</summary>
     <pre><code>//Three columns (example stacks on small devices)
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-md&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
@@ -418,47 +435,49 @@ css:
 
 <h3>Nested conjunction<span class="label label-info">New</span></h3>
 <p>For instances where one of the decision points may have it's own set of decision points.</p>
+<section>
 <h4>An or decision point that stacks on small, nested with an always stacked and decision point</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
 	<div class="cnjnctn-col-80">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A</p>
 	</div>
 	<div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
     <div class="cnjnctn-type-and"> 
 	<div class="cnjnctn-col"> 
-		<h4 class="text-muted">Header B.1</h4>
+		<h6 class="text-muted">Header B.1</h6>
 		<p>This is content for header B.1</p>
 	</div>
 	<div class="cnjnctn-col">
-		<h4 class="text-muted">Header B.2</h4>
+		<h6 class="text-muted">Header B.2</h6>
 		<p>This is content for header B.2</p>
 	</div>
 </div>
 	</div>
 </div>
+</section>
 <details>
-    <summary>Code</summary>
+    <summary>View code</summary>
     <pre><code>//nested decision point example
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 &lt;div class=&quot;cnjnctn-col-80&quot;&gt;
-&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 &lt;p&gt;This is content for header A&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;cnjnctn-col&quot;&gt;
-&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 &lt;p&gt;This is content for header B&lt;/p&gt;
 &lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 &lt;div class=&quot;cnjnctn-type-and&quot;&gt;
 &lt;div class=&quot;cnjnctn-col&quot;&gt;
-&lt;h4 class=&quot;text-muted&quot;&gt;Header B.1&lt;/h4&gt;
+&lt;h6 class=&quot;text-muted&quot;&gt;Header B.1&lt;/h6&gt;
 &lt;p&gt;This is content for header B.1&lt;/p&gt;
 &lt;/div&gt;
 &lt;div class=&quot;cnjnctn-col&quot;&gt;
-&lt;h4 class=&quot;text-muted&quot;&gt;Header B.2&lt;/h4&gt;
+&lt;h6 class=&quot;text-muted&quot;&gt;Header B.2&lt;/h6&gt;
 &lt;p&gt;This is content for header B.2&lt;/p&gt;
 &lt;/div&gt;
 &lt;/div&gt;
@@ -472,136 +491,156 @@ css:
 <h3>Width of column</h3>
 <p>To accommodate options that might be lopsided in the amount of text but a need to be visually pleasing, the columns can be set to a percentage of itself to allow larger content to wrap less. The default is 100% (<code>cnjnctn-col</code>).</p>
 <p><strong>Note:</strong> The width cannot be adjusted based on different resolutions, best to stack the columns when content becomes difficult to read on smaller devices.</p>
+<section>
 <h4>Column set to 90% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
 	<div class="cnjnctn-col-90">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
         <p>This is content for header A (at 90% of default <code>cnjnctn-col-90</code>)</p>
 	</div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
         <p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 80% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
 	<div class="cnjnctn-col-80">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 80% of default <code>cnjnctn-col-80</code>)</p>
 	</div>
 	<div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 75% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-75">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
         <p>This is content for header A (at 75% of default <code>cnjnctn-col-75</code>)</p>
     </div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 70% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-70">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 70% of default <code>cnjnctn-col-70</code>)</p>
 	</div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 60% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-60">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 60% of default <code>cnjnctn-col-60</code>)</p>
 	</div>
 	<div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 50% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-50">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 50% of default <code>cnjnctn-col-50</code>)</p>
 	</div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 40% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-40">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 40% of default <code>cnjnctn-col-40</code>)</p>
 	</div>
 	<div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 30% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-30">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 30% of default <code>cnjnctn-col-30</code>)</p>
 	</div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 25% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-25">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 25% of default <code>cnjnctn-col-25</code>)</p>
 	</div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
+<section>
 <h4>Column set to 20% of original width (example stacks on medium devices)</h4>
 <div class="cnjnctn-type-or cnjnctn-lg">
     <div class="cnjnctn-col-20">
-		<h4 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h4>
+		<h5 class="text-muted">Header A<span class="wb-inv">: Option 1 of X</span></h5>
 		<p>This is content for header A (at 20% of default <code>cnjnctn-col-20</code>)</p>
 	</div>
     <div class="cnjnctn-col">
-		<h4 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h4>
+		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
 	</div>
 </div>
+</section>
 <details>
     <summary>Code</summary>
-    <pre><code>//90% of default width
+   <pre><code>//90% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-90&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -609,11 +648,11 @@ css:
 //80% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-80&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -621,11 +660,11 @@ css:
 //75% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-75&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -633,11 +672,11 @@ css:
 //70% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-70&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -645,11 +684,11 @@ css:
 //60% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-60&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -657,11 +696,11 @@ css:
 //50% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-50&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -669,11 +708,11 @@ css:
 //40% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-40&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -681,11 +720,11 @@ css:
 //30% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-30&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -693,11 +732,11 @@ css:
 //25% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-25&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;
@@ -705,11 +744,11 @@ css:
 //20% of default width
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col-20&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
-		&lt;h4 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h4&gt;
+		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of X&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 		&lt;p&gt;Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. &lt;/p&gt;
 	&lt;/div&gt;

--- a/méli-mélo/2021-05-conjunction/index.html
+++ b/méli-mélo/2021-05-conjunction/index.html
@@ -8,6 +8,15 @@ css:
 ---
 <p>Providing a more visual seperation between two decision points by a visual cue (or) based on user testing.  Also provide a connecting conjunction to show two parts are connected (and).</p>
 
+<nav>
+	<h2 class="h5">Table of content</h2>
+	<ul>
+		<li>And/Or decision points (Conjunctions)</li>
+		<li><a href="index-fr.html" hreflang="fr"><span lang="en">And/Or decision points (Conjunctions)</span> - Français</a></li>
+		<li><a href="edge-cases.html">Edge cases of And/Or decision points (Conjunctions)</a></li>
+	</ul>
+</nav>
+
 <h2>GCWeb implementation plan</h2>
 <ul>
 	<li>2021-06 - Engage with TBS to show them this design pattern</li>
@@ -33,7 +42,7 @@ css:
         <p>Some options are:</p>
         <ul>
 		<li>Creating the and/or using the list (<code>&lt;ul&gt;</code>) element</li>
-		
+
     <li>Adding option X of X to all headers</li>
     <li>Adding the word &quot;or&quot; as part of the last statement in each column (except the last column)</li>
   </ul>
@@ -144,7 +153,7 @@ css:
 &lt;header class=&quot;panel-heading&quot;&gt;
 &lt;h5 class=&quot;panel-title&quot;&gt;Heading&lt;/h5&gt;
 &lt;/header&gt;
-&lt;div class=&quot;panel-body&quot;&gt;	
+&lt;div class=&quot;panel-body&quot;&gt;
 &lt;ul class=&quot;cnjnctn-type-or brdr-0&quot;&gt;
 	&lt;li class=&quot;cnjnctn-col&quot;&gt;
 		This is content for option A
@@ -201,7 +210,7 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
-</section>	
+</section>
 <section>
         <h3>Always stacked (mobile first, no side-by-side)</h3>
         <div class="cnjnctn-type-or">
@@ -224,7 +233,7 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
-</section>	
+</section>
         <details>
     <summary>
         View code
@@ -253,8 +262,8 @@ css:
 &lt;/div&gt;
 
 //Always stacked "or"
-&lt;div class="cnjnctn-type-or"&gt; 
-	&lt;div class="cnjnctn-col"&gt; 
+&lt;div class="cnjnctn-type-or"&gt;
+	&lt;div class="cnjnctn-col"&gt;
 		&lt;h4 class="text-muted"&gt;Header A&lt;span class="wb-inv"&gt;: Option 1 of 2&lt;/span&gt;&lt;/h4&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
@@ -264,8 +273,8 @@ css:
 	&lt;/div&gt;
 &lt;/div&gt;
 //Always stacked "and"
-&lt;div class="cnjnctn-type-and"&gt; 
-	&lt;div class="cnjnctn-col"&gt; 
+&lt;div class="cnjnctn-type-and"&gt;
+	&lt;div class="cnjnctn-col"&gt;
 		&lt;h4 class="text-muted"&gt;Header A&lt;/h4&gt;
 		&lt;p&gt;This is content for header A &lt;/p&gt;
 	&lt;/div&gt;
@@ -278,7 +287,7 @@ css:
   </details>
         <h3>Responsive design</h3>
         <p><strong>Note:</strong> all designs going forward will use the "or" model to simplify the amount of examples.</p>
-<section>      
+<section>
 <h4>Stacks on extra small devices, phones (&lt;768px)</h4>
         <div class="cnjnctn-type-or cnjnctn-sm">
     <div class="cnjnctn-col">
@@ -316,10 +325,10 @@ css:
             <p>This is content for header B</p>
           </div>
   </div>
-</section>	
+</section>
         <details>
     <summary>View code</summary>
-    <pre><code>//Stacks on extra small devices, phones	
+    <pre><code>//Stacks on extra small devices, phones
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-sm&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
 		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of 2&lt;/span&gt;&lt;/h5&gt;
@@ -329,8 +338,8 @@ css:
 		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of 2&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 	&lt;/div&gt;
-&lt;/div&gt;				
-//Stacks on small devices, tablets	
+&lt;/div&gt;
+//Stacks on small devices, tablets
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-md&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
 		&lt;h5 class=&quot;text-muted&quot;&gt;Header A&lt;span class=&quot;wb-inv&quot;&gt;: Option 1 of 2&lt;/span&gt;&lt;/h5&gt;
@@ -340,7 +349,7 @@ css:
 		&lt;h5 class=&quot;text-muted&quot;&gt;Header B&lt;span class=&quot;wb-inv&quot;&gt;: Option 2 of 2&lt;/span&gt;&lt;/h5&gt;
 		&lt;p&gt;This is content for header B&lt;/p&gt;
 	&lt;/div&gt;
-&lt;/div&gt;				
+&lt;/div&gt;
 //Stacks on medium devices
 &lt;div class=&quot;cnjnctn-type-or cnjnctn-lg&quot;&gt;
 	&lt;div class=&quot;cnjnctn-col&quot;&gt;
@@ -356,7 +365,7 @@ css:
         <p>Use the <strong>always stacked</strong> design to stack across all resolutions.</p>
         <h2>Extended configurations</h2>
         <h3>Column count</h3>
-<section>        
+<section>
 <h4>Three columns (example stacks on small devices)</h4>
         <div class="cnjnctn-type-or cnjnctn-md">
     <div class="cnjnctn-col">
@@ -446,8 +455,8 @@ css:
 		<h5 class="text-muted">Header B<span class="wb-inv">: Option 2 of X</span></h5>
 		<p>This is content for header B</p>
 		<p>Nam fermentum cursus sodales. Mauris leo leo, congue et fringilla in, egestas eu sapien. </p>
-    <div class="cnjnctn-type-and"> 
-	<div class="cnjnctn-col"> 
+    <div class="cnjnctn-type-and">
+	<div class="cnjnctn-col">
 		<h6 class="text-muted">Header B.1</h6>
 		<p>This is content for header B.1</p>
 	</div>


### PR DESCRIPTION
Added option to remove border to always stacked patterns when already contained in a visible design constraint (e.g. panel or zebra striping) to minimize the design and remove the redundant double border.  Also removed margin-left: 5px from stacked design to allow custom use of margin.