### PR TITLE
Build warnings: includes, byline and more

### DIFF
--- a/components/byline/includes/byline.html
+++ b/components/byline/includes/byline.html
@@ -1,7 +1,7 @@
 <p><strong>
-{%- if i18nText-lang == "fr" -%}
+{%- if page.language == "fr" -%}
 	De <a href="#">[nom de l’institution]</a>
-{%- elsif i18nText-lang == "en" -%}
+{%- elsif page.language == "en" -%}
 	From <a href="#">[Institution name]</a>
 {%- endif -%}
 </strong></p>

--- a/components/components-en.html
+++ b/components/components-en.html
@@ -9,6 +9,8 @@
 	"share": "true"
 }
 ---
+<span class="wb-prettify all-pre">
+
 <p>Generic destination pages share many characteristics. For example, they are often long-form documents requiring structure to facilitate usability and readability. In many cases, they include images, charts, graphs or tables. Following are patterns aimed at increasing the usability and consistency of destination pages of various types.</p>
 
 <nav role="navigation" class="gc-toc">
@@ -25,7 +27,21 @@
 	<p>Download links are used for referencing and linking to non-HTML files on Canada.ca web pages.</p>
 	<div class="row">
 		<div class="col-sm-4">
-			{{>comp-download}}
+			<a class="gc-dwnld-lnk" href="#">
+				<div class="well gc-dwnld">
+					<div class="row">
+						<div class="col-xs-4">
+							<p><img class="img-responsive thumbnail gc-dwnld-img" src="./../templates/img/doc.png" alt="" /></p>
+						</div>
+						<div class="col-xs-8">
+							<p class="gc-dwnld-txt">
+								<span>Document Title</span>
+								<span class="gc-dwnld-info">(<abbr title="Portable Document Format">PDF</abbr>, 273 <abbr title="KiloByte">KB/abbr>)</span>
+							</p>
+						</div>
+					</div>
+				</div>
+			</a>
 		</div>
 	</div>
 </section>
@@ -53,9 +69,24 @@
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quam delectus iusto repellat assumenda nobis, modi accusamus, rerum praesentium ad dignissimos ipsam? Facilis repellat, quibusdam qui? Et dolore ipsa ut repellendus.</p>
 	</section>
 </section>
-<div id="min-port">
-{{>minister-port}}
-</div>
+<section id="min-port" class="gc-mnstr-prtfl">
+	<h2>Portfolio ministers</h2>
+
+	<p>Provides access to the profiles of all portfolio ministers under the institution’s portfolio</p>
+	<div class="row wb-eqht-grd">
+		{% for i in (1..4) %}
+		<div class="col-md-3 col-sm-6">
+			<a href="#">
+				<figure>
+					<img src="https://via.placeholder.com/218x291?text=[President]" alt="" class="img-responsive thumbnail">
+					<figcaption>[Chairperson]</figcaption>
+				</figure>
+			</a>
+			<p>[Organization head]</p>
+		</div>
+		{% endfor %}
+	</div>
+</section>
 
 <section>
 <h2 id="alert">Alert designs</h2>

--- a/components/components-fr.html
+++ b/components/components-fr.html
@@ -9,6 +9,8 @@
 	"share": "true"
 }
 ---
+<span class="wb-prettify all-pre">
+
 <p>Les pages de destination génériques ont plusieurs caractéristiques en commun. Par exemple, elles consistent souvent en de longs documents nécessitant une structure afin qu’ils soient faciles à utiliser et à lire. Dans bien des cas, elles comprennent des images, des graphiques ou des tableaux. Vous trouverez ci-dessous une description des configurations visant à accroître la convivialité et l’uniformité des pages de destination de différents types.</p>
 <nav role="navigation" class="gc-toc">
 	<h2>Table des matières</h2>
@@ -24,7 +26,21 @@
 	<p>Les liens de téléchargement servent à renvoyer ou à lier à des fichiers de format autre que HTML sur les pages Web de Canada.ca.</p>
 	<div class="row">
 		<div class="col-sm-4">
