### PR TITLE
DoAction: Ability to search on the whole table

### DIFF
--- a/components/wb-actionmng/actionmng.js
+++ b/components/wb-actionmng/actionmng.js
@@ -183,9 +183,15 @@ var $document = wb.doc,
 		if ( $source.get( 0 ).nodeName !== "TABLE" ) {
 			throw "Table filtering can only applied on table";
 		}
+
 		$datatable = $source.dataTable( { "retrieve": true } ).api();
-		column = ( colInt === true ) ? colInt : column;
-		$datatable.column( column ).search( data.value, regex, smart, caseinsen ).draw();
+
+		if ( column ) {
+			column = ( colInt === true ) ? colInt : column;
+			$datatable.column( column ).search( data.value, regex, smart, caseinsen ).draw();
+		} else {
+			$datatable.search( data.value, regex, smart, caseinsen ).draw();
+		}
 	},
 	geomapAOIAct = function( event, data ) {
 		var $source = $( data.source || event.target ),

--- a/components/wb-doaction/doaction-doc-en.html
+++ b/components/wb-doaction/doaction-doc-en.html
@@ -459,7 +459,7 @@
 </tr>
 <tr>
 <td>column</td>
-<td><p>Required for table filtering, this is specify on which column the filter should be applied</p>
+<td><p>Optional for table filtering, this specifies on which column the filter should be applied. If not defined, the filter will be applied on the whole table and the term will appear in the search field.</p>
 <p>Available for:</p>
 <ul>
 <li>tblfilter</li>

--- a/components/wb-doaction/doaction-doc-fr.html
+++ b/components/wb-doaction/doaction-doc-fr.html
@@ -467,7 +467,7 @@
 	</tr>
 	<tr>
 		<td>column</td>
-		<td><p>Required for table filtering, this is specify on which column the filter should be applied</p>
+		<td><p>Optional for table filtering, this specifies on which column the filter should be applied. If not defined, the filter will be applied on the whole table and the term will appear in the search field.</p>
 			<p>Available for:</p>
 			<ul>
 				<li>tblfilter</li>

--- a/components/wb-doaction/tblfilter-en.html
+++ b/components/wb-doaction/tblfilter-en.html
@@ -53,6 +53,10 @@
 
 <button type="button" class="btn btn-default" data-wb-doaction='{ "action": "tocsv", "source": "#dataset-filter" }'>Download the following table as CSV</button>
 
+<button type="button" class="btn btn-default" data-wb-doaction='{ "action": "tblfilter", "source": "#dataset-filter", "value": "quality" }'>Global search in table for "quality"</button>
+
+<button type="button" class="btn btn-link" data-wb-doaction='{ "action": "tblfilter", "source": "#dataset-filter", "value": "" }'>Clear global table search</button>
+
 <table class="wb-tables table table-striped table-hover" id="dataset-filter"
 		aria-live="polite"
 		data-wb-tables='{

--- a/components/wb-doaction/tblfilter-fr.html
+++ b/components/wb-doaction/tblfilter-fr.html
@@ -52,6 +52,11 @@
 
 <button type="button" class="btn btn-default" data-wb-doaction='{ "action": "tocsv", "source": "#dataset-filter" }'>Télécharger le tableau suivant en format CSV</button>
 
+
+<button type="button" class="btn btn-default" data-wb-doaction='{ "action": "tblfilter", "source": "#dataset-filter", "value": "quality" }'>Rechercher globalement dans le tableau pour "<span lang="en">quality</span>"</button>
+
+<button type="button" class="btn btn-link" data-wb-doaction='{ "action": "tblfilter", "source": "#dataset-filter", "value": "" }'>Effacer la recherche globale du tableau</button>
+
 <p>Le contenu du tableau suivant est disponible en anglais seulement.</p>
 
 <table lang="en" class="wb-tables table table-striped table-hover" id="dataset-filter"


### PR DESCRIPTION
Adding the ability to filter on whole table when the column property is not defined. If a column if not defined, the value will be added to the datatables search box (default datatables behaviour).

Changes related to WET-297