### PR TITLE
Create the-zev thematique. Demo, metadata and css

### DIFF
--- a/méli-mélo/th-zev/meta.md
+++ b/méli-mélo/th-zev/meta.md
@@ -1,0 +1,33 @@
+---
+feature: thématique
+lang: en
+title: Zero Emission Vehicles (ZEV) Theme
+description: Background colours used for NRCan's ZEV campaign
+componentName: th-zev
+expiry: May 31, 2024
+mainPage: zev.html
+cssClass:
+- bg-zev-purple
+- bg-zev-green
+- btn-zev-purple
+- btn-zev-green
+- panel-zev-green
+- panel-zev-purple
+- zev-header-padding
+a11yStatement: >
+  These colours meet the colour contrast requirements as outlined in WCAG 2.1 AA Success Criterion 1.4.3: Contrast (Minimum).
+  Tested by Eric Goodwin, eric.goodwin at nrcan-rncan.gc.ca. 2023-04-18.
+peNote:
+- The <code>bg-zev-purple</code> class must be accompanied with another dark contrast background colour such as <code>bg-dark</code>
+- The <code>panel-zev-purple</code> or <code>panel-zev-green</code> class must be accompagnied with a fall back color such as <code>panel-default</code>
+- Use <code>bg-zev-green</code> with standard text colour to ensure sufficient contrast between text and background
+- Use <code>bg-zev-purple</code> with <code>text-white</code> colour to ensure sufficient contrast between text and background
+- <code>zev-header-padding</code> shouldn't have any accessibility impacts. Use to adjust padding within elements
+pages:
+  examples:
+    - title: Zero Emission Vehicles (ZEV) Theme
+      language: en
+      path: zev.html
+sponsor: NRCan - Eric Goodwin (@auxonic)
+output: false
+---

--- a/méli-mélo/th-zev/style.css
+++ b/méli-mélo/th-zev/style.css
@@ -1,0 +1,168 @@
+/* ZEV theme */
+/* General Backgrounds */
+.bg-zev-purple {
+    background-color: #7B1964;
+  }
+  .bg-zev-purple a {
+    color: #FFFFFF;
+  }
+  .bg-zev-purple a:hover {
+    color: #FFFFFF;
+  }
+  
+  .bg-zev-green {
+    background-color: #9AC43F;
+  }
+  .bg-zev-green a {
+    color: #292929;
+  }
+  .bg-zev-green a:hover {
+    color: #292929;
+  }
+  
+  /* Buttons */
+  .btn-zev-purple {
+    color: #F8D3ED;
+    background-color: #7B1964;
+    border-color: #551145;
+  }
+  
+  .btn-zev-purple:visited {
+    color: #F8D3ED;
+  }
+  
+  .btn-zev-purple.active, .btn-zev-purple.focus, .btn-zev-purple:active, .btn-zev-purple:focus, .btn-zev-purple:hover, .open > .btn-zev-purple.dropdown-toggle {
+    color: #F8D3ED;
+    background-color: #551145;
+    border-color: #551145;
+  }
+  
+  .btn-zev-green {
+    color: #1D270C;
+    background-color: #9AC43F;
+    border-color: #7a9c30;
+  }
+  
+  .btn-zev-green:visited {
+    color: #1D270C;
+  }
+  
+  .btn-zev-green.active, .btn-zev-green.focus, .btn-zev-green:active, .btn-zev-green:focus, .btn-zev-green:hover, .open > .btn-zev-green.dropdown-toggle {
+    color: #1D270C;
+    background-color: #7a9c30;
+    border-color: #7a9c30;
+  }
+  
+  /* Wells */
+  .well.bg-zev-green, .well.bg-zev-purple {
+    padding: 30px;
+    border-radius: 0;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+  }
+  .well.bg-zev-green .well-link, .well.bg-zev-purple .well-link {
+    font-weight: bold;
+  }
+  .well.bg-zev-green.well-lg, .well.bg-zev-purple.well-lg {
+    padding: 24px;
+    border-radius: 0;
+  }
+  .well.bg-zev-green.well-sm, .well.bg-zev-purple.well-sm {
+    padding: 9px;
+    border-radius: 0;
+  }
+  .well.bg-zev-green > :first-child, .well.bg-zev-purple > :first-child {
+    margin-top: 0;
+  }
+  .well.bg-zev-green > :last-child, .well.bg-zev-purple > :last-child {
+    margin-bottom: 0;
+  }
+  .well.bg-zev-green {
+    background-color: #9AC43F;
+    border: 1px solid #7a9c30;
+    color: #292929;
+  }
+  .well.bg-zev-green .well-link, .well.bg-zev-green .well-text {
+    color: #1D270C;
+  }
+  .well.bg-zev-purple {
+    background-color: #7B1964;
+    border: 1px solid #551145;
+    color: #FFFFFF;
+  }
+  .well.bg-zev-purple .well-link, .well.bg-zev-purple .well-text {
+    color: #F8D3ED;
+  }
+  
+  /* Panels */
+  .panel-zev-green {
+    border-color: #9AC43F;
+    border-radius: 0;
+    border: 3px solid #9AC43F;
+  }
+  
+  .panel-zev-green > .panel-heading > h2 {
+    margin: 0.5em 0;
+  }
+  
+  .panel-zev-green > .panel-heading,
+  .panel-zev-green > .panel-footer {
+    color: #292929;
+    background-color: #9AC43F;
+    border-radius: 0;
+    border: 1px solid #9AC43F;
+    margin: -1px;
+  }
+  
+  .panel-zev-green > .panel-heading + .panel-collapse > .panel-body {
+    border-top-color: #9AC43F;
+  }
+  
+  .panel-zev-green > .panel-heading .badge {
+    color: #9AC43F;
+    background-color: #292929;
+  }
+  
+  .panel-zev-green > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #9AC43F;
+  }
+  
+  .panel-zev-purple {
+    border-color: #7B1964;
+    border-radius: 0;
+    border: 3px solid #7B1964;
+  }
+  
+  .panel-zev-purple > .panel-heading > h2 {
+    margin: 0.5em 0;
+  }
+  
+  .panel-zev-purple > .panel-heading,
+  .panel-zev-purple > .panel-footer {
+    color: #FFFFFF;
+    background-color: #7B1964;
+    border-radius: 0;
+    border: 1px solid #7B1964;
+    margin: -1px;
+  }
+  
+  .panel-zev-purple > .panel-heading + .panel-collapse > .panel-body {
+    border-top-color: #7B1964;
+  }
+  
+  .panel-zev-purple > .panel-heading .badge {
+    color: #7B1964;
+    background-color: #FFFFFF;
+  }
+  
+  .panel-zev-purple > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #7B1964;
+  }
+  
+  /* Misc */
+  .zev-header-padding {
+    padding-bottom: 20px;
+    padding-top: 20px;
+  }
+  