-			{{>comp-download}}
+			<a class="gc-dwnld-lnk" href="#">
+				<div class="well gc-dwnld">
+					<div class="row">
+						<div class="col-xs-4">
+							<p><img class="img-responsive thumbnail gc-dwnld-img" src="./../templates/img/doc.png" alt="" /></p>
+						</div>
+						<div class="col-xs-8">
+							<p class="gc-dwnld-txt">
+								<span>Titre du document</span>
+								<span class="gc-dwnld-info">(<abbr lang="en" title="Portable Document Format">PDF</abbr>, 273 <abbr title="kilo octet">Ko</abbr>)</span>
+							</p>
+						</div>
+					</div>
+				</div>
+			</a>
 		</div>
 	</div>
 </section>
@@ -52,9 +68,24 @@
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quam delectus iusto repellat assumenda nobis, modi accusamus, rerum praesentium ad dignissimos ipsam? Facilis repellat, quibusdam qui? Et dolore ipsa ut repellendus.</p>
 	</section>
 </section>
-<div id="min-port">
-{{>minister-port}}
-</div>
+<section id="min-port" class="gc-mnstr-prtfl">
+	<h2>Ministres du portefeuille</h2>
+
+	<p>Donne accès à un profil de plus grande visibilité des ministres détenant un portefeuille au sein de l’institution</p>
+	<div class="row wb-eqht-grd">
+		{% for i in (1..4) %}
+		<div class="col-md-3 col-sm-6">
+			<a href="#">
+				<figure>
+					<img src="https://via.placeholder.com/218x291?text=[Président]" alt="" class="img-responsive thumbnail">
+					<figcaption>[Président]</figcaption>
+				</figure>
+			</a>
+			<p>[Chef de l’organisme]</p>
+		</div>
+		{% endfor %}
+	</div>
+</section>
 
 <section>
 <h2 id="avis">Conceptions des avis</h3>

--- a/sites/gcweb-menu/ajax/sitemenu-en.hbs
+++ b/sites/gcweb-menu/ajax/sitemenu-en.hbs
@@ -3,4 +3,124 @@
 	language: "en"
 }
 ---
