### PR TITLE
Archive notice update to fix issues with overlay

### DIFF
--- a/sites/headers-includes/archive.html
+++ b/sites/headers-includes/archive.html
@@ -1,13 +1,4 @@
-<section class="gc-archv wb-inview modal-content show-none bar-demo" data-inview="top-bar">
-	<div class="container">
+<section class="container gc-archv wb-inview modal-content show-none bar-demo" data-inview="top-bar">
 	<h2>{{ i18nText-archived }}</h2>
 	<p>{{ i18nText-archived-desc }}</p>
-	</div>
-</section>
-
-<section id="top-bar" class="gc-archv wb-overlay modal-content overlay-def wb-bar-t">
-	<div class="container">
-	<h2>{{ i18nText-archived }}</h2>
-	<p>{{ i18nText-archived-desc }}</p>
-	</div>
 </section>


### PR DESCRIPTION
Removed the overlay from the Archive notice, and the width now matches the width of header.

Instead of fixing the overlay and moving code around, we decided to remove the overlay entirely, so that we didn't have to fix the following 3 issues:

1. overlay must not cause a horizontal scroll bar
2. close button must be visible on all screen sizes
3. user must be able to use Tab key to close overlay


Issue 1: At around 800 pixel width, the overlay “x” button to close is not visible on certain devices.
 
Screenshot of missing close button
![image](https://github.com/wet-boew/GCWeb/assets/15619641/38ab7657-d8cb-4a6b-aa1a-8e0fb7d709e2)
 
Screenshot of visible close button on smaller device/width 
![image](https://github.com/wet-boew/GCWeb/assets/15619641/a1329649-b974-43ce-9ccc-3eaee161d3ff)
 
Screenshot of visible close button on larger device/width
![image](https://github.com/wet-boew/GCWeb/assets/15619641/fe0001a2-3721-4f8f-81b2-b64e029ec983)
 
 
Issue 2: Horizontal scroll bar around the same screen size where the close button disappears.
![image](https://github.com/wet-boew/GCWeb/assets/15619641/bafdb28a-dc34-4722-ae26-02470f8abe1d)

 
