### PR TITLE
Provisional alert include: Simplify link destination

### DIFF
--- a/_includes/alert-provisional.html
+++ b/_includes/alert-provisional.html
@@ -3,13 +3,13 @@
 	<h2>Fonctionnalité instable</h2>
 	<p>À être utilisé <strong>à vos propres risques</strong>. Toutes les fonctionnalités décrites ci-dessous pourraient être retirées à n'importe quelle version mineur/majeur ultérieure et l'ensemble des fonctionnalités provisoires sont exclues de l'API publique de GCWeb.</p>
 	<p>La documentation et/ou les exemples pratiques pourraient être incomplets ou être non disponible.</p>
-	<p><a href="{{ include.provisionaldir }}provisional-fr.html">Voir l'ensemble des fonctionnalités provisoires.</a></p>
+	<p><a href="{{ "components/provisional-fr.html" | relative_url }}">Voir l'ensemble des fonctionnalités provisoires.</a></p>
 </div>
 {%- elsif page.language == "en" -%}
 <div class="alert alert-warning">
 	<h2>Unstable feature</h2>
 	<p>To be used at <strong>your own risks</strong>. All functionalities described below could be removed in any subsequent minor/major release and are excluded from the GCWeb public API.</p>
 	<p>Documentation and/or working examples for those features could be incomplete or not available.</p>
-	<p><a href="{{ include.provisionaldir }}provisional-en.html">See all provisional features.</a></p>
+	<p><a href="{{ "components/provisional-en.html" | relative_url }}">See all provisional features.</a></p>
 </div>
 {%- endif -%}

--- a/components/gc-featured-link/gc-featured-link-en.html
+++ b/components/gc-featured-link/gc-featured-link-en.html
@@ -9,7 +9,7 @@ layout: no-container
 <div class="container">
 	<h1>{{ page.title }}</h1>
 
-	{% include alert-provisional.html siteroot="../../" %}
+	{% include alert-provisional.html %}
 
 	<span class="wb-prettify all-pre hide"></span>
 

--- a/components/gc-featured-link/gc-featured-link-fr.html
+++ b/components/gc-featured-link/gc-featured-link-fr.html
@@ -9,7 +9,7 @@ layout: no-container
 <div class="container">
 	<h1>{{ page.title }}</h1>
 
-	{% include alert-provisional.html siteroot="../../" %}
+	{% include alert-provisional.html %}
 
 	<span class="wb-prettify all-pre hide"></span>
 

--- a/components/gc-feeds/gc-feeds-en.html
+++ b/components/gc-feeds/gc-feeds-en.html
@@ -8,7 +8,7 @@ language: "en"
 altLangPage: "gc-feeds-fr.html"
 title: "Feeds plugin GC override - Provisional feature"
 ---
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <span class="wb-prettify all-pre hide"></span>
 

--- a/components/gc-feeds/gc-feeds-fr.html
+++ b/components/gc-feeds/gc-feeds-fr.html
@@ -8,7 +8,7 @@ language: "fr"
 altLangPage: "gc-feeds-en.html"
 title: "Fils de syndication remplacement et application de styles GC - fonctionnalité provisoire"
 ---
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <span class="wb-prettify all-pre hide"></span>
 

--- a/components/gc-most-requested/gc-most-requested-en.html
+++ b/components/gc-most-requested/gc-most-requested-en.html
@@ -8,7 +8,7 @@ language: "en"
 altLangPage: "gc-most-requested-fr.html"
 title: "Most requested - Provisional feature"
 ---
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <span class="wb-prettify all-pre hide"></span>
 

--- a/components/gc-most-requested/gc-most-requested-fr.html
+++ b/components/gc-most-requested/gc-most-requested-fr.html
@@ -8,7 +8,7 @@ language: "fr"
 altLangPage: "gc-most-requested-en.html"
 title: "En demande - fonctionnalité provisoire"
 ---
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <span class="wb-prettify all-pre hide"></span>
 

--- a/components/gc-subway/aem-bad-implementation-en.html
+++ b/components/gc-subway/aem-bad-implementation-en.html
@@ -14,7 +14,7 @@
 	<p>This implementation of the GC-Subway plugin is deprecated and will be removed shortly.</p>
 </div>
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/aem-bad-implementation-fr.html
+++ b/components/gc-subway/aem-bad-implementation-fr.html
@@ -14,7 +14,7 @@
 	<p>Cette implémentation du plugiciel GC-Subway est obsolète et sera bientôt supprimée.</p>
 </div>
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/docs-en.html
+++ b/components/gc-subway/docs-en.html
@@ -8,7 +8,7 @@
 	"share": "true"
 }
 ---
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <div class="wb-prettify all-pre hide"></div>
 

--- a/components/gc-subway/docs-fr.html
+++ b/components/gc-subway/docs-fr.html
@@ -8,7 +8,7 @@
 	"share": "true"
 }
 ---
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <div class="wb-prettify all-pre hide"></div>
 

--- a/components/gc-subway/index-en.html
+++ b/components/gc-subway/index-en.html
@@ -10,7 +10,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <h1 property="name" id="wb-cont" class="gc-thickline">GC Subway index</h1>
 

--- a/components/gc-subway/index-fr.html
+++ b/components/gc-subway/index-fr.html
@@ -10,7 +10,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 <h1 property="name" id="wb-cont" class="gc-thickline">Page d'introduction de GC Métro</h1>
 

