### PR TITLE
Fonts: fixing font loading

### DIFF
--- a/sites/baseline/_font.scss
+++ b/sites/baseline/_font.scss
@@ -106,7 +106,7 @@
 }
 /* latin */
 @font-face {
-	font-display: optional;
+	font-display: fallback;
 	font-family: "Lato";
 	font-style: italic;
 	font-weight: 400;
@@ -142,7 +142,7 @@
 }
 /* latin */
 @font-face {
-	font-display: optional;
+	font-display: fallback;
 	font-family: "Lato";
 	font-style: normal;
 	font-weight: 400;


### PR DESCRIPTION
Fixing Lato font loading issue when cache is cleared or accessing site for the first time.

`font-display: fallback;` allows 3 seconds to load the font.