### PR TITLE
gc-features: removing 'text-decoration: none' on hover

### DIFF
--- a/components/gc-features/_base.scss
+++ b/components/gc-features/_base.scss
@@ -13,10 +13,6 @@
 
 	margin-bottom: $space-md;
 
-	a:hover {
-		text-decoration: none;
-	}
-
 	img {
 		width: 100%;
 		}


### PR DESCRIPTION
Re-applying the underline on hover of gc-features. New PR on WET applying box shadow to panels and wells containing a stretched-link.

Dependent on https://github.com/wet-boew/wet-boew/pull/9614 being merged.