--- a/components/gc-subway/section-rel-info-en.html
+++ b/components/gc-subway/section-rel-info-en.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section-rel-info-fr.html
+++ b/components/gc-subway/section-rel-info-fr.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section-subtitle-en.html
+++ b/components/gc-subway/section-subtitle-en.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section-subtitle-fr.html
+++ b/components/gc-subway/section-subtitle-fr.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section1-en.html
+++ b/components/gc-subway/section1-en.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section1-fr.html
+++ b/components/gc-subway/section1-fr.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section2-en.html
+++ b/components/gc-subway/section2-en.html
@@ -10,7 +10,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/section2-fr.html
+++ b/components/gc-subway/section2-fr.html
@@ -10,7 +10,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/sub-section-en.html
+++ b/components/gc-subway/sub-section-en.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/sub-section-fr.html
+++ b/components/gc-subway/sub-section-fr.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/sub-section-noline-en.html
+++ b/components/gc-subway/sub-section-noline-en.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-subway/sub-section-noline-fr.html
+++ b/components/gc-subway/sub-section-noline-fr.html
@@ -9,7 +9,7 @@
 }
 ---
 
-{% include alert-provisional.html siteroot="../../" %}
+{% include alert-provisional.html %}
 
 {%- include_relative fragments/docs-questions.html -%}
 

--- a/components/gc-table/gc-table-en.html
+++ b/components/gc-table/gc-table-en.html
@@ -11,7 +11,7 @@
 	"title": "GC tables"
 }
 ---
-{% include alert-provisional.html provisionaldir="../" %}
+{% include alert-provisional.html %}
 <span class="wb-prettify all-pre hide"></span>
 
 <dl class="horizontal">

--- a/components/gc-table/gc-table-fr.html
+++ b/components/gc-table/gc-table-fr.html
@@ -11,7 +11,7 @@
 	"title": "Tableaux GC"
 }
 ---
-{% include alert-provisional.html provisionaldir="../" %}
+{% include alert-provisional.html %}
 <span class="wb-prettify all-pre hide"></span>
 
 <dl class="horizontal">

--- a/components/wb-chtwzrd/chatwizard-en.html
+++ b/components/wb-chtwzrd/chatwizard-en.html
@@ -9,7 +9,7 @@ altLangPage: "chatwizard-fr.html"
 dateModified: "2022-08-25"
 ---
 
-{% include alert-provisional.html provisionaldir="../" %}
+{% include alert-provisional.html %}
 
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="docs.html">Documentation</a></li>

--- a/components/wb-chtwzrd/chatwizard-fr.html
+++ b/components/wb-chtwzrd/chatwizard-fr.html
@@ -8,7 +8,7 @@ parentdir: "chatwizard"
 altLangPage: "chatwizard-en.html"
 dateModified: "2022-08-25"
 ---
-{% include alert-provisional.html provisionaldir="../" %}
+{% include alert-provisional.html %}
 
 <div class="wb-prettify all-pre"></div>
 

--- a/components/wb-chtwzrd/chatwizard-json-en.html
+++ b/components/wb-chtwzrd/chatwizard-json-en.html
@@ -8,7 +8,7 @@ parentdir: "chatwizard"
 altLangPage: "chatwizard-json-fr.html"
 dateModified: "2022-08-25"
 ---
-{% include alert-provisional.html provisionaldir="../" %}
+{% include alert-provisional.html %}
 
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="docs.html">Documentation</a></li>

--- a/components/wb-chtwzrd/chatwizard-json-fr.html
+++ b/components/wb-chtwzrd/chatwizard-json-fr.html
@@ -8,7 +8,7 @@ parentdir: "chatwizard"
 altLangPage: "chatwizard-json-en.html"
 dateModified: "2022-08-25"
 ---
-{% include alert-provisional.html provisionaldir="../" %}
+{% include alert-provisional.html %}
 
 <div class="wb-prettify all-pre"></div>
 

--- a/templates/thematic/dark-theme-en.html
+++ b/templates/thematic/dark-theme-en.html
@@ -12,5 +12,5 @@
 	"share": "true"
 }
 ---
-{% include alert-provisional.html provisionaldir="../../components/" %}
+{% include alert-provisional.html %}
 {% include web-contents/placeholdercontent-en.html %}

--- a/templates/thematic/dark-theme-fr.html
+++ b/templates/thematic/dark-theme-fr.html
@@ -12,5 +12,5 @@
 	"share": "true"
 }
 ---
-{% include alert-provisional.html provisionaldir="../../components/" %}
+{% include alert-provisional.html %}
 {% include web-contents/placeholdercontent-fr.html %}

--- a/templates/thematic/pink-day-en.html
+++ b/templates/thematic/pink-day-en.html
@@ -12,7 +12,7 @@
 	"share": "true"
 }
 ---
-{% include alert-provisional.html provisionaldir="../../components/" %}
+{% include alert-provisional.html %}
 {% include web-contents/placeholdercontent-en.html %}
 
 <h2>Home page banner sample</h2>

--- a/templates/thematic/pink-day-fr.html
+++ b/templates/thematic/pink-day-fr.html
@@ -12,7 +12,7 @@
 	"share": "true"
 }
 ---
-{% include alert-provisional.html provisionaldir="../../components/" %}
+{% include alert-provisional.html %}
 {% include web-contents/placeholdercontent-fr.html %}
 
 <h2>Example de la page d'accueil</h2>


### PR DESCRIPTION
* Use the ``relative_url`` Liquid filter for the provisional page's link destination (makes it relative to ``baseurl``)
* Remove the ``provisionaldir`` and ``siteroot`` variables
* Fixes broken links caused by incorrect relative paths
* Spinoff of #2179