### PR TITLE
Fieldflow: Support empty values in query actions

### DIFF
--- a/components/wb-fieldflow/alternative-en.html
+++ b/components/wb-fieldflow/alternative-en.html
@@ -183,3 +183,151 @@ dateModified: "2021-04-28"
 		&lt;/ul&gt;
 	&lt;/div&gt;</code></pre>
 </section>
+
+<section>
+	<h2><code>query</code> action, use of empty value</h2>
+	<h3>For individual <code>query</code> action</h2>
+	<div class="wb-frmvld">
+		<form action="alternative-en.html" method="get">
+			<div class="wb-fieldflow hidden" data-wb-fieldflow='{
+				"noForm": true,
+				"defaultselectedlabel": false
+			}'>
+				<p>Pick an option</p>
+				<ul>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q1", "value": "" }
+					]'>Custom: Make your selection...</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q1", "value": "opt1" }
+					]'>Option 1</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q1", "value": "opt2" }
+					]'>Option 2</li>
+				</ul>
+			</div>
+			<button>Submit</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;alternative-en.html&quot; method=&quot;get&quot;&gt;
+		&lt;div class=&quot;wb-fieldflow hidden&quot; data-wb-fieldflow='{
+			&quot;noForm&quot;: true,
+			&quot;defaultselectedlabel&quot;: false
+		}'&gt;
+			&lt;p&gt;Pick an option&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q1&quot;, &quot;value&quot;: &quot;&quot; }
+				]'&gt;Custom: Make your selection...&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q1&quot;, &quot;value&quot;: &quot;opt1&quot; }
+				]'&gt;Option 1&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q1&quot;, &quot;value&quot;: &quot;opt2&quot; }
+				]'&gt;Option 2&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;button&gt;Submit&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
+	<h3>When the new default global action is <code>query</code></h3>
+	<div class="wb-frmvld">
+		<form action="alternative-en.html" method="get">
+			<div class="wb-fieldflow hidden" data-wb-fieldflow='{
+				"noForm": true,
+				"defaultselectedlabel": false,
+				"action": "query", "name": "q2", "prop": "value"
+			}'>
+				<p>Pick an option</p>
+				<ul>
+					<li data-wb-fieldflow=''>Custom: Make your selection...</li>
+					<li data-wb-fieldflow='opt1'>Option 1</li>
+					<li data-wb-fieldflow='opt2'>Option 2</li>
+				</ul>
+			</div>
+			<button>Submit</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;alternative-en.html&quot; method=&quot;get&quot;&gt;
+		&lt;div class=&quot;wb-fieldflow hidden&quot; data-wb-fieldflow='{
+			&quot;noForm&quot;: true,
+			&quot;defaultselectedlabel&quot;: false,
+			&quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q2&quot;, &quot;prop&quot;: &quot;value&quot;
+		}'&gt;
+			&lt;p&gt;Pick an option&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow=''&gt;Custom: Make your selection...&lt;/li&gt;
+				&lt;li data-wb-fieldflow='opt1'&gt;Option 1&lt;/li&gt;
+				&lt;li data-wb-fieldflow='opt2'&gt;Option 2&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;button&gt;Submit&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
+	<h3>With multiple actions</h3>
+	<p>It can ease the code readability compare of defining it through the "default" configuration applied on the component instance.</p>
+	<div class="alert alert-warning"><p><strong>The example bellow are only to test the functional aspect of that feature and might produce experience/code that are not fully conform to WCAG Level AA.</strong></p></div>
+	<div class="wb-frmvld">
+		<form action="http://localhost/" method="post">
+			<div class="wb-fieldflow hidden" data-wb-fieldflow='{
+				"noForm": true,
+				"defaultselectedlabel": false
+			}'>
+				<p>Pick an option</p>
+				<ul>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q3", "value": "" },
+						{ "action": "addClass", "source": ".redgreen", "class": "text-danger", "live": true },
+						{ "action": "removeClass", "source": ".redgreen", "class": "text-success", "live": true }
+					]'>Custom: Make your selection...</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q3", "value": "opt1" },
+						{ "action": "addClass", "source": ".redgreen", "class": "text-success", "live": true },
+						{ "action": "removeClass", "source": ".redgreen", "class": "text-danger", "live": true }
+					]'>Option 1</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q3", "value": "opt2" },
+						{ "action": "addClass", "source": ".redgreen", "class": "text-success", "live": true },
+						{ "action": "removeClass", "source": ".redgreen", "class": "text-danger", "live": true }
+					]'>Option 2</li>
+				</ul>
+			</div>
+			<p class="redgreen">Red when default option is selected <strong>or</strong> green if a real option selected.</p>
+			<button>Submit</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;http://localhost/&quot; method=&quot;post&quot;&gt;
+		&lt;div class=&quot;wb-fieldflow hidden&quot; data-wb-fieldflow='{
+			&quot;noForm&quot;: true,
+			&quot;defaultselectedlabel&quot;: false
+		}'&gt;
+			&lt;p&gt;Pick an option&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q3&quot;, &quot;value&quot;: &quot;&quot; },
+					{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-danger&quot;, &quot;live&quot;: true },
+					{ &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-success&quot;, &quot;live&quot;: true }
+				]'&gt;Custom: Make your selection...&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q3&quot;, &quot;value&quot;: &quot;opt1&quot; },
+					{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-success&quot;, &quot;live&quot;: true },
+					{ &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-danger&quot;, &quot;live&quot;: true }
+				]'&gt;Option 1&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q3&quot;, &quot;value&quot;: &quot;opt2&quot; },
+					{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-success&quot;, &quot;live&quot;: true },
+					{ &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-danger&quot;, &quot;live&quot;: true }
+				]'&gt;Option 2&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;p class=&quot;redgreen&quot;&gt;Red when default option is selected &lt;strong&gt;or&lt;/strong&gt; green if a real option selected.&lt;/p&gt;
+		&lt;button&gt;Submit&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
+</section>