--- a/méli-mélo/th-zev/zev.html
+++ b/méli-mélo/th-zev/zev.html
@@ -1,0 +1,173 @@
+---
+title: Zero Emission Vehicles (ZEV) Theme
+dateModified: 2023-04-20
+description: ZEV CSS styles
+lang: en
+css:
+- style.css
+layout: no-container
+---
+<div class="container">
+    <h1>{{ page.title }}</h1>
+    {% assign metadata = site.pages | where: "output", "false" | where: "componentName", "th-zev" | first %}
+    <p>Sponsor: {{ metadata.sponsor }}</p>
+    <p>Accessibility statement: {{ metadata.a11yStatement }}</p>
+    <p>Progressive enhancement note:</p>
+    <ul>
+      {% for peNote in metadata.peNote %}
+      <li>{{ peNote }}</li>
+      {% endfor %}
+    </ul>
+    <h2>On this page</h2>
+    <ul>
+      <li><a href="#a1">Coloured Backgrounds</a></li>
+      <li><a href="#a2">Example - Themed Wells</a></li>
+      <li><a href="#a3">Example - Themed Buttons</a></li>
+      <li><a href="#a4">Example - Themed Panels</a></li>
+    </ul>
+
+    <h2 id="a1">Coloured Backgrounds</h2>
+    <p>Used to theme an element with the green or purple background and text colors</p>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <h3 class="mrgn-tp-0">Appearance</h3>
+        <div class="row wb-eqht-grd mrgn-tp-md">
+          <div class="col-md-4">
+            <section class="well bg-zev-green">
+              <h4 class="h2 mrgn-tp-0">ZEV Green</h4>
+              <p>This section is styled with <code>.bg-zev-green</code>.</p>
+              <p><a href="#">Link example</a></p>
+              <button class="btn-info mrgn-bttm-md btn-zev-green" type="button">Button example</button>
+              <button class="btn-info mrgn-bttm-md btn-zev-purple text-white" type="button">Button example</button>
+            </section>
+          </div>
+          <div class="col-md-4">
+            <section class="well bg-dark text-white bg-zev-purple">
+              <h4 class="h2 mrgn-tp-0">ZEV Purple</h4>
+              <p>This section is styled with <code>.bg-dark</code>, <code>.bg-zev-purple</code> and <code>.text-white</code>.</p>
+              <p><a class="text-white" href="#">Link example</a></p>
+              <button class="btn-info mrgn-bttm-md btn-zev-green" type="button">Button example</button>
+              <button class="btn-info mrgn-bttm-md btn-zev-purple text-white" type="button">Button example</button>
+            </section>
+          </div>
+          <div class="col-md-4">
+            <section class="well">
+              <h4 class="h2 mrgn-tp-0">Normal Well</h4>
+              <p>This section is styled with <code>.well</code>.</p>
+              <p><a href="#">Link example</a></p>
+              <button class="btn-info mrgn-bttm-md" type="button">Button example</button>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-6">
+        <h3 class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Correct use</h3>
+        <p>Compliance point(s):</p>
+        <ul>
+          <li>Use to introduce contrast to information</li>
+          <li>Use <code>.bg-zev-purple</code> in combination with <code>.text-white</code> to ensure sufficient contrast between text and background</li>
+          <li>In the case of <code>.bg-zev-purple</code>use a fallback colour such as <code>.bg-dark</code> for sections and paragraphs, <code>.btn-info</code> for buttons or <code>.panel-default</code> for panels to accommodate progressive enhancement</li>
+          <li>Wrap text in a &lt;span&gt; tag if a style does not appear as it is meant to, due to specificity reasons</li>
+        </ul>
+      </div>
+      <div class="col-md-6">
+        <h3 class="text-danger"><span class="glyphicon glyphicon-remove-circle"></span> Incorrect use</h3>
+        <p>Compliance point(s):</p>
+        <ul>
+          <li>Do not use this component in a way that conflicts with the preceding compliance <span class="nowrap">point(s)</span></li>
+          <li>Do not use as the only way to communicate information or intent, as colour alone is not accessible</li>
+        </ul>
+      </div>
+    </div>
+
+    <h3>CSS classes</h3>
+    <dl class="dl-horizontal">
+      <dt><code>.bg-zev-green</code></dt>
+      <dd>Set a background colour in an element or well to green</dd>
+      <dt><code>.bg-zev-purple</code></dt>
+      <dd>Set a background colour in an element or well to purple</dd>
+      <dt><code>.btn-zev-green</code></dt>
+      <dd>Set a button to the ZEV purple green</dd>
+      <dt><code>.btn-zev-purple</code></dt>
+      <dd>Set a button to the ZEV purple style</dd>
+      <dt><code>.panel-zev-green</code></dt>
+      <dd>Set a Panel to the ZEV purple green header, footer, and border.</dd>
+      <dt><code>.panel-zev-purple</code></dt>
+      <dd>Set a Panel to the ZEV purple purple header, footer, and border.</dd>
+      <dt><code>.zev-header-padding</code></dt>
+      <dd>fixes the top and bottom padding to 20px</dd>
+      
+    </dl>
+
+    <h2>Examples</h2>
+    <h3 id="a2">Well example</h3>
+    <section class="well bg-zev-green">
+      <h4 class="well-text zev-header-padding">This is a <code>.bg-zev-green</code> well with <code>well-text</code> and <code>.zev-header-padding</code> on the header</h4>
+      <p>Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. Mi sit amet mauris commodo quis imperdiet massa tincidunt nunc. <a class="well-link" href="#">Morbi tincidunt augue interdum </a>velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.</p>
+    </section>
+    <section class="well bg-dark bg-zev-purple">
+        <h4 class="text-white mrgn-tp-sm well-text">This is a <code>.bg-zev-purple</code> well</h4>
+        <p class="text-white">Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. Mi sit amet mauris commodo quis imperdiet massa tincidunt nunc. <a href="#">Morbi tincidunt augue interdum </a>velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.</p>
+    </section>
+    <h4>Code</h4>
+    <pre><code>&lt;section class=&quot;well bg-zev-green&quot;&gt;
+  &lt;h4 class=&quot;well-text zev-header-padding&quot;&gt;This is a &lt;code&gt;.bg-zev-green&lt;/code&gt; well with &lt;code&gt;well-text&lt;/code&gt; and &lt;code&gt;.zev-header-padding&lt;/code&gt; on the header&lt;/h4&gt;
+  &lt;p&gt;Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. Mi sit amet mauris commodo quis imperdiet massa tincidunt nunc. &lt;a class=&quot;well-link&quot; href=&quot;#&quot;&gt;Morbi tincidunt augue interdum &lt;/a&gt;velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.&lt;/p&gt;
+&lt;/section&gt;
+
+&lt;section class=&quot;well bg-dark bg-zev-purple&quot;&gt;
+  &lt;h4 class=&quot;text-white mrgn-tp-sm well-text&quot;&gt;This is a &lt;code&gt;.bg-zev-purple&lt;/code&gt; well&lt;/h4&gt;
+  &lt;p class=&quot;text-white&quot;&gt;Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. Mi sit amet mauris commodo quis imperdiet massa tincidunt nunc. &lt;a href=&quot;#&quot;&gt;Morbi tincidunt augue interdum &lt;/a&gt;velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.&lt;/p&gt;
+&lt;/section&gt;</code></pre>
+
+    
+    <h3 id="a3">Button example</h3>
+    <ul>
+      <li class="mrgn-bttm-sm"><a href="#" class="btn btn-default btn-zev-green">This is a button in the <code>.btn-zev-green</code> style</a></li>
+      <li class="mrgn-bttm-sm"><a href="#" class="btn btn-default btn-zev-purple">This is a button in the <code>.btn-zev-purple</code> style</a></li>
+    </ul>
+    <h4>Code</h4>
+    <pre><code>&lt;a href=&quot;#&quot; class=&quot;btn btn-default btn-zev-green&quot;&gt;This is a button in the &lt;code&gt;.btn-zev-green&lt;/code&gt; style&lt;/a&gt;
+&lt;a href=&quot;#&quot; class=&quot;btn btn-default btn-zev-purple&quot;&gt;This is a button in the &lt;code&gt;.btn-zev-purple&lt;/code&gt; style&lt;/a&gt;</code></pre>
+
+    <h3 id="a4">Panels example</h3>
+    <section class="panel panel-default panel-zev-green">
+      <header class="panel-heading">
+        <h4 class="panel-title">This is a <code>.panel-zev-green</code> panel </h4>
+      </header>
+      <div class="panel-body">
+        <p>Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. <a class="well-link" href="#">Morbi tincidunt augue interdum </a>velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.</p>
+      </div>
+    </section>
+    <section class="panel panel-default panel-zev-purple">
+      <header class="panel-heading">
+        <h4 class="panel-title">This is a <code>.panel-zev-purple</code> panel </h4>
+      </header>
+      <div class="panel-body">
+        <p>Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. <a class="well-link" href="#">Morbi tincidunt augue interdum </a>velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.</p>
+      </div>
+    </section>
+    <h4>Code</h4>
+    <pre><code>&lt;section class=&quot;panel panel-default panel-zev-green&quot;&gt;
+  &lt;header class=&quot;panel-heading&quot;&gt;
+    &lt;h4 class=&quot;panel-title&quot;&gt;This is a &lt;code&gt;.panel-zev-green&lt;/code&gt; panel &lt;/h4&gt;
+  &lt;/header&gt;
+  &lt;div class=&quot;panel-body&quot;&gt;
+    &lt;p&gt;Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. &lt;a class=&quot;well-link&quot; href=&quot;#&quot;&gt;Morbi tincidunt augue interdum &lt;/a&gt;velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/section&gt;
+
+&lt;section class=&quot;panel panel-default panel-zev-purple&quot;&gt;
+  &lt;header class=&quot;panel-heading&quot;&gt;
+    &lt;h4 class=&quot;panel-title&quot;&gt;This is a &lt;code&gt;.panel-zev-purple&lt;/code&gt; panel &lt;/h4&gt;
+  &lt;/header&gt;
+  &lt;div class=&quot;panel-body&quot;&gt;
+    &lt;p&gt;Integer feugiat scelerisque varius morbi enim nunc faucibus a. Vel eros donec ac odio tempor orci. &lt;a class=&quot;well-link&quot; href=&quot;#&quot;&gt;Morbi tincidunt augue interdum &lt;/a&gt;velit euismod in pellentesque massa. Eu tincidunt tortor aliquam nulla facilisi cras fermentum odio eu. Non enim praesent elementum facilisis leo vel fringilla est. Amet justo donec enim diam vulputate.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/section&gt;</code></pre>      
+
+</div>
+   


### PR DESCRIPTION
This pull request adds the th-zev folder and files to the meli-melo section so that it can be added to the theme for use.  Based on the th-canadaday example.

This compiles locally for me in jekyll so with luck it should work well for you.

There is no JS and the CSS is scoped to just the listed tags and implements the green and purple colours across background, butons, wells, and panels.

Thanks,
Eric