### PR TITLE
Page feedback: fixing global GCWeb-Jekyll feedback url

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -557,12 +557,12 @@ module.exports = (grunt) ->
 			#	src: "_includes/settings.liquid"
 			jekyllRunLocal:
 				options:
-					banner: """{%- assign setting-resourcesBasePathTheme = "/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/<%= distFolder %>/wet-boew" -%}{%- assign setting-root = "" -%}"""
+					banner: """{%- assign setting-resourcesBasePathTheme = "/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/<%= distFolder %>/wet-boew" -%}"""
 					position: "bottom"
 				src: "<%= jekyllDist %>/_includes/settings.liquid"
 			jekyllRunDemo:
 				options:
-					banner: """{%- assign setting-resourcesBasePathTheme = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/wet-boew" -%}{%- assign setting-root = "/wet-boew-demos/""" + grunt.option('branch') + """ -%}"""
+					banner: """{%- assign setting-resourcesBasePathTheme = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/wet-boew" -%}"""
 					position: "bottom"
 				src: "<%= jekyllDist %>/_includes/settings.liquid"
 			jekyllRunUnminified:

--- a/sites/feedback/includes/feedback.html
+++ b/sites/feedback/includes/feedback.html
@@ -2,7 +2,7 @@
 	{%- if page.feedbackPath -%}
 		{{ page.feedbackPath }}
 	{%- elsif site.global.feedbackPath and site.global.feedbackPath.first -%}
-		{{ setting-root }}{{ site.global.feedbackPath[ i18nText-lang ] }}
+		{{ site.global.feedbackPath[ i18nText-lang ] }}
 	{%- endif -%}
 {%- endcapture -%}
 {%- capture feedbackFallback -%}

--- a/sites/includes/settings.liquid
+++ b/sites/includes/settings.liquid
@@ -12,4 +12,3 @@
 	https://wet-boew.github.io/themes-dist/GCWeb/{{ setting-packageName }}
 {%- endcapture -%}
 {%- assign setting-resourcesBasePathWetboew = "https://wet-boew.github.io/themes-dist/GCWeb/wet-boew" -%}
-{%- assign setting-root = "/GCWeb" -%}


### PR DESCRIPTION
Page feedback global URL was adding `/GCWeb` since the URL was relative at some point. Since it is now absolute, there is no need for this logic.