### PR TITLE
Méli-mélo: Change SASS line comment to CSS comment

### DIFF
--- a/méli-mélo/2021-04-gcaem/css/mandatetracker.css
+++ b/méli-mélo/2021-04-gcaem/css/mandatetracker.css
@@ -262,7 +262,7 @@ _:-ms-fullscreen, :root .c100 {
 	position: absolute;
 	text-align: center;
 	white-space: nowrap;
-	// width: 5em;
+	/* width: 5em; */
 	width: 100%;
 }
 


### PR DESCRIPTION
Fixes the root cause of an "invalid property name" warning in the ``cssmin`` task. But the warning won't go anywhere since the flawed line comment still exists in the "frozen" méli-mélo CSS files (which is what actually gets processed by ``cssmin``).

SASS line comments don't work in CSS files.