-{{>fullmenu}}
+<!-- secondary navigation if enabled -->
+<div class="pnl-strt container nvbar">
+	<h2 class="wb-inv">Topics menu</h2>
+	<div class="row">
+		<ul class="list-inline menu" role="menubar">
+			<li><a href="#jobs" class="item">Jobs</a>
+				<ul class="sm list-unstyled" id="jobs" role="menu">
+					<li><a href="https://www.canada.ca/en/services/jobs/opportunities.html">Find a job</a></li>
+					<li><a href="https://www.canada.ca/en/services/jobs/training.html">Training</a></li>
+					<li><a href="https://www.canada.ca/business-management">Hire and manage employees</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/start.html">Starting a business</a></li>
+					<li><a href="https://www.canada.ca/en/services/jobs/workplace.html">Workplace standards</a></li>
+					<li><a href="https://www.canada.ca/en/services/finance/pensions.html">Pensions and retirement</a></li>
+					<li><a href="https://www.canada.ca/ei">Employment insurance</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services/jobs.html">Jobs - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#immigration" class="item">Immigration</a>
+				<ul class="sm list-unstyled" id="immigration" role="menu">
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/application.html">My application</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/immigrate-canada.html">Immigrate</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada.html">Visit</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/work-canada.html">Work</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/study-canada.html">Study</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-citizenship.html">Citizenship</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/new-immigrants.html">New immigrants</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/canadians.html">Canadians</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/refugees.html">Refugees and asylum</a></li>
+					<li><a href="https://www.canada.ca/en/services/immigration-citizenship/enforcement-violations.html">Enforcement and violations</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#travel" class="item">Travel</a>
+				<ul class="sm list-unstyled" id="travel" role="menu">
+					<li><a href="https://travel.gc.ca/travelling/advisories">Travel advice and advisories</a></li>
+					<li><a href="https://travel.gc.ca/canadian-tourism">Canadian attractions, events and experiences</a></li>
+					<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports.html">Canadian passports</a></li>
+					<li><a href="https://travel.gc.ca/travelling">Travelling abroad</a></li>
+					<li><a href="https://travel.gc.ca/air">Air travel</a></li>
+					<li><a href="https://travel.gc.ca/returning">Returning to Canada</a></li>
+					<li><a href="https://travel.gc.ca/assistance">Assistance abroad</a></li>
+					<li><a href="https://travel.gc.ca/stay-connected">Stay connected</a></li>
+					<li><a href="https://www.canada.ca/visit">Visit Canada</a></li>
+					<li class="slflnk"><a href="https://travel.gc.ca/">Travel - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#business" class="item">Business</a>
+				<ul class="sm list-unstyled" id="business" role="menu">
+					<li><a href="https://www.canada.ca/start-business">Starting a business</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/grants.html">Grants and financing</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/taxes.html">Business taxes</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/doing-business.html">Doing business with government</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/trade.html">International trade and investment</a></li>
+					<li><a href="https://www.canada.ca/en/services/science/innovation.html">Research and development (R&amp;D) and innovation</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/ip.html">Intellectual property and copyright</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/permits.html">Permits, licences and regulations</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/research.html">Research and business intelligence</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/hire.html">Hiring and managing employees</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/maintaingrowimprovebusiness.html">Maintaining your business</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/protecting.html">Protect your business</a></li>
+					<li><a href="https://www.canada.ca/en/services/business/bankruptcy.html">Bankruptcy for business</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services/business.html">Business - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#benefits" class="item">Benefits</a>
+				<ul class="sm list-unstyled" id="benefits" role="menu">
+					<li><a href="https://www.canada.ca/en/services/benefits/ei.html">Employment Insurance</a></li>
+					<li><a href="https://www.canada.ca/en/services/benefits/family.html">Family benefits</a></li>
+					<li><a href="https://www.canada.ca/en/services/benefits/publicpensions.html">Public pensions</a></li>
+					<li><a href="https://www.canada.ca/en/services/benefits/education.html">Education and student aid</a></li>
+					<li><a href="https://www.canada.ca/en/services/benefits/housing.html">Housing benefits</a></li>
+					<li><a href="https://www.canada.ca/en/services/benefits/disability.html">Disability benefits</a></li>
+					<li><a href="http://www.canadabenefits.gc.ca">Benefits finder</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services/benefits.html">Benefits - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#health" class="item">Health</a>
+				<ul class="sm list-unstyled" id="health" role="menu">
+					<li><a href="https://www.canada.ca/en/services/health/food-nutrition.html">Food and nutrition</a></li>
+					<li><a href="https://www.canada.ca/en/public-health/services/diseases.html">Diseases and conditions</a></li>
+					<li><a href="https://www.canada.ca/en/public-health/topics/immunization-vaccines.html">Vaccines and immunization</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/drug-health-products.html">Drug and health products</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/product-safety.html">Product safety</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/health-risks-safety.html">Health risks and safety</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/healthy-living.html">Healthy living</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/aboriginal-health.html">Indigenous health</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/health-system-services.html">Health system and services</a></li>
+					<li><a href="https://www.canada.ca/en/services/health/science-research-data.html">Science, research and data</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services/health.html">Health - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#taxes" class="item">Taxes</a>
+				<ul class="sm list-unstyled" id="taxes" role="menu">
+					<li><a href="https://www.canada.ca/en/services/taxes/income-tax.html">Income tax</a></li>
+					<li><a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses.html">GST/HST</a></li>
+					<li><a href="https://www.canada.ca/en/services/taxes/payroll.html">Payroll</a></li>
+					<li><a href="https://www.canada.ca/en/services/taxes/business-number.html">Business number</a></li>
+					<li><a href="https://www.canada.ca/en/services/taxes/savings-and-pension-plans.html">Savings and pension plans</a></li>
+					<li><a href="https://www.canada.ca/en/services/taxes/child-and-family-benefits.html">Child and family benefits</a></li>
+					<li><a href="https://www.canada.ca/en/services/taxes/excise-taxes-duties-and-levies.html">Excise taxes, duties, and levies</a></li>
+					<li><a href="https://www.canada.ca/en/services/taxes/charities.html">Charities and giving</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services/taxes.html">Taxes - More</a></li>
+				</ul>
+			</li>
+			<li><a href="#more-services" class="item">More services</a>
+				<ul class="sm list-unstyled" id="more-services" role="menu">
+					<li><a href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
+					<li><a href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
+					<li><a href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
+					<li><a href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
+					<li><a href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
+					<li><a href="https://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
+					<li><a href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
+					<li><a href="https://www.canada.ca/en/services/science.html">Science and innovation</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/en/services.html">All services</a></li>
+				</ul>
+			</li>
+
+		</ul>
+	</div>
+</div>

