### PR TITLE
Templates: Fix flawed H1 heading setups

### DIFF
--- a/templates/institutional/institution-arms-en.html
+++ b/templates/institutional/institution-arms-en.html
@@ -1,7 +1,6 @@
 ---
 {
 	"title": "[Institution Name]",
-	"layout": "without-h1",
 	"language": "en",
 	"altLangPage": "institution-arms-fr.html",
 	"pageType": "institution",
@@ -14,7 +13,6 @@
 	"armslength": true
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-5 col-xs-12 pull-right gc-rms-lngth">
 		<img class="img-responsive" alt="Department name" src="img/arms-en.png" />

--- a/templates/institutional/institution-arms-fr.html
+++ b/templates/institutional/institution-arms-fr.html
@@ -1,7 +1,6 @@
 ---
 {
 	"title": "[Nom de l’institution]",
-	"layout": "without-h1",
 	"language": "fr",
 	"altLangPage": "institution-arms-en.html",
 	"pageType": "institution",
@@ -14,7 +13,6 @@
 	"armslength": true
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-5 col-xs-12 pull-right gc-rms-lngth">
 		<img class="img-responsive" alt="Nom du département" src="img/arms-fr.png" />

--- a/templates/institutional/institution-en.html
+++ b/templates/institutional/institution-en.html
@@ -12,7 +12,6 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 <div class="col-sm-7 pull-left">
 <p>[Institution name] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>

--- a/templates/institutional/institution-fr.html
+++ b/templates/institutional/institution-fr.html
@@ -12,7 +12,6 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 <div class="col-sm-7 pull-left">
 <p>[Nom de l’institution] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>

--- a/templates/localnav/index-en.html
+++ b/templates/localnav/index-en.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Topic - Local navigation]",
+	"layout": "without-h1",
 	"language": "en",
 	"altLangPage": "index-fr.html",
 	"pageclass": "page-type-nav",

--- a/templates/localnav/index-fr.html
+++ b/templates/localnav/index-fr.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Sujet - Navigation locale]",
+	"layout": "without-h1",
 	"language": "fr",
 	"altLangPage": "index-en.html",
 	"pageclass": "page-type-nav",

--- a/templates/organizational/organizational-arms-en.html
+++ b/templates/organizational/organizational-arms-en.html
@@ -1,7 +1,6 @@
 ---
 {
 	"title": "[Organization Name]",
-	"layout": "without-h1",
 	"language": "en",
 	"altLangPage": "organizational-arms-fr.html",
 	"pageType": "organization",
@@ -13,7 +12,6 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p class="gc-byline">We are a federal institution that operates at arm’s length from the Government of Canada.</p>

--- a/templates/organizational/organizational-arms-fr.html
+++ b/templates/organizational/organizational-arms-fr.html
@@ -1,7 +1,6 @@
 ---
 {
 	"title": "[Nom de l’organisme]",
-	"layout": "without-h1",
 	"language": "fr",
 	"altLangPage": "organizational-arms-en.html",
 	"pageType": "organization",
@@ -13,7 +12,6 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p class="gc-byline">Nous sommes un organisme qui agissons indépendamment du gouvernement du Canada.</p>

--- a/templates/organizational/organizational-en.html
+++ b/templates/organizational/organizational-en.html
@@ -12,7 +12,6 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p>[Institution name] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>

--- a/templates/organizational/organizational-fr.html
+++ b/templates/organizational/organizational-fr.html
@@ -12,7 +12,6 @@
 	"share": "true"
 }
 ---
-<h1 property="name" id="wb-cont">{{ page.title }}</h1>
 <div class="row">
 	<div class="col-sm-7 pull-left">
 		<p>[Nom de l’institution] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor. Cras sagittis massa sed libero eleifend, ac iaculis urna tempor.</p>

--- a/templates/theme-en.html
+++ b/templates/theme-en.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Theme title]",
+	"layout": "without-h1",
 	"language": "en",
 	"altLangPage": "theme-fr.html",
 	"pageclass": "page-type-nav",

--- a/templates/theme-fr.html
+++ b/templates/theme-fr.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Titre du thème]",
+	"layout": "without-h1",
 	"language": "fr",
 	"altLangPage": "theme-en.html",
 	"pageclass": "page-type-nav",

--- a/templates/topic/topic-en.html
+++ b/templates/topic/topic-en.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Topic title]",
+	"layout": "without-h1",
 	"language": "en",
 	"altLangPage": "topic-fr.html",
 	"pageclass": "page-type-nav",

--- a/templates/topic/topic-fr.html
+++ b/templates/topic/topic-fr.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Titre du sujet]",
+	"layout": "without-h1",
 	"language": "fr",
 	"altLangPage": "topic-en.html",
 	"pageclass": "page-type-nav",

--- a/templates/topic/topic-testcase-1-en.html
+++ b/templates/topic/topic-testcase-1-en.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Topic title, test case 1]",
+	"layout": "without-h1",
 	"language": "en",
 	"altLangPage": "topic-testcase-1-fr.html",
 	"pageclass": "page-type-nav",

--- a/templates/topic/topic-testcase-1-fr.html
+++ b/templates/topic/topic-testcase-1-fr.html
@@ -1,6 +1,7 @@
 ---
 {
 	"title": "[Titre du sujet, cas d'essaie 1]",
+	"layout": "without-h1",
 	"language": "fr",
 	"altLangPage": "topic-testcase-1-en.html",
 	"pageclass": "page-type-nav",


### PR DESCRIPTION
Several page templates had flawed H1 heading implementations. Probably mostly-caused by handlebars leftovers.

Specifically:
* Some templates showed duplicate H1s:
  * Caused by using both a hardcoded H1 and a default Jekyll layout (which already comes with a built-in H1)
* Some templates showed one H1:
  * Using a standard-looking hardcoded H1 (not in a grid) and the "without-h1" Jekyll layout... i.e. unnecessarily-complicated setup

This resolves it by:
* Removing hardcoded standard-looking H1s from pages that use the default Jekyll layout
* Adding the "without-h1" Jekyll layout to pages that use a hardcoded H1 in a grid
* Removing both hardcoded H1s and the "without-h1" layout from pages that don't actually need them

Note:
* Didn't update modified dates since these changes just restore intended H1 presentations. Plus the dates weren't changed when the presentations broke in the first place.