### PR TITLE
Build warnings: WET demos alerts, syntax errors

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -709,6 +709,10 @@ module.exports = (grunt) ->
 				dest: "_wetboew-demos"
 				rename: (dest, src) ->
 					return dest + "/" + src.replace( 'node_modules/wet-boew/src/plugins/', '' ).replace( ".hbs", ".html" )
+				options: {
+					process: (content, srcpath) ->
+						return content.replace(/{{>alertariahidden}}/g, "")
+				}
 
 			# méli-mélo tasks
 			mélimélo:

--- a/index-en.md
+++ b/index-en.md
@@ -19,7 +19,7 @@ css:
 		</div>
 		<div class="col-xs-12 col-md-auto pull-right">
 			<p><a href="https://github.com/wet-boew/GCWeb/archive/v12.6.0.zip" class="btn btn-primary">Download GCWeb theme <strong>v12.6.0</strong></a><br />
-				<small>(<time>{{ page.dateModified | %F }}</time> - <a href="https://github.com/wet-boew/gcweb/releases/latest">Release notes</a>)</small></p>
+				<small>(<time>{{ page.dateModified | date: %F }}</time> - <a href="https://github.com/wet-boew/gcweb/releases/latest">Release notes</a>)</small></p>
 		</div>
 	</div>
 </div>

--- a/index-fr.md
+++ b/index-fr.md
@@ -19,7 +19,7 @@ css:
 		</div>
 		<div class="col-xs-12 col-md-auto pull-right">
 			<p><a href="https://github.com/wet-boew/GCWeb/archive/v12.6.0.zip" class="btn btn-primary">Télécharger le thème <strong>GCWeb v12.6.0</strong></a><br />
-				<small>(<time>{{ page.dateModified | %F }}</time> - <a href="https://github.com/wet-boew/gcweb/releases/latest">Note de version</a>)</small></p>
+				<small>(<time>{{ page.dateModified | date: %F }}</time> - <a href="https://github.com/wet-boew/gcweb/releases/latest">Note de version</a>)</small></p>
 		</div>
 	</div>
 </div>

--- a/sites/gcweb-menu/ajax/sitemenu-v5-en.hbs
+++ b/sites/gcweb-menu/ajax/sitemenu-v5-en.hbs
@@ -4,7 +4,7 @@ language: "en"
 }
 ---
 
-{{!-- This menu items are kept for a template purpose only --}}
+<!-- These menu items are kept for template purposes only -->
 <li role="presentation">
 	<a role="menuitem" tabindex="-1" aria-haspopup="true" aria-controls="gc-mnu-jobs" aria-expanded="false" href="#">Jobs and the workplace</a>
 	<ul id="gc-mnu-jobs" role="menu" aria-orientation="vertical">

--- a/sites/gcweb-menu/ajax/sitemenu-v5-fr.hbs
+++ b/sites/gcweb-menu/ajax/sitemenu-v5-fr.hbs
@@ -4,7 +4,7 @@
 }
 ---
 
-{{!-- This menu items are kept for a template purpose only --}}
+<!-- These menu items are kept for template purposes only -->
 <li role="presentation">
 	<a role="menuitem" tabindex="-1" aria-haspopup="true" aria-controls="gc-mnu-jobs" aria-expanded="false" href="#">Emplois et milieu de travail</a>
 	<ul id="gc-mnu-jobs" role="menu" aria-orientation="vertical">

--- a/templates/institutional/institution-arms-en.html
+++ b/templates/institutional/institution-arms-en.html
@@ -17,7 +17,7 @@
 <h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-5 col-xs-12 pull-right gc-rms-lngth">
-		<img class="img-responsive" alt="{{{i18n "arms-image-alt"}}}" src="img/arms-en.png" />
+		<img class="img-responsive" alt="Department name" src="img/arms-en.png" />
 	</div>
 	<div class="col-sm-7 pull-left">
 		<p class="gc-byline">We are a federal institution that operates at arm’s length from the Government of Canada.</p>

--- a/templates/institutional/institution-arms-fr.html
+++ b/templates/institutional/institution-arms-fr.html
@@ -17,7 +17,7 @@
 <h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-5 col-xs-12 pull-right gc-rms-lngth">
-		<img class="img-responsive" alt="{{{i18n "arms-image-alt"}}}" src="img/arms-fr.png" />
+		<img class="img-responsive" alt="Nom du département" src="img/arms-fr.png" />
 	</div>
 	<div class="col-sm-7 pull-left">
 		<p class="gc-byline">Nous sommes un organisme qui agissons indépendamment du gouvernement du Canada.</p>


### PR DESCRIPTION
Resolving build warnings part 2:
- Removing aria-hidden instruction for WET-BOEW demos on GCWeb (visible for form-valid and post-feedback)
- Converting hbs comment to HTML comment
- Removing reference to string which was unnecessary in institution-arms