--- a/sites/gcweb-menu/ajax/sitemenu-fr.hbs
+++ b/sites/gcweb-menu/ajax/sitemenu-fr.hbs
@@ -3,4 +3,124 @@
 	language: "fr"
 }
 ---
-{{>fullmenu}}
+<!-- secondary navigation if enabled -->
+<div class="pnl-strt container nvbar">
+	<h2 class="wb-inv">Menu des sujets</h2>
+	<div class="row">
+		<ul class="list-inline menu" role="menubar">
+			<li><a href="#emplois" class="item">Emplois</a>
+				<ul class="sm list-unstyled" id="emplois" role="menu">
+					<li><a href="https://www.canada.ca/fr/services/emplois/opportunites.html">Trouver un emploi</a></li>
+					<li><a href="https://www.canada.ca/fr/services/emplois/formation.html">Formation</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/engager.html">Embauche et gestion de personnel</a></li>
+					<li><a href="https://www.canada.ca/demarrage-entreprise">Démarrage d'entreprise</a></li>
+					<li><a href="https://www.canada.ca/fr/services/emplois/milieu-travail.html">Normes en milieu de travail</a></li>
+					<li><a href="https://www.canada.ca/fr/services/finance/pensions.html">Pensions et retraite</a></li>
+					<li><a href="https://www.canada.ca/ae">Assurance-emploi</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services/emplois.html">Emplois – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#immigration" class="item">Immigration</a>
+				<ul class="sm list-unstyled" id="immigration" role="menu">
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/demande.html">Ma demande</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/immigrer-canada.html">Immigrer</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/visiter-canada.html">Visiter</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/travailler-canada.html">Travailler</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/etudier-canada.html">Étudier</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/citoyennete-canadienne.html">Citoyenneté</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/nouveaux-immigrants.html">Nouveaux immigrants</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/canadiens.html">Canadiens</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/refugies.html">Réfugiés et demandes d’asile</a></li>
+					<li><a href="https://www.canada.ca/fr/services/immigration-citoyennete/application-loi-infractions.html">Application de la loi et violations</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services/immigration-citoyennete.html">Immigration – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#voyage" class="item">Voyage</a>
+				<ul class="sm list-unstyled" id="voyage" role="menu">
+					<li><a href="https://voyage.gc.ca/voyager/avertissements">Conseils aux voyageurs et avertissements</a></li>
+					<li><a href="https://voyage.gc.ca/tourisme-canadien">Attraits touristiques, événements et expériences au Canada</a></li>
+					<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens.html">Passeports canadiens</a></li>
+					<li><a href="https://voyage.gc.ca/voyager">Voyager à l'étranger</a></li>
+					<li><a href="https://voyage.gc.ca/avion">Voyager en avion</a></li>
+					<li><a href="https://voyage.gc.ca/retour">Retour au Canada</a></li>
+					<li><a href="https://voyage.gc.ca/assistance">Assistance à l’étranger</a></li>
+					<li><a href="https://voyage.gc.ca/restez-branches">Restez branchés</a></li>
+					<li><a href="https://www.canada.ca/visiter">Visiter le Canada</a></li>
+					<li class="slflnk"><a href="https://voyage.gc.ca/">Voyage – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#entreprises" class="item">Entreprises</a>
+				<ul class="sm list-unstyled" id="entreprises" role="menu">
+					<li><a href="https://www.canada.ca/fr/services/entreprises/lancer.html">Démarrage d'entreprise</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/subventions.html">Subventions et financement</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/impots.html">Taxes et impôt des entreprises</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/faire-affaire.html">Faire affaire avec le gouvernement</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/commerce.html">Commerce international et investissements</a></li>
+					<li><a href="https://www.canada.ca/fr/services/science/innovation.html">Recherche-développement et innovation</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/pi.html">Propriété intellectuelle et droit d'auteur</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/permis.html">Permis, licences et règlements</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/recherche.html">Recherche et renseignements d'affaires</a></li>
+					<li><a href="https://www.canada.ca/gestion-entreprise">Embauche et gestion de personnel</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/maintenirfairecroitreameliorerentreprise.html">Administration de votre entreprise</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/proteger.html">Protection de votre entreprise</a></li>
+					<li><a href="https://www.canada.ca/fr/services/entreprises/faillites.html">Faillite pour les entreprises</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services/entreprises.html">Entreprises – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#prestations" class="item">Prestations</a>
+				<ul class="sm list-unstyled" id="prestations" role="menu">
+					<li><a href="https://www.canada.ca/fr/services/prestations/ae.html">Assurance-emploi</a></li>
+					<li><a href="https://www.canada.ca/fr/services/prestations/famille.html">Prestations pour les familles</a></li>
+					<li><a href="https://www.canada.ca/fr/services/prestations/pensionspubliques.html">Pensions publiques</a></li>
+					<li><a href="https://www.canada.ca/fr/services/prestations/etudes.html">Éducation et aide aux étudiants</a></li>
+					<li><a href="https://www.canada.ca/fr/services/prestations/logement.html">Prestations relatives au logement</a></li>
+					<li><a href="https://www.canada.ca/fr/services/prestations/handicap.html">Prestations relatives aux personnes handicapées</a></li>
+					<li><a href="http://www.prestationsducanada.gc.ca">Chercheur de prestations</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services/prestations.html">Prestations – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#sante" class="item">Santé</a>
+				<ul class="sm list-unstyled" id="sante" role="menu">
+					<li><a href="https://www.canada.ca/fr/services/sante/aliments-et-nutrition.html">Aliments et nutrition</a></li>
+					<li><a href="https://www.canada.ca/fr/sante-publique/services/maladies.html">Maladies et affections</a></li>
+					<li><a href="https://www.canada.ca/fr/sante-publique/sujets/immunisation-et-vaccins.html">Vaccins et immunisation</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/medicaments-et-produits-sante.html">Médicaments et produits de santé</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/securite-produits.html">Sécurité des produits</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/securite-et-risque-pour-sante.html">Sécurité et risque pour la santé</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/vie-saine.html">Vie saine</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/sante-autochtones.html">Santé des Autochtones</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/systeme-et-services-sante.html">Système et services de santé</a></li>
+					<li><a href="https://www.canada.ca/fr/services/sante/science-recherche-et-donnees.html">Science, recherche et données</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services/sante.html">Santé – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#impots" class="item">Impôts</a>
+				<ul class="sm list-unstyled" id="impots" role="menu">
+					<li><a href="https://www.canada.ca/fr/services/impots/impot-sur-le-revenu.html">Impôt sur le revenu</a></li>
+					<li><a href="https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/tps-tvh-entreprises.html">TPS/TVH</a></li>
+					<li><a href="https://www.canada.ca/fr/services/impots/retenues-sur-la-paie.html">Retenues sur la paie</a></li>
+					<li><a href="https://www.canada.ca/fr/services/impots/numero-dentreprise.html">Numéro d’entreprise</a></li>
+					<li><a href="https://www.canada.ca/fr/services/impots/regimes-depargne-et-de-pension.html">Régimes d’épargne et de pension</a></li>
+					<li><a href="https://www.canada.ca/fr/services/impots/prestations-pour-enfants-et-familles.html">Prestations pour enfants et familles</a></li>
+					<li><a href="https://www.canada.ca/fr/services/impots/taxes-daccise-droits-et-prelevements.html">Taxes d’accise, droits et prélèvements</a></li>
+					<li><a href="https://www.canada.ca/fr/services/impots/bienfaisance.html">Organismes de bienfaisance et dons</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services/impots.html">Impôts – Autres</a></li>
+				</ul>
+			</li>
+			<li><a href="#autres-services" class="item">Autres services</a>
+				<ul class="sm list-unstyled" id="autres-services" role="menu">
+					<li><a href="https://www.canada.ca/fr/services/environnement.html">Environnement et ressources naturelles</a></li>
+					<li><a href="https://www.canada.ca/fr/services/defense.html">Sécurité nationale et défense</a></li>
+					<li><a href="https://www.canada.ca/fr/services/culture.html">Culture, histoire et sport</a></li>
+					<li><a href="https://www.canada.ca/fr/services/police.html">Services de police, justice et urgences</a></li>
+					<li><a href="https://www.canada.ca/fr/services/transport.html">Transport et infrastructure</a></li>
+					<li><a href="https://international.gc.ca/world-monde/index.aspx?lang=fra">Le Canada et le monde</a></li>
+					<li><a href="https://www.canada.ca/fr/services/finance.html">Argent et finances</a></li>
+					<li><a href="https://www.canada.ca/fr/services/science.html">Science et innovation</a></li>
+					<li class="slflnk"><a href="https://www.canada.ca/fr/services.html">Tous les services</a></li>
+				</ul>
+			</li>
+
+		</ul>
+	</div>
+</div>

