### PR TITLE
Grunt: Adding capability to generate demo files

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -49,6 +49,17 @@ module.exports = (grunt) ->
 	)
 
 	@registerTask(
+		"demo"
+		"Build a demo ready version of the site"
+		[
+			"jekyll-theme"
+			"jekyll-theme-runDemo"
+			"core-dist-DEBUG"
+			"site-contents"
+		]
+	)
+
+	@registerTask(
 		"méli-mélo"
 		"Build méli-mélo files and run it in-place"
 		[
@@ -59,7 +70,6 @@ module.exports = (grunt) ->
 			"copy:méliméloGelé"
 		]
 	)
-
 
 	@registerTask(
 		"site-contents"
@@ -72,7 +82,6 @@ module.exports = (grunt) ->
 			"copy:wetboew_demos"
 		]
 	)
-
 
 	@registerTask(
 		"méli-mélo-remote"
@@ -116,12 +125,22 @@ module.exports = (grunt) ->
 			"copy:samples"
 		]
 	)
+
 	@registerTask(
 		"jekyll-theme-runLocal"
 		"DEBUG - Jekyll theme but with the run local variant"
 		[
 			"usebanner:jekyllRunLocal"
 			"copy:jekyllRunLocal"
+		]
+	)
+
+	@registerTask(
+		"jekyll-theme-runDemo"
+		"DEBUG - Jekyll theme but with the run demo variant"
+		[
+			"usebanner:jekyllRunDemo"
+			"copy:jekyllRunDemo"
 		]
 	)
 
@@ -135,6 +154,7 @@ module.exports = (grunt) ->
 			"usebanner:jekyllRunUnminified"
 		]
 	)
+
 	@registerTask(
 		"core-dist-PROD"
 		"Compile core GCWeb files"
@@ -163,6 +183,7 @@ module.exports = (grunt) ->
 			"copy:depsJS_custom"
 		]
 	)
+
 	@registerTask(
 		"core-dist-POST"
 		"Post task to complete the compilation of core GCWeb files"
@@ -172,7 +193,6 @@ module.exports = (grunt) ->
 			"clean:depsJS"
 		]
 	)
-
 
 	@registerTask(
 		"deploy-packagejson"
@@ -198,7 +218,6 @@ module.exports = (grunt) ->
 			};
 			grunt.file.write(writeTo, JSON.stringify(pkg, null, 2));
 	)
-
 
 	@registerTask(
 		"linting"
@@ -472,6 +491,7 @@ module.exports = (grunt) ->
 					"<%= méliméloFolder %>/<%= curMéliPack %>/workdir/**/*.css"
 				]
 				dest: "<%= méliméloFolder %>/<%= curMéliPack %>/<%= curMéliPack %>.css"
+
 		usebanner:
 			css:
 				options:
@@ -494,6 +514,11 @@ module.exports = (grunt) ->
 			jekyllRunLocal:
 				options:
 					banner: """{%- assign setting-resourcesBasePathTheme = "/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/<%= distFolder %>/wet-boew" -%}"""
+					position: "bottom"
+				src: "<%= jekyllDist %>/_includes/settings.liquid"
+			jekyllRunDemo:
+				options:
+					banner: """{%- assign setting-resourcesBasePathTheme = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/wet-boew" -%}"""
 					position: "bottom"
 				src: "<%= jekyllDist %>/_includes/settings.liquid"
 			jekyllRunUnminified:
@@ -597,6 +622,13 @@ module.exports = (grunt) ->
 				rename: (dest, src) ->
 					dest + "/" + src.replace( 'samples/', '' )
 			jekyllRunLocal:
+				src: [
+					"_includes/**.*",
+					"_includes/**/*.*",
+					"_layouts/**.*"
+				]
+				dest: "<%= jekyllDist %>/"
+			jekyllRunDemo:
 				src: [
 					"_includes/**.*",
 					"_includes/**/*.*",
@@ -734,6 +766,7 @@ module.exports = (grunt) ->
 #					console.log( src )
 #					console.log( dest )
 #					return dest
+
 		postcss:
 			options:
 				processors: [
@@ -747,6 +780,7 @@ module.exports = (grunt) ->
 				]
 				dest: "<%= themeDist %>/css"
 				expand: true
+
 		cssmin:
 			theme:
 				expand: true

--- a/docs/developing-en.md
+++ b/docs/developing-en.md
@@ -107,6 +107,12 @@ HTML lint
 grunt htmllint:all
 ```
 
+## Build demo files
+
+Run the following command to generate files for a demo on https://github.com/ServiceCanada/wet-boew-demos where `[branchName]` refers to the branch name where your demo is hosted.
+
+`grunt demo --branch=[branchName]`
+
 ## Refresh your github pages with the latest theme changes
 
 You can make a commit to your site and it will get regenerated with the latest version of the jekyll theme. Alternatively, the following curl command will told github to regenerate your site.

--- a/docs/developing-fr.md
+++ b/docs/developing-fr.md
@@ -109,6 +109,12 @@ HTML lint
 grunt htmllint:all
 ```
 
+## Build demo files
+
+Run the following command to generate files for a demo on https://github.com/ServiceCanada/wet-boew-demos where `[branchName]` refers to the branch name where your demo is hosted.
+
+`grunt demo --branch=[branchName]`
+
 ## Refresh your github pages with the latest theme changes
 
 You can make a commit to your site and it will get regenerated with the latest version of the jekyll theme. Alternatively, the following curl command will told github to regenerate your site.


### PR DESCRIPTION
Running `grunt demo --branch=[branchName]` will generate dist files url's that work on the demo repository (https://github.com/ServiceCanada/wet-boew-demos/)

Also fixed some inconsistencies with new lines.

Changes related to WET-298