### PR TITLE
Footer: customizable transparency links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,12 @@ global:
           text: "Other documentation"
         - url: "https://wet-boew.github.io/GCWeb/index-en.html#implementing-developing"
           text: "Implementing&nbsp;/ Developing"
+  termsUrl:
+    en: "https://www.canada.ca/en/transparency/terms.html"
+    fr: "https://www.canada.ca/fr/transparence/avis.html"
+  privacyUrl:
+    en: "https://www.canada.ca/en/transparency/privacy.html"
+    fr: "https://www.canada.ca/fr/transparence/confidentialite.html"
 
 #
 # Override include to use

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -320,6 +320,16 @@
 				"title": "Masquer les bandes contextuelle et principale ainsi que les liens optionnels de la bande sous le pied de page du pied de page",
 				"language": "fr",
 				"path": "no-footers-fr.html"
+			},
+			{
+				"title": "Customize 'Terms and conditions' and 'Privacy' links in footer",
+				"language": "en",
+				"path": "custom-transparency-links-en.html"
+			},
+			{
+				"title": "Personnaliser les liens 'Avis' et 'Confidentialité' dans le pied de page",
+				"language": "fr",
+				"path": "custom-transparency-links-fr.html"
 			}
 		]
 	}

--- a/sites/footers/custom-transparency-links-en.html
+++ b/sites/footers/custom-transparency-links-en.html
@@ -1,0 +1,40 @@
+---
+{
+	"title": "Customize 'Terms and conditions' and 'Privacy' links in footer",
+	"language": "en",
+	"breadcrumbs": [
+		{ "title": "Footer", "link": "sites/footers/footers-en.html" }
+	],
+	"altLangPage": "custom-transparency-links-fr.html",
+	"secondlevel": false,
+	"dateModified": "2022-12-12",
+	"share": "true",
+	"contextualFooter": {
+		"title": "[Contextual footer header]",
+		"links": [
+			{ "url": "http://canada.ca/en", "text": "Contextual link 1"},
+			{ "url": "http://canada.ca/en", "text": "Contextual link 2"},
+			{ "url": "http://canada.ca/en", "text": "Contextual link 3"}
+		]
+	},
+	"termsUrl": "http://canada.ca/en",
+	"privacyUrl": "http://canada.ca/en",
+	"includes": { "footer": "edge" }
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+{% include alert-softlaunch.html component="site footer" version="4" %}
+
+<p>By setting the <code>termsUrl</code> and/or <code>privacyUrl</code> variable to a specific URL, their respective link's URL will be updated.</p>
+<p>GCWeb Jekyll specific:</p>
+<ul>
+	<li>If the <code>termsUrl</code> variable is not defined in the front-matter of the page, the link's URL defined in <code>_config.yml</code> will be used instead. If it is neither defined in the front-matter nor in <code>_config.yml</code>, the URL will default to: "https://www.canada.ca/en/transparency/terms.html".</li>
+	<li>If the <code>privacyUrl</code> variable is not defined in the front-matter of the page, the link's URL defined in <code>_config.yml</code> will be used instead. If it is neither defined in the front-matter nor in <code>_config.yml</code>, the URL will default to: "https://www.canada.ca/en/transparency/privacy.html".</li>
+</ul>
+
+<h2>Expected output code</h2>
+{%- include variable-core.liquid -%}
+{% highlight html %}
+	{%- include footers/footer.html -%}
+{% endhighlight %}

--- a/sites/footers/custom-transparency-links-fr.html
+++ b/sites/footers/custom-transparency-links-fr.html
@@ -1,0 +1,40 @@
+---
+{
+	"title": "Personnaliser les liens 'Avis' et 'Confidentialité' dans le pied de page",
+	"language":	"fr",
+	"breadcrumbs": [
+		{ "title": "Pied de page", "link": "sites/footers/footers-fr.html" }
+	],
+	"altLangPage": "custom-transparency-links-en.html",
+	"secondlevel": false,
+	"dateModified": "2022-12-12",
+	"share": "true",
+	"contextualFooter": {
+		"title": "[Bande du pied de page contextuel]",
+		"links": [
+			{ "url": "http://canada.ca/fr", "text": "Lien contextuel 1"},
+			{ "url": "http://canada.ca/fr", "text": "Lien contextuel 2"},
+			{ "url": "http://canada.ca/fr", "text": "Lien contextuel 3"}
+		]
+	},
+	"termsUrl": "http://canada.ca/fr",
+	"privacyUrl": "http://canada.ca/fr",
+	"includes": { "footer": "edge" }
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+{% include alert-softlaunch.html component="pied de page" version="4" %}
+
+<p>En définissant la variable <code>termsUrl</code> et/ou <code>privacyUrl</code> avec une URL spécifique, l'URL de leur lien respectif sera mise à jour.</p>
+<p>Spécifique à GCWeb Jekyll&nbsp;:</p>
+<ul>
+	<li>Si la variable <code>termsUrl</code> n'est pas définie dans le front-matter de la page, l'URL du lien défini dans <code>_config.yml</code> sera utilisée à la place. Si elle n'est défini ni dans le front-matter ni dans <code>_config.yml</code>, l'URL par défaut sera&nbsp;: "https://www.canada.ca/fr/transparence/avis.html".</li>
+	<li>Si la variable <code>privacyUrl</code> n'est pas définie dans le front-matter de la page, l'URL du lien défini dans <code>_config.yml</code> sera utilisée à la place. Si elle n'est défini ni dans le front-matter ni dans <code>_config.yml</code>, l'URL par défaut sera&nbsp;: "https://www.canada.ca/fr/transparence/confidentialite.html".</li>
+</ul>
+
+<h2>Code de final attendu</h2>
+{%- include variable-core.liquid -%}
+{% highlight html %}
+	{%- include footers/footer.html -%}
+{% endhighlight %}

--- a/sites/footers/includes/footer.html
+++ b/sites/footers/includes/footer.html
@@ -14,6 +14,26 @@
 	{%- endif -%}
 {%- endcapture -%}
 
+{%- capture termsUrl -%}
+	{%- if page.termsUrl -%}
+		{{ page.termsUrl }}
+	{%- elsif site.global.termsUrl[i18nText-lang] -%}
+		{{ site.global.termsUrl[i18nText-lang] }}
+	{%- else -%}
+		{{ i18nText-termsUrl }}
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture privacyUrl -%}
+	{%- if page.privacyUrl -%}
+		{{ page.privacyUrl }}
+	{%- elsif site.global.privacyUrl[i18nText-lang] -%}
+		{{ site.global.privacyUrl[i18nText-lang] }}
+	{%- else -%}
+		{{ i18nText-privacyUrl }}
+	{%- endif -%}
+{%- endcapture -%}
+
 {%- comment -%} Footer version control, allow to use multiple version of an include to ease migration {%- endcomment -%}
 {%- if footerIncludeVersion == "v2" -%}
 
@@ -131,11 +151,11 @@
 					{%- endif -%}
 					{% endunless %}
 					{%- if i18nText-lang == "fr" -%}
-					<li><a href="https://www.canada.ca/fr/transparence/avis.html">Avis</a></li>
-					<li><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Confidentialité</a></li>
+					<li><a href="{{termsUrl}}">Avis</a></li>
+					<li><a href="{{privacyUrl}}">Confidentialité</a></li>
 					{%- elsif i18nText-lang == "en" -%}
-					<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
-					<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
+					<li><a href="{{termsUrl}}">Terms and conditions</a></li>
+					<li><a href="{{privacyUrl}}">Privacy</a></li>
 					{%- endif -%}
 				</ul>
 			</nav>

--- a/sites/footers/index.json-ld
+++ b/sites/footers/index.json-ld
@@ -110,6 +110,16 @@
 				"title": "Masquer les bandes contextuelle et principale ainsi que les liens optionnels de la bande sous le pied de page du pied de page",
 				"language": "fr",
 				"path": "no-footers-fr.html"
+			},
+			{
+				"title": "Customize 'Terms and conditions' and 'Privacy' links in footer",
+				"language": "en",
+				"path": "custom-transparency-links-en.html"
+			},
+			{
+				"title": "Personnaliser les liens 'Avis' et 'Confidentialité' dans le pied de page",
+				"language": "fr",
+				"path": "custom-transparency-links-fr.html"
 			}
 		]
 	}