--- a/templates/content-gcweb-4-0-29-font-style-en.html
+++ b/templates/content-gcweb-4-0-29-font-style-en.html
@@ -8,6 +8,8 @@
 	"share": "true"
 }
 ---
+<span class="wb-prettify all-pre"></span>
+
 {% include byline/byline.html %}
 
 <p>This is a temporary style to assist implementer with some of their page design where the visual was thighly  optimized for desktop first. The following capability would be remove in a future version of GCWeb.</p>
@@ -29,6 +31,6 @@
 &lt;/div&gt;</code></pre>
 <hr />
 <div class="force-style-gcweb-4-0-29">
-{{>placeholdercontent}}
+	{% include web-contents/placeholdercontent-en.html %}
 </div>
 <hr />

--- a/templates/content-gcweb-4-0-29-font-style-fr.html
+++ b/templates/content-gcweb-4-0-29-font-style-fr.html
@@ -8,6 +8,8 @@
 	"share": "true"
 }
 ---
+<span class="wb-prettify all-pre"></span>
+
 {% include byline/byline.html %}
 
 <p>Ceci est un style temporaire afin d'assister l'implémentation du nouveau style pour certaine page d'où leur conception a étroitement optimisé pour un visionnement primaire sur un bureau. Cette fonctionalité sera retiré de GCWeb dans une version future.</p>
