### PR TITLE
Build warnings: Fixing page title references

### DIFF
--- a/templates/localnav/index-en.html
+++ b/templates/localnav/index-en.html
@@ -14,7 +14,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-6">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>This topic page shows child destination pages that have a local left navigation. Click on a task for an example. This would typically happen on a lowest-level topic page.</p>
 		{{>follow}}
 	</div>

--- a/templates/localnav/index-fr.html
+++ b/templates/localnav/index-fr.html
@@ -14,7 +14,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-6">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>Cette page de sujet comporte des liens vers des pages de destination qui ont une navigation locale. Cliquez sur une tâche pour voir un exemple. Normalement, cette situation devrait arriver sur des pages de sujet de plus bas niveau.</p>
 		{{>follow}}
 	</div>

--- a/templates/organizational/organizational-arms-en.html
+++ b/templates/organizational/organizational-arms-en.html
@@ -13,7 +13,7 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{{title}}}</h1>
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p class="gc-byline">We are a federal institution that operates at arm’s length from the Government of Canada.</p>

--- a/templates/organizational/organizational-arms-fr.html
+++ b/templates/organizational/organizational-arms-fr.html
@@ -13,7 +13,7 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{{title}}}</h1>
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p class="gc-byline">Nous sommes un organisme qui agissons indépendamment du gouvernement du Canada.</p>

--- a/templates/organizational/organizational-en.html
+++ b/templates/organizational/organizational-en.html
@@ -12,7 +12,7 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{{title}}}</h1>
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p>[Institution name] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>

--- a/templates/organizational/organizational-fr.html
+++ b/templates/organizational/organizational-fr.html
@@ -12,7 +12,7 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{{title}}}</h1>
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p>[Nom de l’institution] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>

--- a/templates/service-en.html
+++ b/templates/service-en.html
@@ -16,7 +16,7 @@
 <div class="row">
 	<div class="col-md-8">
 
-		<p>{{{ title }}}, lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
+		<p>{{ page.title }}, lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<section>
 			<h2>[Eligibility details]</h2>
 			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti cupiditate voluptatem praesentium, facilis corporis magni esse reiciendis distinctio. Vitae totam iste porro, esse facere obcaecati? Laborum earum minus harum enim.</p>

--- a/templates/service-fr.html
+++ b/templates/service-fr.html
@@ -15,7 +15,7 @@
 <p class="gc-byline"><strong>De <a href="./institutional/institution-fr.html">[nom de l'institution]</a></strong></p>
 <div class="row">
 	<div class="col-md-8">
-		<p>{{{title}}}, lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
+		<p>{{ page.title }}, lorem ipsum dolor sit amet, consectetur adipisicing elit. Unde ipsam deserunt, doloremque mollitia laudantium quas ut accusamus perspiciatis repellendus quaerat omnis corporis laborum quasi magni possimus qui necessitatibus, aperiam enim.</p>
 		<section>
 			<h2>[Détails sur l’admissibilité]</h2>
 			<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti cupiditate voluptatem praesentium, facilis corporis magni esse reiciendis distinctio. Vitae totam iste porro, esse facere obcaecati? Laborum earum minus harum enim.</p>

--- a/templates/theme-en.html
+++ b/templates/theme-en.html
@@ -12,7 +12,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-5">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>1-2 sentences that describe the topics and top tasks that can be accessed on this page.</p>
 		{{>follow}}
 	</div>

--- a/templates/theme-fr.html
+++ b/templates/theme-fr.html
@@ -12,7 +12,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-5">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>1 ou 2 phrases d’introduction qui définissent les sujets et les tâches principales qui peuvent être consultés sur cette page.</p>
 		{{>follow}}
 	</div>

--- a/templates/topic/topic-en.html
+++ b/templates/topic/topic-en.html
@@ -14,7 +14,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-6">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>1-2 sentences that describe the topics and top tasks that can be accessed on this page.</p>
 		{{>follow}}
 	</div>

--- a/templates/topic/topic-fr.html
+++ b/templates/topic/topic-fr.html
@@ -14,7 +14,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-6">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>1 ou 2 phrases d’introduction qui définissent les sous-sujets et les tâches principales qui peuvent être consultés sur cette page.</p>
 		{{>follow}}
 	</div>

--- a/templates/topic/topic-testcase-1-en.html
+++ b/templates/topic/topic-testcase-1-en.html
@@ -14,7 +14,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-6">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>1-2 sentences that describe the topics and top tasks that can be accessed on this page.</p>
 		{{>follow}}
 	</div>

--- a/templates/topic/topic-testcase-1-fr.html
+++ b/templates/topic/topic-testcase-1-fr.html
@@ -14,7 +14,7 @@
 ---
 <div class="row profile">
 	<div class="col-md-6">
-		<h1 property="name" id="wb-cont">{{{title}}}</h1>
+		<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 		<p>1 ou 2 phrases d’introduction qui définissent les sous-sujets et les tâches principales qui peuvent être consultés sur cette page.</p>
 		{{>follow}}
 	</div>


### PR DESCRIPTION
Resolving build warnings part 5:
- Fixing syntax for reference to page title