--- a/sites/includes/i18n.liquid
+++ b/sites/includes/i18n.liquid
@@ -37,6 +37,9 @@
 	{% assign i18nText-gocCorporate = "Organisation du gouvernement du Canada" %}
 	{% assign i18nText-transparency = "Transparence" %}
 
+	{% assign i18nText-termsUrl = "https://www.canada.ca/fr/transparence/avis.html" %}
+	{% assign i18nText-privacyUrl = "https://www.canada.ca/fr/transparence/confidentialite.html" %}
+
 {%- elsif i18nText-lang == "en" -%}
 
 	{% assign i18nText-homePage = "https://www.canada.ca/en.html" %}
@@ -63,5 +66,8 @@
 	{% assign i18nText-themeLinks = "Themes and topics" %}
 	{% assign i18nText-gocCorporate = "Government of Canada Corporate" %}
 	{% assign i18nText-transparency = "Transparency" %}
+
+	{% assign i18nText-termsUrl = "https://www.canada.ca/en/transparency/terms.html" %}
+	{% assign i18nText-privacyUrl = "https://www.canada.ca/en/transparency/privacy.html" %}
 
 {%- endif -%}


### PR DESCRIPTION
Transparency links in sub-footer band can now be customized either globally or on a per-page basis. If the links are neither defined on the page or globally, they will default to the Canada.ca transparency URLs.