@@ -29,6 +31,6 @@
 &lt;/div&gt;</code></pre>
 <hr />
 <div class="force-style-gcweb-4-0-29">
-{{>placeholdercontent}}
+	{% include web-contents/placeholdercontent-fr.html %}
 </div>
 <hr />

--- a/templates/institutional/institution-contact-en.html
+++ b/templates/institutional/institution-contact-en.html
@@ -13,7 +13,7 @@
 ---
 <div class="row">
 <div class="col-sm-7 pull-left">
-{{>byline}}
+	{% include byline/byline.html %}
 	<p>[Institution name] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>
 </div>
 	<div class="col-sm-5 col-xs-12 pull-right">

--- a/templates/institutional/institution-contact-fr.html
+++ b/templates/institutional/institution-contact-fr.html
@@ -13,7 +13,7 @@
 ---
 <div class="row">
 <div class="col-sm-7 pull-left">
-{{>byline}}
+	{% include byline/byline.html %}
 	<p>[Nom de l’institution] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>
 </div>
 	<div class="col-sm-5 col-xs-12 pull-right">

--- a/templates/institutional/institutional-service-performance-en.html
+++ b/templates/institutional/institutional-service-performance-en.html
@@ -8,7 +8,7 @@
 	"share": "true"
 }
 ---
-{{>byline}}
+{% include byline/byline.html %}
 <p>This report covers the 2015 to 2016 fiscal year. A fiscal year runs from April 1 to March 31.</p>
 <nav role="navigation">
 	<h2>On this page</h2>

--- a/templates/institutional/institutional-service-performance-fr.html
+++ b/templates/institutional/institutional-service-performance-fr.html
@@ -8,7 +8,7 @@
 	"share": "true"
 }
 ---
-{{>byline}}
+{% include byline/byline.html %}
 <p>Ce rapport couvre l’exercice 2015 à 2016. Un exercice financier s’étend du 1<sup>er</sup> avril au 31 mars</p>
 <nav role="navigation">
 	<h2>Sur cette page</h2>