--- a/components/wb-fieldflow/alternative-fr.html
+++ b/components/wb-fieldflow/alternative-fr.html
@@ -184,3 +184,150 @@ dateModified: "2021-04-28"
 		&lt;/ul&gt;
 	&lt;/div&gt;</code></pre>
 </section>
+
+<section>
+	<h2>Action <code>query</code> (requête) Utilisation d'une valeur vide</h2>
+	<h3>Pour des actions <code>query</code> (requête) individuelles</h2>
+	<div class="wb-frmvld">
+		<form action="alternative-en.html" method="get">
+			<div class="wb-fieldflow hidden" data-wb-fieldflow='{
+				"noForm": true,
+				"defaultselectedlabel": false
+			}'>
+				<p>Choisir une option</p>
+				<ul>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q1", "value": "" }
+					]'>Personalisé: Faites votre sélection...</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q1", "value": "opt1" }
+					]'>Option 1</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q1", "value": "opt2" }
+					]'>Option 2</li>
+				</ul>
+			</div>
+			<button>Soumettre</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;alternative-en.html&quot; method=&quot;get&quot;&gt;
+		&lt;div class=&quot;wb-fieldflow hidden&quot; data-wb-fieldflow='{
+			&quot;noForm&quot;: true,
+			&quot;defaultselectedlabel&quot;: false
+		}'&gt;
+			&lt;p&gt;Choisir une option&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q1&quot;, &quot;value&quot;: &quot;&quot; }
+				]'&gt;Personalisé: Faites votre sélection...&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q1&quot;, &quot;value&quot;: &quot;opt1&quot; }
+				]'&gt;Option 1&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q1&quot;, &quot;value&quot;: &quot;opt2&quot; }
+				]'&gt;Option 2&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;button&gt;Soumettre&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
+	<h3>Lorsque le nouveau défaut de l'action globale est <code>query</code> (requête)</h3>
+	<div class="wb-frmvld">
+		<form action="alternative-en.html" method="get">
+			<div class="wb-fieldflow hidden" data-wb-fieldflow='{
+				"noForm": true,
+				"defaultselectedlabel": false,
+				"action": "query", "name": "q2", "prop": "value"
+			}'>
+				<p>Choisir une option</p>
+				<ul>
+					<li data-wb-fieldflow=''>Personalisé: Faites votre sélection...</li>
+					<li data-wb-fieldflow='opt1'>Option 1</li>
+					<li data-wb-fieldflow='opt2'>Option 2</li>
+				</ul>
+			</div>
+			<button>Soumettre</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;alternative-en.html&quot; method=&quot;get&quot;&gt;
+		&lt;div class=&quot;wb-fieldflow hidden&quot; data-wb-fieldflow='{
+			&quot;noForm&quot;: true,
+			&quot;defaultselectedlabel&quot;: false,
+			&quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q2&quot;, &quot;prop&quot;: &quot;value&quot;
+		}'&gt;
+			&lt;p&gt;Choisir une option&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow=''&gt;Personalisé: Faites votre sélection...&lt;/li&gt;
+				&lt;li data-wb-fieldflow='opt1'&gt;Option 1&lt;/li&gt;
+				&lt;li data-wb-fieldflow='opt2'&gt;Option 2&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;button&gt;Soumettre&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
+	<h3>Avec plusieurs actions</h3>
+	<p>Cette notation peut améliorer la lisibilité du code comparativement à l'utilisation du paramètre "default" appartenant à l'instance du composant..</p>
+	<div class="alert alert-warning"><p><strong>L'example suivant est seulement utile afin de vérifier le bon opérabilité de la fonctionalité et il pourrait produire une expérience et du code qui n'est pas entièrement conforme à WCAG niveau AA.</strong></p></div>
+	<div class="wb-frmvld">
+		<form action="http://localhost/" method="post">
+			<div class="wb-fieldflow hidden" data-wb-fieldflow='{
+				"noForm": true,
+				"defaultselectedlabel": false
+			}'>
+				<p>Choisir une option</p>
+				<ul>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q3", "value": "" },
+						{ "action": "addClass", "source": ".redgreen", "class": "text-danger", "live": true },
+						{ "action": "removeClass", "source": ".redgreen", "class": "text-success", "live": true }
+					]'>Personalisé: Faites votre sélection....</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q3", "value": "opt1" },
+						{ "action": "addClass", "source": ".redgreen", "class": "text-success", "live": true },
+						{ "action": "removeClass", "source": ".redgreen", "class": "text-danger", "live": true }
+					]'>Option 1</li>
+					<li data-wb-fieldflow='[
+						{ "action": "query", "name": "q3", "value": "opt2" },
+						{ "action": "addClass", "source": ".redgreen", "class": "text-success", "live": true },
+						{ "action": "removeClass", "source": ".redgreen", "class": "text-danger", "live": true }
+					]'>Option 2</li>
+				</ul>
+			</div>
+			<p class="redgreen">Rouge lorsque l'option par défaut est sélectionné <strong>ou</strong> vert lorsque qu'une option valide est sélectionné.</p>
+			<button>Soumettre</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;http://localhost/&quot; method=&quot;post&quot;&gt;
+		&lt;div class=&quot;wb-fieldflow hidden&quot; data-wb-fieldflow='{
+			&quot;noForm&quot;: true,
+			&quot;defaultselectedlabel&quot;: false
+		}'&gt;
+			&lt;p&gt;Choisir une option&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q3&quot;, &quot;value&quot;: &quot;&quot; },
+					{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-danger&quot;, &quot;live&quot;: true },
+					{ &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-success&quot;, &quot;live&quot;: true }
+				]'&gt;Personalisé: Faites votre sélection....&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q3&quot;, &quot;value&quot;: &quot;opt1&quot; },
+					{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-success&quot;, &quot;live&quot;: true },
+					{ &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-danger&quot;, &quot;live&quot;: true }
+				]'&gt;Option 1&lt;/li&gt;
+				&lt;li data-wb-fieldflow='[
+					{ &quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;q3&quot;, &quot;value&quot;: &quot;opt2&quot; },
+					{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-success&quot;, &quot;live&quot;: true },
+					{ &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;: &quot;.redgreen&quot;, &quot;class&quot;: &quot;text-danger&quot;, &quot;live&quot;: true }
+				]'&gt;Option 2&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;p class=&quot;redgreen&quot;&gt;Rouge lorsque l'option par défaut est sélectionné &lt;strong&gt;ou&lt;/strong&gt; vert lorsque qu'une option valide est sélectionné.&lt;/p&gt;
+		&lt;button&gt;Soumettre&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+</section>

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -229,7 +229,7 @@ var componentName = "wb-fieldflow",
 		if ( fieldName ) {
 			data.provEvt.setAttribute( "name", fieldName );
 		}
-		if ( fieldValue ) {
+		if ( typeof fieldValue === "string" ) {
 			$selectElm.val( fieldValue );
 		}
 
@@ -1031,7 +1031,7 @@ $document.on( "change", selectorForm + " " + crtlSelectSelector, function( event
 				// Retreive action set on the binded element
 				bindToElm = document.getElementById( bindTo );
 				actionAttr = bindToElm.getAttribute( "data-" + componentName );
-				if ( actionAttr ) {
+				if ( typeof actionAttr === "string" ) {
 					if ( actionAttr.startsWith( "{" ) || actionAttr.startsWith( "[" ) ) {
 						try {
 							cacheAction = JSON.parse( actionAttr );


### PR DESCRIPTION
Providing a ``value`` in the ``query`` action causes fieldflow to set it as the ``select`` option's value when that action runs. But it previously wasn't working for empty values.

This fixes it by changing a couple of truthy ``if`` conditions into ``typeof`` string checks.