### PR TITLE
Colour: WGAG 2.1 AA Pre-Assessment

### DIFF
--- a/common/colour/index.json-ld
+++ b/common/colour/index.json-ld
@@ -32,14 +32,14 @@
 		],
 		"reports": [
 			{
-				"title": "Pre accessibility assessment #2 - Color",
+				"title": "Accessibility assessment #2 - Color",
 				"language": "en",
-				"path": "reports/pre-ally-2-en.html"
+				"path": "reports/ally-2-en.html"
 			},
 			{
-				"title": "Pre assessment d'accessibilité #2 - Couleur",
+				"title": "Assessment d'accessibilité #2 - Couleur",
 				"language": "fr",
-				"path": "reports/pre-ally-2-fr.html"
+				"path": "reports/ally-2-fr.html"
 			}
 		]
 	}

--- a/common/colour/reports/a11y-2-en.html
+++ b/common/colour/reports/a11y-2-en.html
@@ -1,15 +1,15 @@
 ---
 {
-	"title": "Pre accessibility assessment #2 - Colour",
+	"title": "Accessibility assessment #2 - Colour",
 	"language": "en",
 	"description": "Evaluation of how various text appears on different backgrounds.",
 	"tag": "colour",
 	"parentdir": "colour",
 	"parentPage": "Colour",
 	"parentPageURL": "colour",
-	"altLangPage": "pre-a11y-2-fr.html",
-	"dateModified": "2023-08-16",
+	"altLangPage": "a11y-2-fr.html",
+	"dateModified": "2023-10-26",
 	"layout": "assessment_wrote_en-en",
-	"reportURL": "pre-a11y-2.json"
+	"reportURL": "a11y-2.json"
 }
 ---

--- a/common/colour/reports/a11y-2-fr.html
+++ b/common/colour/reports/a11y-2-fr.html
@@ -1,15 +1,15 @@
 ---
 {
-	"title": "Pre assessment d'accessibilité #1 - Couleur",
+	"title": "Assessment d'accessibilité #1 - Couleur",
 	"language": "fr",
 	"description": "Évaluation de la façon dont divers textes apparaissent sur différents arrière-plans.",
 	"tag": "couleur",
 	"parentdir": "couleur",
 	"parentPage": "Couleur",
 	"parentPageURL": "couleur",
-	"altLangPage": "pre-a11y-2-en.html",
-	"dateModified": "2023-08-16",
+	"altLangPage": "a11y-2-en.html",
+	"dateModified": "2023-10-26",
 	"layout": "assessment_wrote_en-fr",
-	"reportURL": "pre-a11y-2.json"
+	"reportURL": "a11y-2.json"
 }
 ---

--- a/common/colour/reports/a11y-2.json
+++ b/common/colour/reports/a11y-2.json
@@ -28,8 +28,8 @@
     }
   },
 
-  "dct:date": "2023-08-16",
-  "dct:description": "Analyzing and exploring the subject and produce a pre-evaluation of all WCAG 2.1 SC at level AA.",
+  "dct:date": "2023-10-26",
+  "dct:description": "Analyzing and exploring the subject and produce an evaluation of all WCAG 2.1 SC at level AA.",
   "acr:involvesExpertise": [],
 
   "dct:source": "act:rulesets/wcag2x/wcag21_all_levelAA.json",
@@ -39,7 +39,7 @@
   "earl:result": [
     {
       "earl:test": "WCAG21:non-text-content",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "earl:subject": "_:subject",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
@@ -88,7 +88,7 @@
     {
       "earl:test": "WCAG21:info-and-relationships",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -96,7 +96,7 @@
     {
       "earl:test": "WCAG21:meaningful-sequence",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -104,7 +104,7 @@
     {
       "earl:test": "WCAG21:sensory-characteristics",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -112,7 +112,7 @@
     {
       "earl:test": "WCAG21:orientation",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -128,7 +128,7 @@
     {
       "earl:test": "WCAG21:use-of-color",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -144,7 +144,7 @@
     {
       "earl:test": "WCAG21:contrast-minimum",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -152,7 +152,7 @@
     {
       "earl:test": "WCAG21:resize-text",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -168,7 +168,7 @@
     {
       "earl:test": "WCAG21:reflow",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -176,7 +176,7 @@
     {
       "earl:test": "WCAG21:non-text-contrast",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -184,7 +184,7 @@
     {
       "earl:test": "WCAG21:text-spacing",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -192,7 +192,7 @@
     {
       "earl:test": "WCAG21:content-on-hover-or-focus",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -200,7 +200,7 @@
     {
       "earl:test": "WCAG21:keyboard",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -208,7 +208,7 @@
     {
       "earl:test": "WCAG21:no-keyboard-trap",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -216,7 +216,7 @@
     {
       "earl:test": "WCAG21:character-key-shortcuts",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -240,7 +240,7 @@
     {
       "earl:test": "WCAG21:three-flashes-or-below-threshold",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -248,7 +248,7 @@
     {
       "earl:test": "WCAG21:bypass-blocks",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -256,7 +256,7 @@
     {
       "earl:test": "WCAG21:page-titled",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -264,7 +264,7 @@
     {
       "earl:test": "WCAG21:focus-order",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -272,7 +272,7 @@
     {
       "earl:test": "WCAG21:link-purpose-in-context",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -280,7 +280,7 @@
     {
       "earl:test": "WCAG21:multiple-ways",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -288,7 +288,7 @@
     {
       "earl:test": "WCAG21:headings-and-labels",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -296,7 +296,7 @@
     {
       "earl:test": "WCAG21:focus-visible",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -312,7 +312,7 @@
     {
       "earl:test": "WCAG21:pointer-cancellation",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -320,7 +320,7 @@
     {
       "earl:test": "WCAG21:label-in-name",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -336,7 +336,7 @@
     {
       "earl:test": "WCAG21:language-of-page",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -344,7 +344,7 @@
     {
       "earl:test": "WCAG21:language-of-parts",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -352,7 +352,7 @@
     {
       "earl:test": "WCAG21:on-focus",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -360,7 +360,7 @@
     {
       "earl:test": "WCAG21:on-input",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -368,7 +368,7 @@
     {
       "earl:test": "WCAG21:consistent-navigation",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -376,7 +376,7 @@
     {
       "earl:test": "WCAG21:consistent-identification",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -384,7 +384,7 @@
     {
       "earl:test": "WCAG21:error-identification",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -392,7 +392,7 @@
     {
       "earl:test": "WCAG21:labels-or-instructions",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -400,7 +400,7 @@
     {
       "earl:test": "WCAG21:error-suggestion",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -408,7 +408,7 @@
     {
       "earl:test": "WCAG21:error-prevention-legal-financial-data)",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -416,7 +416,7 @@
     {
       "earl:test": "WCAG21:parsing",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -424,7 +424,7 @@
     {
       "earl:test": "WCAG21:name-role-value",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -432,7 +432,7 @@
     {
       "earl:test": "WCAG21:status-messages",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]


### PR DESCRIPTION
### This pull request includes the WCAG 2.1 Accessibility pre-assessments done for the Color (Foreground/Background) GCWeb page.


General checklist
- [ ] Updated Colour documentation to include the accessibility pre-assessment reports
- [ ] Colour was pre-assessed against WCAG for accessibility
- [ ] Documentation is bilingual 
