### PR TITLE
GC Tables: Improve display for empty cells

### DIFF
--- a/components/gc-table/_screen-sm-max.scss
+++ b/components/gc-table/_screen-sm-max.scss
@@ -92,7 +92,7 @@ $gc-tables-tr-margin-vertical: .625em;
 			}
 		}
 		td {
-			display: block;
+			display: flow-root;
 			font-size: 1em;
 			text-align: right;
 			&::before {

--- a/components/gc-table/gc-table-en.html
+++ b/components/gc-table/gc-table-en.html
@@ -81,6 +81,12 @@
 			<td data-label="Population in 2017">1,377,016 </td>
 			<td data-label="Percentage change">15.9%</td>
 		</tr>
+		<tr>
+			<td data-label="City">Calgary</td>
+			<td data-label="Population in 2007"></td>
+			<td data-label="Population in 2017">1,246,337</td>
+			<td data-label="Percentage change">N/A</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/components/gc-table/gc-table-fr.html
+++ b/components/gc-table/gc-table-fr.html
@@ -83,6 +83,12 @@
 			<td data-label="Population in 2017">1,377,016 </td>
 			<td data-label="Percentage change">15.9%</td>
 		</tr>
+		<tr>
+			<td data-label="City">Calgary</td>
+			<td data-label="Population in 2007"></td>
+			<td data-label="Population in 2017">1,246,337</td>
+			<td data-label="Percentage change">N/A</td>
+		</tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
Fixed display issue when table cell is empty. Previously looked like this (with overlapping):
<img width="594" alt="gc-table-before" src="https://github.com/wet-boew/GCWeb/assets/4353199/d568e7fc-ea8d-4df5-bff1-4a35d7293bad">

Now looks like this with a new table row added for working example purposes:
<img width="494" alt="gc-table-after" src="https://github.com/wet-boew/GCWeb/assets/4353199/f6105612-9dab-4984-a450-7e8598be1a38">

The `flow-root` property allows for an element to preallocate its height as-if there was always a text value in it, and is supported by all major browsers. I tested Safari, Chrome and Firefox and everything looked good. No side effect on the existing examples.

I kept the GC Tables as a Provisional feature.