### PR TITLE
docs: Update guidance links in feedback docs

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -254,8 +254,8 @@
 				"fr": "La variante de l'Outil de rétroaction sur la page remplace le modèle « Signaler un problème » tout en collectant activement les commentaires des utilisateurs."
 			},
 			"guidance": {
-				"en": "https://design.canada.ca/continuous-improvement/monitoring/feedback.html",
-				"fr": "https://conception.canada.ca/amelioration-continue/mesure/retroaction.html"
+				"en": "https://design.canada.ca/feedback/index.html",
+				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
 			"iteration": "_:iteration_pft_1",
 			"example": [
@@ -286,8 +286,8 @@
 				"fr": "La variante de l'Outil de rétroaction sur la page avec lien de contact remplace le modèle « Signaler un problème » tout en collectant activement les commentaires des utilisateurs."
 			},
 			"guidance": {
-				"en": "https://design.canada.ca/continuous-improvement/monitoring/feedback.html",
-				"fr": "https://conception.canada.ca/amelioration-continue/mesure/retroaction.html"
+				"en": "https://design.canada.ca/feedback/index.html",
+				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
 			"iteration": "_:iteration_pft_1",
 			"example": [

--- a/sites/feedback/index.json-ld
+++ b/sites/feedback/index.json-ld
@@ -80,8 +80,8 @@
 				"fr": "La variante de l'Outil de rétroaction sur la page remplace le modèle « Signaler un problème » tout en collectant activement les commentaires des utilisateurs."
 			},
 			"guidance": {
-				"en": "https://design.canada.ca/continuous-improvement/monitoring/feedback.html",
-				"fr": "https://conception.canada.ca/amelioration-continue/mesure/retroaction.html"
+				"en": "https://design.canada.ca/feedback/index.html",
+				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
 			"iteration": "_:iteration_pft_1",
 			"example": [
@@ -112,8 +112,8 @@
 				"fr": "La variante de l'Outil de rétroaction sur la page avec lien de contact remplace le modèle « Signaler un problème » tout en collectant activement les commentaires des utilisateurs."
 			},
 			"guidance": {
-				"en": "https://design.canada.ca/continuous-improvement/monitoring/feedback.html",
-				"fr": "https://conception.canada.ca/amelioration-continue/mesure/retroaction.html"
+				"en": "https://design.canada.ca/feedback/index.html",
+				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
 			"iteration": "_:iteration_pft_1",
 			"example": [


### PR DESCRIPTION
---
name: Update guidance links in feedback docs
about: This is a pull request to change the links to the feedback guidance in the design system.
title: 'docs: Update guidance links in feedback docs'
labels: 'documentation'
assignees: 'delisma'
---

## What does this pull request do?
Update guidance links for the feedback docs in sites.json and index.json-ld. From `https://design.canada.ca/continuous-improvement/monitoring/feedback.html` to `https://design.canada.ca/feedback/index.html` and `https://conception.canada.ca/amelioration-continue/mesure/retroaction.html` to `https://conception.canada.ca/retroaction/index.html`

## General checklist

- [x] [Documentation](README.md) created/updated
- [x] Changelog entry added, if necessary

## Related issues
n/a