--- a/templates/theme-en.html
+++ b/templates/theme-en.html
@@ -17,7 +17,50 @@
 		{{>follow}}
 	</div>
 	<div class="col-md-7">
-		{{>carousel-small}}
+		<h2 class="wb-inv">Promotions</h2>
+		<div class="wb-tabs carousel-s2 playing" data-speed="slow">
+			<ul role="tablist">
+				<li class="active">
+					<a href="#tab1" title="Tab 1: [Title of destination page – call to action]"><img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" /></a>
+				</li>
+				<li>
+					<a href="#tab2" title="Tab 2: [Title of destination page – call to action]"><img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" /></a>
+				</li>
+				<li>
+					<a href="#tab3" title="Tab 3: [Title of destination page – call to action]"><img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" /></a>
+				</li>
+			</ul>
+			<div role="tabpanel" id="tab1" class="in fade">
+				<a href="#" class="learnmore">
+					<figure>
+						<img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" />
+						<figcaption>
+							<p>[Title of destination page – call to action]</p>
+						</figcaption>
+					</figure>
+				</a>
+			</div>
+			<div role="tabpanel" id="tab2" class="out fade">
+				<a href="#" class="learnmore">
+					<figure>
+						<img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" />
+						<figcaption>
+							<p>[Title of destination page – call to action]</p>
+						</figcaption>
+					</figure>
+				</a>
+			</div>
+			<div role="tabpanel" id="tab3" class="out fade">
+				<a href="#" class="learnmore">
+					<figure>
+						<img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" />
+						<figcaption>
+							<p>[Title of destination page – call to action]</p>
+						</figcaption>
+					</figure>
+				</a>
+			</div>
+		</div>
 	</div>
 </div>
 <div class="row">

--- a/templates/theme-fr.html
+++ b/templates/theme-fr.html
@@ -17,7 +17,50 @@
 		{{>follow}}
 	</div>
 	<div class="col-md-7">
-		{{>carousel-small}}
+		<h2 class="wb-inv">Promotions</h2>
+		<div class="wb-tabs carousel-s2 playing" data-speed="slow">
+			<ul role="tablist">
+				<li class="active">
+					<a href="#tab1" title="Languette 1 : [Titre de la page de destination – appel à l’action]"><img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" /></a>
+				</li>
+				<li>
+					<a href="#tab2" title="Languette 2 : [Titre de la page de destination – appel à l’action]"><img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" /></a>
+				</li>
+				<li>
+					<a href="#tab3" title="Languette 3 : [Titre de la page de destination – appel à l’action]"><img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" /></a>
+				</li>
+			</ul>
+			<div role="tabpanel" id="tab1" class="in fade">
+				<a href="#" class="learnmore">
+					<figure>
+						<img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" />
+						<figcaption>
+							<p>[Titre de la page de destination – appel à l’action]</p>
+						</figcaption>
+					</figure>
+				</a>
+			</div>
+			<div role="tabpanel" id="tab2" class="out fade">
+				<a href="#" class="learnmore">
+					<figure>
+						<img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" />
+						<figcaption>
+							<p>[Titre de la page de destination – appel à l’action]</p>
+						</figcaption>
+					</figure>
+				</a>
+			</div>
+			<div role="tabpanel" id="tab3" class="out fade">
+				<a href="#" class="learnmore">
+					<figure>
+						<img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" />
+						<figcaption>
+							<p>[Titre de la page de destination – appel à l’action]</p>
+						</figcaption>
+					</figure>
+				</a>
+			</div>
+		</div>
 	</div>
 </div>
 <div class="row">


### PR DESCRIPTION
Resolving build warnings part 4:
- Fixing byline file include which did not recognize "i18nText-lang"
- Fixing syntax for "byline" include call
- Fixing syntax and url for "placeholdercontent" include call
- Integrating "comp-download" include content directly in files calling it (2 files)
- Integrating "minister-port" include content directly in files calling it (2 files)
- Integrating "fullmenu" include content directly in files calling it (2 files)
- Integrating "carousel-small" include content directly in files calling it (2 files)