### PR TITLE
Breadcrumbs: adding GCWeb Home globally

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -662,12 +662,12 @@ module.exports = (grunt) ->
 			#	src: "_includes/settings.liquid"
 			jekyllRunLocal:
 				options:
-					banner: """{%- assign setting-resourcesBasePathTheme = "/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/<%= distFolder %>/wet-boew" -%}"""
+					banner: """{%- assign setting-resourcesBasePathTheme = "/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/<%= distFolder %>/wet-boew" -%}{%- assign setting-siteBasePath = "/" -%}"""
 					position: "bottom"
 				src: "<%= jekyllDist %>/_includes/settings.liquid"
 			jekyllRunDemo:
 				options:
-					banner: """{%- assign setting-resourcesBasePathTheme = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/wet-boew" -%}"""
+					banner: """{%- assign setting-resourcesBasePathTheme = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/GCWeb" -%}{%- assign setting-resourcesBasePathWetboew = "/wet-boew-demos/""" + grunt.option('branch') + """/<%= distFolder %>/wet-boew" -%}{%- assign setting-siteBasePath = "/wet-boew-demos/""" + grunt.option('branch') + """/" -%}"""
 					position: "bottom"
 				src: "<%= jekyllDist %>/_includes/settings.liquid"
 			jekyllRunUnminified:

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,13 @@ global:
   privacyUrl:
     en: "https://www.canada.ca/en/transparency/privacy.html"
     fr: "https://www.canada.ca/fr/transparence/confidentialite.html"
+  breadcrumbs:
+    en:
+      - link: "index-en.html"
+        title: "GCWeb"
+    fr:
+      - link: "index-fr.html"
+        title: "GCWeb"
 
 #
 # Override include to use

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -668,8 +668,8 @@
 				"fr": "Standard (wet-boew)"
 			},
 			"introduction": {
-				"en": "This implementation is meant for developers/publishers adding the component manually while using the latest version of GCWeb along with the implementation of the page details version 2.0 and above.",
-				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement en utilisant la dernière version de GCWeb avec l'implémentation de la version 2.0 ou plus du détails de la page."
+				"en": "This implementation is meant for developers/publishers adding the component manually while using the latest version of GCWeb along with the implementation of the page details version 3.0 and above.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement en utilisant la dernière version de GCWeb avec l'implémentation de la version 3.0 ou plus du détails de la page."
 			},
 			"instructions": {
 				"en": [
@@ -824,8 +824,8 @@
 				"fr": "Standard (WET-BOEW)"
 			},
 			"introduction": {
-				"en": "This implementation is meant for developers/publishers adding the component manually while using the latest version of GCWeb along with the implementation of the page details version 2.0 and above.",
-				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement en utilisant la dernière version de GCWeb avec l'implémentation de la version 2.0 ou plus du détails de la page."
+				"en": "This implementation is meant for developers/publishers adding the component manually while using the latest version of GCWeb along with the implementation of the page details version 3.0 and above.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement en utilisant la dernière version de GCWeb avec l'implémentation de la version 3.0 ou plus du détails de la page."
 			},
 			"instructions": {
 				"en": [

--- a/common/ajax-fetch/ajax-fetch-en.html
+++ b/common/ajax-fetch/ajax-fetch-en.html
@@ -3,9 +3,6 @@
 	"title": "Ajax Fetch",
 	"language": "en",
 	"altLangPage": "ajax-fetch-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-08-25"
 }
 ---

--- a/common/ajax-fetch/ajax-fetch-fr.html
+++ b/common/ajax-fetch/ajax-fetch-fr.html
@@ -3,9 +3,6 @@
 	"title": "Récupération de ressource via Ajax",
 	"language": "fr",
 	"altLangPage": "ajax-fetch-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-08-25"
 }
 ---

--- a/common/alert/alerts-en.html
+++ b/common/alert/alerts-en.html
@@ -3,9 +3,6 @@
 	"title": "GCWeb Alert example",
 	"language": "en",
 	"altLangPage": "alerts-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-02-28"
 }
 ---

--- a/common/alert/alerts-fr.html
+++ b/common/alert/alerts-fr.html
@@ -3,9 +3,6 @@
 	"title": "GCWeb Alert example",
 	"language": "fr",
 	"altLangPage": "alerts-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-02-28"
 }
 ---

--- a/common/list/list-group-en.html
+++ b/common/list/list-group-en.html
@@ -3,9 +3,6 @@
 	"title": "List group",
 	"language": "en",
 	"altLangPage": "list-group-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-03-05"
 }
 ---

--- a/common/list/list-group-fr.html
+++ b/common/list/list-group-fr.html
@@ -3,9 +3,6 @@
 	"title": "Liste groupé",
 	"language": "fr",
 	"altLangPage": "list-group-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-03-05"
 }
 ---

--- a/common/list/lists-en.html
+++ b/common/list/lists-en.html
@@ -3,9 +3,6 @@
 	"title": "Lists",
 	"language": "en",
 	"altLangPage": "lists-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-03-05"
 }
 ---

--- a/common/list/lists-fr.html
+++ b/common/list/lists-fr.html
@@ -3,9 +3,6 @@
 	"title": "Listes",
 	"language": "fr",
 	"altLangPage": "lists-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-03-05"
 }
 ---

--- a/common/scaffolding/forms.html
+++ b/common/scaffolding/forms.html
@@ -3,9 +3,6 @@
 	"title": "Forms - Scaffolding",
 	"language": "en",
 	"altLangPage": "formulaires.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-02-20"
 }
 ---

--- a/common/scaffolding/formulaires.html
+++ b/common/scaffolding/formulaires.html
@@ -3,9 +3,6 @@
 	"title": "Formulaires - Échafaudage",
 	"language": "fr",
 	"altLangPage": "forms.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb accueil", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-02-20"
 }
 ---

--- a/common/tables/table-en.html
+++ b/common/tables/table-en.html
@@ -3,9 +3,6 @@
 	"title": "Tables",
 	"language": "en",
 	"altLangPage": "table-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-02-28"
 }
 ---

--- a/common/tables/table-fr.html
+++ b/common/tables/table-fr.html
@@ -3,9 +3,6 @@
 	"title": "Tables",
 	"language": "fr",
 	"altLangPage": "table-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-02-28"
 }
 ---

--- a/common/wb-disable/wb-disable-en.html
+++ b/common/wb-disable/wb-disable-en.html
@@ -3,9 +3,6 @@
 	"title": "Basic HTML",
 	"language": "en",
 	"altLangPage": "wb-disable-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-08-25"
 }
 ---

--- a/common/wb-disable/wb-disable-fr.html
+++ b/common/wb-disable/wb-disable-fr.html
@@ -3,9 +3,6 @@
 	"title": "HTML simplifié",
 	"language": "fr",
 	"altLangPage": "wb-disable-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-08-25"
 }
 ---

--- a/components/gc-dwnld/download_link-en.html
+++ b/components/gc-dwnld/download_link-en.html
@@ -3,9 +3,6 @@
 	"title": "Download link example",
 	"language": "en",
 	"altLangPage": "download_link-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-04-20"
 }
 ---

--- a/components/gc-dwnld/download_link-fr.html
+++ b/components/gc-dwnld/download_link-fr.html
@@ -3,9 +3,6 @@
 	"title": "Lien de téléchargement",
 	"language": "fr",
 	"altLangPage": "download_link-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-04-20"
 }
 ---

--- a/components/gc-feeds/gc-feeds-en.html
+++ b/components/gc-feeds/gc-feeds-en.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
-]
 dateModified: "2021-06-02"
 description: "Documentation and working example of a GC override to the feeds plugin  - provisional feature"
 language: "en"

--- a/components/gc-feeds/gc-feeds-fr.html
+++ b/components/gc-feeds/gc-feeds-fr.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
-]
 dateModified: "2021-06-02"
 description: "Documentation et exemple pratique d'un remplacement et application de styles GC au plugiciel de fils de syndication - fonctionnalité provisoire"
 language: "fr"

--- a/components/gc-most-requested/gc-most-requested-en.html
+++ b/components/gc-most-requested/gc-most-requested-en.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
-]
 dateModified: "2021-05-21"
 description: "Documentation and working example for most requested - provisional feature"
 language: "en"

--- a/components/gc-most-requested/gc-most-requested-fr.html
+++ b/components/gc-most-requested/gc-most-requested-fr.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
-]
 dateModified: "2021-05-21"
 description: "Documentation et exemple pratique de en demande- fonctionnalité provisoire"
 language: "fr"

--- a/components/gc-servinfo/gc-srvinfo-examples.html
+++ b/components/gc-servinfo/gc-srvinfo-examples.html
@@ -3,7 +3,6 @@
 	"title": "Services and information - Working examples",
 	"language": "en",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" },
 		{ "title": "gc-srvinfo", "link": "components/gc-servinfo/gc-srvinfo.html" }
 	],
 	"secondlevel": false,

--- a/components/gc-servinfo/gc-srvinfo.html
+++ b/components/gc-servinfo/gc-srvinfo.html
@@ -2,9 +2,6 @@
 {
 	"title": "Services and information - Common design pattern",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-01-08",
 	"share": "true"

--- a/components/gc-stp-stp/gc-stp-stp-en.html
+++ b/components/gc-stp-stp/gc-stp-stp-en.html
@@ -4,21 +4,20 @@
 	"secondTitle": "2. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "gc-stp-stp-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2023-09-05",
 	"share": "true",
 	"steps": [
-		{ "name": "1. [Step / section page name]", "link": "index-en.html" },
+		{ "name": "1. [Step / section page name]", "link": "#" },
 		{ "name": "2. [Step / section page name]", "isActive": true },
-		{ "name": "3. [Step / section page name]", "link": "page3-en.html" },
-		{ "name": "4. [Step / section page name]", "link": "page4-en.html" },
-		{ "name": "5. [Step / section page name]", "link": "page5-en.html" },
-		{ "name": "6. [Step / section page name]", "link": "page6-en.html" }
+		{ "name": "3. [Step / section page name]", "link": "#" },
+		{ "name": "4. [Step / section page name]", "link": "#" },
+		{ "name": "5. [Step / section page name]", "link": "#" },
+		{ "name": "6. [Step / section page name]", "link": "#" }
 	]
 }
 ---

--- a/components/gc-stp-stp/gc-stp-stp-fr.html
+++ b/components/gc-stp-stp/gc-stp-stp-fr.html
@@ -4,21 +4,20 @@
 	"secondTitle": "2. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "gc-stp-stp-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2023-09-05",
 	"share": "true",
 	"steps": [
-		{ "name": "1. [Nom de la page de la section ou de l’étape]", "link": "index-fr.html" },
+		{ "name": "1. [Nom de la page de la section ou de l’étape]", "link": "#" },
 		{ "name": "2. [Nom de la page de la section ou de l’étape]", "isActive": true },
-		{ "name": "3. [Nom de la page de la section ou de l’étape]", "link": "page3-fr.html" },
-		{ "name": "4. [Nom de la page de la section ou de l’étape]", "link": "page4-fr.html" },
-		{ "name": "5. [Nom de la page de la section ou de l’étape]", "link": "page5-fr.html" },
-		{ "name": "6. [Nom de la page de la section ou de l’étape]", "link": "page6-fr.html" }
+		{ "name": "3. [Nom de la page de la section ou de l’étape]", "link": "#" },
+		{ "name": "4. [Nom de la page de la section ou de l’étape]", "link": "#" },
+		{ "name": "5. [Nom de la page de la section ou de l’étape]", "link": "#" },
+		{ "name": "6. [Nom de la page de la section ou de l’étape]", "link": "#" }
 	]
 }
 ---

--- a/components/gc-table/gc-table-en.html
+++ b/components/gc-table/gc-table-en.html
@@ -2,8 +2,7 @@
 {
 	"altLangPage": "gc-table-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" },
-		{ "title": "Provisional functionality", "link": "https://wet-boew.github.io/themes-dist/GCWeb/provisional-en.html" }
+		{ "title": "Provisional functionality", "link": "components/provisional-en.html" }
 	],
 	"dateModified": "2021-06-16",
 	"description": "Simple responsive gc tables",

--- a/components/gc-table/gc-table-fr.html
+++ b/components/gc-table/gc-table-fr.html
@@ -2,8 +2,7 @@
 {
 	"altLangPage": "gc-table-en.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" },
-		{ "title": "Provisional functionality", "link": "https://wet-boew.github.io/themes-dist/GCWeb/provisional-fr.html" }
+		{ "title": "Provisional functionality", "link": "components/provisional-fr.html" }
 	],
 	"dateModified": "2021-06-16",
 	"description": "Tableau simple responsive pour le GC",

--- a/components/gc-toc/toc-en.html
+++ b/components/gc-toc/toc-en.html
@@ -3,9 +3,6 @@
 	"title": "In-page table of contents",
 	"language": "en",
 	"altLangPage": "toc-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-06-16"
 }
 ---

--- a/components/gc-toc/toc-fr.html
+++ b/components/gc-toc/toc-fr.html
@@ -3,9 +3,6 @@
 	"title": "Table des matières à l'intérieur de la page",
 	"language": "fr",
 	"altLangPage": "toc-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-06-16"
 }
 ---

--- a/components/header-rwd/well-header-rwd-en.html
+++ b/components/header-rwd/well-header-rwd-en.html
@@ -3,9 +3,6 @@
 	"title": "Well header responsive - GCWeb theme",
 	"language": "en",
 	"altLangPage": "well-header-rwd-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-09",
 	"share": "true"

--- a/components/header-rwd/well-header-rwd-fr.html
+++ b/components/header-rwd/well-header-rwd-fr.html
@@ -3,9 +3,6 @@
 	"title": "Entête well responsive - Thème de GCWeb",
 	"language": "fr",
 	"altLangPage": "well-header-rwd-en.html",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-09",
 	"share": "true"

--- a/components/labels/labels-en.html
+++ b/components/labels/labels-en.html
@@ -3,9 +3,6 @@
 	"title": "Labels",
 	"language": "en",
 	"altLangPage": "labels-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"description": "Labels are use to describe and highlight text-based (non-numerical) information.",
 	"dateModified": "2023-07-11"
 }

--- a/components/labels/labels-fr.html
+++ b/components/labels/labels-fr.html
@@ -3,9 +3,6 @@
 	"title": "Étiquettes",
 	"language": "fr",
 	"altLangPage": "labels-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"description": "Les étiquettes sont utilisés pour décrire et mettre en surbrillance des renseignements textuels (non numériques).",
 	"dateModified": "2023-07-11"
 }

--- a/components/list/list-en.html
+++ b/components/list/list-en.html
@@ -3,9 +3,6 @@
 	"title": "List - Additional styles - GCWeb theme V5",
 	"language": "en",
 	"altLangPage": "list-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-07-07",
 	"share": "true"

--- a/components/list/list-fr.html
+++ b/components/list/list-fr.html
@@ -3,9 +3,6 @@
 	"title": "Liste - Styles additionels - Thème de GCWeb V5",
 	"language": "fr",
 	"altLangPage": "list-en.html",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-07-07",
 	"share": "true"

--- a/components/provisional-en.html
+++ b/components/provisional-en.html
@@ -3,9 +3,6 @@
 	"title": "Provisional functionality - GCWeb theme",
 	"language": "en",
 	"altLangPage": "provisional-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-12-06",
 	"share": "true"

--- a/components/provisional-fr.html
+++ b/components/provisional-fr.html
@@ -3,9 +3,6 @@
 	"title": "Fonctionalités provisoires - Thème de GCWeb",
 	"language": "fr",
 	"altLangPage": "provisional-en.html",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-12-06",
 	"share": "true"

--- a/components/redacted-en.html
+++ b/components/redacted-en.html
@@ -3,9 +3,6 @@
 	"title": "Redacted text",
 	"language": "en",
 	"altLangPage": "redacted-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" }
-	],
 	"description": "Guidance on how to code redacted text.",
 	"dateModified": "2019-03-26"
 }

--- a/components/redacted-fr.html
+++ b/components/redacted-fr.html
@@ -3,9 +3,6 @@
 	"title": "Texte caviardé",
 	"language": "en",
 	"altLangPage": "redacted-en.html",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "index-fr.html" }
-	],
 	"description": "Ligne directrice sur le codage de texte caviarder (ou expurgé).",
 	"dateModified": "2019-03-26"
 }

--- a/components/well-bold/well-bold-doc-en.html
+++ b/components/well-bold/well-bold-doc-en.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
-]
 dateModified: "2022-04-28"
 description: "Documentation and working example for the well bold"
 language: "en"

--- a/components/well-bold/well-bold-doc-fr.html
+++ b/components/well-bold/well-bold-doc-fr.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
-]
 dateModified: "2022-04-28"
 description: "Documentation et exemple pratique d'une boîte grise en gras"
 language: "fr"

--- a/components/well-bold/well-bold-en.html
+++ b/components/well-bold/well-bold-en.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/home.html" }
-]
 dateModified: "2022-08-25"
 description: "Working example for the well bold"
 language: "en"

--- a/components/well-bold/well-bold-fr.html
+++ b/components/well-bold/well-bold-fr.html
@@ -1,7 +1,4 @@
 ---
-breadcrumbs: [
-	{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/accueil.html" }
-]
 dateModified: "2022-08-25"
 description: "Documentation et exemple pratique d'une boîte grise en gras"
 language: "fr"

--- a/docs/evaluation-report/1-accessibility.html
+++ b/docs/evaluation-report/1-accessibility.html
@@ -2,9 +2,6 @@
 {
 	"title": "1 - Accessibility assesment of GCWeb theme version 2",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2018-11-14",
 	"share": "true"

--- a/docs/evaluation-report/2-wetplugin-gcweb2.html
+++ b/docs/evaluation-report/2-wetplugin-gcweb2.html
@@ -2,9 +2,6 @@
 {
 	"title": "2 - Regression user acceptance testing of WET plugin for GCWeb theme version 2",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2018-11-16",
 	"share": "true"

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,9 +2,6 @@
 {
 	"title": "GCWeb theme - Meta information",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-09-12",
 	"share": "true"

--- a/docs/release/dev-build.html
+++ b/docs/release/dev-build.html
@@ -4,7 +4,6 @@
 	"description": "Developper build pre-release notes - Canada.ca theme (GCWeb)",
 	"language": "en",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/index-en.html
+++ b/docs/release/index-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "index-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/index-fr.html
+++ b/docs/release/index-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "index-en.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb accueil", "link": "index-fr.html" },
 		{ "title": "GCWeb thème", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v5.0-en.html
+++ b/docs/release/v5.0-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "v5.0-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v5.0-fr.html
+++ b/docs/release/v5.0-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "v5.0-en.html",
 	"breadcrumbs": [
-		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
 		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v5.1-en.html
+++ b/docs/release/v5.1-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "v5.1-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v5.1-fr.html
+++ b/docs/release/v5.1-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "v5.1-en.html",
 	"breadcrumbs": [
-		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
 		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v6.0-en.html
+++ b/docs/release/v6.0-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "v6.0-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v6.0-fr.html
+++ b/docs/release/v6.0-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "v6.0-en.html",
 	"breadcrumbs": [
-		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
 		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v6.1-en.html
+++ b/docs/release/v6.1-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "v6.1-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v6.1-fr.html
+++ b/docs/release/v6.1-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "v6.1-en.html",
 	"breadcrumbs": [
-		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
 		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v7.0-en.html
+++ b/docs/release/v7.0-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "v7.0-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v7.0-fr.html
+++ b/docs/release/v7.0-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "v7.0-en.html",
 	"breadcrumbs": [
-		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
 		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v8.0-en.html
+++ b/docs/release/v8.0-en.html
@@ -5,7 +5,6 @@
 	"language": "en",
 	"altLangPage": "v8.0-fr.html",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "GCWeb theme", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/release/v8.0-fr.html
+++ b/docs/release/v8.0-fr.html
@@ -5,7 +5,6 @@
 	"language": "fr",
 	"altLangPage": "v8.0-en.html",
 	"breadcrumbs": [
-		{ "title": "Accueil de GCWeb", "link": "index-fr.html" },
 		{ "title": "Thème de GCWeb", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/temp-v5issue.html
+++ b/docs/temp-v5issue.html
@@ -3,7 +3,6 @@
 	"title": "Temporary issue and todo list - GCWeb theme V5",
 	"language": "en",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "Theme meta", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/docs/test-case-1.html
+++ b/docs/test-case-1.html
@@ -2,9 +2,6 @@
 {
 	"title": "From examples - test cases",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-07-31",
 	"share": "true"

--- a/docs/test-menu.html
+++ b/docs/test-menu.html
@@ -2,9 +2,6 @@
 {
 	"title": "Menu - test",
 	"language": "fr",
-	"breadcrumbs": [
-		{ "title": "GCWeb accueil", "link": "index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-01-20",
 	"share": "true"

--- a/docs/v5-migration.html
+++ b/docs/v5-migration.html
@@ -4,7 +4,6 @@
 	"language": "en",
 	"languagetoggle": "false",
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "Theme meta", "link": "docs/index.html" }
 	],
 	"secondlevel": false,

--- a/index-en.md
+++ b/index-en.md
@@ -5,6 +5,7 @@ dateModified: 2023-11-15
 description: "Home page describing all the components of the Canada.ca theme, named GCWeb."
 layout: no-container
 language: en
+overwriteBreadcrumbs: true
 feedback: true
 css:
 - href: https://use.fontawesome.com/releases/v5.8.1/css/all.css

--- a/index-fr.md
+++ b/index-fr.md
@@ -5,6 +5,7 @@ dateModified: 2023-11-15
 description: "Page d'accueil décrivant l'ensemble des composants du thème de Canada.ca, nommé GCWeb."
 layout: no-container
 language: fr
+overwriteBreadcrumbs: true
 feedback: true
 css:
 - href: https://use.fontawesome.com/releases/v5.8.1/css/all.css

--- a/sites/breadcrumbs/breadcrumbs-en.html
+++ b/sites/breadcrumbs/breadcrumbs-en.html
@@ -1,10 +1,6 @@
 ---
 {
 	"altLangPage": "breadcrumbs-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" },
-		{ "title": "Méli-mélo", "link": "https://wet-boew.github.io/GCWeb/méli-mélo/méli-mélo-en.html" }
-	],
 	"dateModified": "2023-03-08",
 	"description": "Documentation on how to use breadcrumb trail.",
 	"language": "en",

--- a/sites/breadcrumbs/breadcrumbs-fr.html
+++ b/sites/breadcrumbs/breadcrumbs-fr.html
@@ -1,11 +1,6 @@
 ---
 {
 	"altLangPage": "breadcrumbs-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb accueil", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" },
-		{ "title": "Méli-mélo", "link": "https://wet-boew.github.io/GCWeb/méli-mélo/méli-mélo-fr.html" }
-
-	],
 	"dateModified": "2023-03-08",
 	"description": "Documentation sur l'utilisation du fil d'Ariane.",
 	"language": "fr",

--- a/sites/breadcrumbs/includes/breadcrumbs.html
+++ b/sites/breadcrumbs/includes/breadcrumbs.html
@@ -1,4 +1,5 @@
 {%- unless page.pageclass contains "home" or page.breadcrumbs == false -%}
+
 <nav id="wb-bc" property="breadcrumb">
 	<h2>{{ i18nText-breadcrumb }}</h2>
 	<div class="container">
@@ -9,18 +10,31 @@
 				</a>
 				<meta property="position" content="1">
 			</li>
-{%- if page.breadcrumbs -%}
-	{% assign breadcrumbCounter = 2 %}
-	{% for breadcrumb in page.breadcrumbs %}
-			<li property="itemListElement" typeof="ListItem">
-				<a property="item" typeof="WebPage" href="{{ breadcrumb.link | relative_url }}">
-					<span property="name">{{ breadcrumb.title }}</span>
-				</a>
-				<meta property="position" content="{{ breadcrumbCounter }}">
-			</li>
-			{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
-	{%- endfor -%}
-{% endif %}
+			{% assign breadcrumbCounter = 2 %}
+			{%- unless page.overwriteBreadcrumbs -%}
+				{%- if site.global.breadcrumbs -%}
+					{% for breadcrumb in site.global.breadcrumbs[i18nText-lang] %}
+							<li property="itemListElement" typeof="ListItem">
+								<a property="item" typeof="WebPage" href="{% unless breadcrumb.link contains "http" %}{{ setting-siteBasePath }}{% endunless %}{{ breadcrumb.link }}">
+									<span property="name">{{ breadcrumb.title }}</span>
+								</a>
+								<meta property="position" content="{{ breadcrumbCounter }}">
+							</li>
+							{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
+					{%- endfor -%}
+				{% endif %}
+			{%- endunless -%}
+			{%- if page.breadcrumbs -%}
+				{% for breadcrumb in page.breadcrumbs %}
+						<li property="itemListElement" typeof="ListItem">
+							<a property="item" typeof="WebPage" href="{% unless breadcrumb.link contains "http" %}{{ setting-siteBasePath }}{% endunless %}{{ breadcrumb.link }}">
+								<span property="name">{{ breadcrumb.title }}</span>
+							</a>
+							<meta property="position" content="{{ breadcrumbCounter }}">
+						</li>
+						{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
+				{%- endfor -%}
+			{% endif %}
 		</ol>
 	</div>
 </nav>

--- a/sites/date-modified/date-modified-en.html
+++ b/sites/date-modified/date-modified-en.html
@@ -2,9 +2,6 @@
 {
 	"layout": "documentation",
 	"altLangPage": "date-modified-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/GCWeb/index-en.html" }
-	],
 	"dateModified": "2023-11-02",
 	"index_json": "index.json-ld",
 	"description": "Documentation on how to use the date modified.",

--- a/sites/date-modified/date-modified-fr.html
+++ b/sites/date-modified/date-modified-fr.html
@@ -2,9 +2,6 @@
 {
 	"layout": "documentation",
 	"altLangPage": "date-modified-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb accueil", "link": "https://wet-boew.github.io/GCWeb/index-fr.html" }
-	],
 	"dateModified": "2023-11-02",
 	"index_json": "index.json-ld",
 	"description": "Documentation sur l'utilisation de la date de modification.",

--- a/sites/feedback/feedback-form-destination.html
+++ b/sites/feedback/feedback-form-destination.html
@@ -2,9 +2,6 @@
 {
 	"title": "Feedback form destination page",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "Canada.ca", "link": "https://www.canada.ca/en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-04-26"
 }

--- a/sites/footers/contextual-example-en.md
+++ b/sites/footers/contextual-example-en.md
@@ -1,8 +1,6 @@
 ---
 altLangPage: contextual-example-fr.html
 breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-en.html
   - title: Footer
     link: sites/footers/footers-en.html
 contextualFooter:

--- a/sites/footers/contextual-example-fr.md
+++ b/sites/footers/contextual-example-fr.md
@@ -1,8 +1,6 @@
 ---
 altLangPage: no-footer-main-en.html
 breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-fr.html
   - title: Pied de page
     link: sites/footers/footers-fr.html
 contextualFooter:

--- a/sites/footers/footers-en.md
+++ b/sites/footers/footers-en.md
@@ -1,8 +1,5 @@
 ---
 altLangPage: footers-fr.html
-breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-en.html
 contextualFooter:
   title: "[Contextual footer header]"
   links:

--- a/sites/footers/footers-fr.md
+++ b/sites/footers/footers-fr.md
@@ -1,8 +1,5 @@
 ---
 altLangPage: footers-en.html
-breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-fr.html
 contextualFooter:
   title: "[Bande du pied de page contextuel]"
   links:

--- a/sites/footers/no-footer-main-fr.md
+++ b/sites/footers/no-footer-main-fr.md
@@ -1,8 +1,6 @@
 ---
 altLangPage: no-footer-main-en.html
 breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-fr.html
   - title: Pied de page
     link: sites/footers/footers-fr.html
 contextualFooter:

--- a/sites/footers/only-footer-corporate-en.md
+++ b/sites/footers/only-footer-corporate-en.md
@@ -1,8 +1,6 @@
 ---
 altLangPage: only-footer-corporate-fr.html
 breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-en.html
   - title: Footer
     link: sites/footers/footers-en.html
 dateModified: 2023-01-16

--- a/sites/footers/only-footer-corporate-fr.md
+++ b/sites/footers/only-footer-corporate-fr.md
@@ -1,8 +1,6 @@
 ---
 altLangPage: only-footer-corporate-en.html
 breadcrumbs:
-  - title: GCWeb
-    link: https://wet-boew.github.io/GCWeb/index-fr.html
   - title: Pied de page
     link: sites/footers/footers-fr.html
 dateModified: 2023-01-16

--- a/sites/helpers/colour-en.html
+++ b/sites/helpers/colour-en.html
@@ -3,9 +3,6 @@
 	"title": "Colour",
 	"language": "en",
 	"altLangPage": "colour-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-01",
 	"share": "true"

--- a/sites/helpers/colour-fr.html
+++ b/sites/helpers/colour-fr.html
@@ -3,9 +3,6 @@
 	"title": "Couleur",
 	"language": "fr",
 	"altLangPage": "colour-en.html",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-01",
 	"share": "true"

--- a/sites/includes/settings.liquid
+++ b/sites/includes/settings.liquid
@@ -12,3 +12,4 @@
 	https://wet-boew.github.io/themes-dist/GCWeb/{{ setting-packageName }}
 {%- endcapture -%}
 {%- assign setting-resourcesBasePathWetboew = "https://wet-boew.github.io/themes-dist/GCWeb/wet-boew" -%}
+{%- assign setting-siteBasePath = "https://wet-boew.github.io/GCWeb/" -%}

--- a/templates/advancedservice/index-en.html
+++ b/templates/advancedservice/index-en.html
@@ -4,10 +4,9 @@
 	"secondTitle": "1. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/index-fr.html
+++ b/templates/advancedservice/index-fr.html
@@ -4,10 +4,9 @@
 	"secondTitle": "1. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page2-en.html
+++ b/templates/advancedservice/page2-en.html
@@ -4,10 +4,10 @@
 	"secondTitle": "2. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "page2-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" },
+		{ "title": "[Service name]", "link": "templates/advancedservice/index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page2-fr.html
+++ b/templates/advancedservice/page2-fr.html
@@ -4,10 +4,10 @@
 	"secondTitle": "2. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "page2-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" },
+		{ "title": "[Nom du service]", "link": "templates/advancedservice/index-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page3-en.html
+++ b/templates/advancedservice/page3-en.html
@@ -4,10 +4,10 @@
 	"secondTitle": "3. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "page3-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" },
+		{ "title": "[Service name]", "link": "templates/advancedservice/index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page3-fr.html
+++ b/templates/advancedservice/page3-fr.html
@@ -4,10 +4,10 @@
 	"secondTitle": "3. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "page3-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" },
+		{ "title": "[Nom du service]", "link": "templates/advancedservice/index-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page4-en.html
+++ b/templates/advancedservice/page4-en.html
@@ -4,10 +4,10 @@
 	"secondTitle": "4. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "page4-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" },
+		{ "title": "[Service name]", "link": "templates/advancedservice/index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page4-fr.html
+++ b/templates/advancedservice/page4-fr.html
@@ -4,10 +4,10 @@
 	"secondTitle": "4. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "page4-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" },
+		{ "title": "[Nom du service]", "link": "templates/advancedservice/index-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page5-en.html
+++ b/templates/advancedservice/page5-en.html
@@ -4,10 +4,10 @@
 	"secondTitle": "5. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "page5-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" },
+		{ "title": "[Service name]", "link": "templates/advancedservice/index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page5-fr.html
+++ b/templates/advancedservice/page5-fr.html
@@ -4,10 +4,10 @@
 	"secondTitle": "5. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "page5-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" },
+		{ "title": "[Nom du service]", "link": "templates/advancedservice/index-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page6-en.html
+++ b/templates/advancedservice/page6-en.html
@@ -4,10 +4,10 @@
 	"secondTitle": "6. [Step / section page name]",
 	"language": "en",
 	"altLangPage": "page6-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Institution name]", "link": "#" },
-		{ "title": "[Topic name]", "link": "#" },
-		{ "title": "[Service name]", "link": "#" }
+		{ "title": "[Topic name]", "link": "templates/theme-topic/theme-topic-en.html" },
+		{ "title": "[Service name]", "link": "templates/advancedservice/index-en.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/advancedservice/page6-fr.html
+++ b/templates/advancedservice/page6-fr.html
@@ -4,10 +4,10 @@
 	"secondTitle": "6. [Nom de la page de la section ou de l’étape]",
 	"language": "fr",
 	"altLangPage": "page6-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "[Nom de l'institution]", "link": "#" },
-		{ "title": "[Nom du sujet]", "link": "#" },
-		{ "title": "[Nom du service]", "link": "#" }
+		{ "title": "[Nom du sujet]", "link": "templates/theme-topic/theme-topic-fr.html" },
+		{ "title": "[Nom du service]", "link": "templates/advancedservice/index-fr.html" }
 	],
 	"secondlevel": false,
 	"dateModified": "2017-04-07",

--- a/templates/campaign/api.html
+++ b/templates/campaign/api.html
@@ -2,9 +2,6 @@
 {
 	"title": "[ESDC peers template] - Meta information",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2018-10-15",
 	"share": "true"

--- a/templates/institutional/institution-arms-en.html
+++ b/templates/institutional/institution-arms-en.html
@@ -5,6 +5,7 @@
 	"altLangPage": "institution-arms-fr.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],

--- a/templates/institutional/institution-arms-fr.html
+++ b/templates/institutional/institution-arms-fr.html
@@ -5,6 +5,7 @@
 	"altLangPage": "institution-arms-en.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],

--- a/templates/institutional/institution-contact-en.html
+++ b/templates/institutional/institution-contact-en.html
@@ -4,6 +4,7 @@
 	"language": "en",
 	"altLangPage": "institution-contact-fr.html",
 	"pageType": "institution",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],

--- a/templates/institutional/institution-contact-fr.html
+++ b/templates/institutional/institution-contact-fr.html
@@ -4,6 +4,7 @@
 	"language": "fr",
 	"altLangPage": "institution-contact-en.html",
 	"pageType": "institution",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],

--- a/templates/institutional/institution-en.html
+++ b/templates/institutional/institution-en.html
@@ -5,6 +5,7 @@
 	"altLangPage": "institution-fr.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],

--- a/templates/institutional/institution-fr.html
+++ b/templates/institutional/institution-fr.html
@@ -5,6 +5,7 @@
 	"altLangPage": "institution-en.html",
 	"pageType": "institution",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],

--- a/templates/institutional/institution-landing-en.html
+++ b/templates/institutional/institution-landing-en.html
@@ -3,6 +3,7 @@ title: "[Institution-landing-page]"
 layout: no-container
 language: "en"
 altLangPage: "institution-landing-fr.html"
+overwriteBreadcrumbs: true
 breadcrumbs: [
 	{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 ]

--- a/templates/institutional/institution-landing-fr.html
+++ b/templates/institutional/institution-landing-fr.html
@@ -3,6 +3,7 @@ title: "[Institution-landing-page]"
 layout: no-container
 language: "fr"
 altLangPage: "institution-landing-en.html"
+overwriteBreadcrumbs: true
 breadcrumbs: [
 	{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 ]

--- a/templates/legislation/act-en.html
+++ b/templates/legislation/act-en.html
@@ -3,6 +3,7 @@
 	"title": "[Act name] <small>([NN-XX])</small>",
 	"language": "en",
 	"altLangPage": "act-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Acts & regulations", "link": "#" }
 	],

--- a/templates/legislation/act-fr.html
+++ b/templates/legislation/act-fr.html
@@ -3,6 +3,7 @@
 	"title": "[Titre de la loi] <small>([NN-XX])</small>",
 	"language": "fr",
 	"altLangPage": "act-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Lois et règlements", "link": "#" }
 	],

--- a/templates/legislation/regulations-en.html
+++ b/templates/legislation/regulations-en.html
@@ -3,6 +3,7 @@
 	"title": "[Regulation name] <small>([NN-XX])</small>",
 	"language": "en",
 	"altLangPage": "regulations-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Acts & regulations", "link": "#" }
 	],

--- a/templates/legislation/regulations-fr.html
+++ b/templates/legislation/regulations-fr.html
@@ -3,6 +3,7 @@
 	"title": "[Nom du règlement] <small>([NN-XX])</small>",
 	"language": "fr",
 	"altLangPage": "regulations-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Lois et règlements", "link": "#" }
 	],

--- a/templates/lowest-topic/index-en.html
+++ b/templates/lowest-topic/index-en.html
@@ -5,6 +5,7 @@
 	"language": "en",
 	"altLangPage": "index-fr.html",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Theme Name]", "link": "templates/theme-en.html" }
 	],

--- a/templates/lowest-topic/index-fr.html
+++ b/templates/lowest-topic/index-fr.html
@@ -5,6 +5,7 @@
 	"language": "fr",
 	"altLangPage": "index-en.html",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Thème]", "link": "templates/theme-fr.html" }
 	],

--- a/templates/lowest-topic/task1/index-en.html
+++ b/templates/lowest-topic/task1/index-en.html
@@ -23,9 +23,10 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2017-09-29",

--- a/templates/lowest-topic/task1/index-fr.html
+++ b/templates/lowest-topic/task1/index-fr.html
@@ -23,9 +23,10 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2017-09-29",

--- a/templates/lowest-topic/task1/task1/index-en.html
+++ b/templates/lowest-topic/task1/task1/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task1/index-fr.html
+++ b/templates/lowest-topic/task1/task1/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task1/task2/index-en.html
+++ b/templates/lowest-topic/task1/task2/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task2/index-fr.html
+++ b/templates/lowest-topic/task1/task2/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task1/task3/index-en.html
+++ b/templates/lowest-topic/task1/task3/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task3/index-fr.html
+++ b/templates/lowest-topic/task1/task3/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task1/task4/index-en.html
+++ b/templates/lowest-topic/task1/task4/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task4/index-fr.html
+++ b/templates/lowest-topic/task1/task4/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task1/task5/index-en.html
+++ b/templates/lowest-topic/task1/task5/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task5/index-fr.html
+++ b/templates/lowest-topic/task1/task5/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task1/task6/index-en.html
+++ b/templates/lowest-topic/task1/task6/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task6/index-fr.html
+++ b/templates/lowest-topic/task1/task6/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task1/task7/index-en.html
+++ b/templates/lowest-topic/task1/task7/index-en.html
@@ -16,10 +16,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 1]", "link": "templates/localnav/task1/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 1]", "link": "templates/lowest-topic/task1/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task1/task7/index-fr.html
+++ b/templates/lowest-topic/task1/task7/index-fr.html
@@ -16,10 +16,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 1]", "link": "templates/localnav/task1/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 1]", "link": "templates/lowest-topic/task1/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task2/index-en.html
+++ b/templates/lowest-topic/task2/index-en.html
@@ -13,9 +13,10 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task2/index-fr.html
+++ b/templates/lowest-topic/task2/index-fr.html
@@ -13,9 +13,10 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task3/index-en.html
+++ b/templates/lowest-topic/task3/index-en.html
@@ -19,9 +19,10 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task3/index-fr.html
+++ b/templates/lowest-topic/task3/index-fr.html
@@ -19,9 +19,10 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task3/task1/index-en.html
+++ b/templates/lowest-topic/task3/task1/index-en.html
@@ -12,10 +12,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/lowest-topic/task3/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task3/task1/index-fr.html
+++ b/templates/lowest-topic/task3/task1/index-fr.html
@@ -12,10 +12,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 3]", "link": "templates/localnav/task3/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 3]", "link": "templates/lowest-topic/task3/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task3/task2/index-en.html
+++ b/templates/lowest-topic/task3/task2/index-en.html
@@ -17,10 +17,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/lowest-topic/task3/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task3/task2/index-fr.html
+++ b/templates/lowest-topic/task3/task2/index-fr.html
@@ -17,10 +17,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 3]", "link": "templates/localnav/task3/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 3]", "link": "templates/lowest-topic/task3/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task3/task2/task1/index-en.html
+++ b/templates/lowest-topic/task3/task2/task1/index-en.html
@@ -11,11 +11,12 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" },
-		{ "title": "[Sub task 2]", "link": "templates/localnav/task3/task2/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/lowest-topic/task3/index-en.html" },
+		{ "title": "[Sub task 2]", "link": "templates/lowest-topic/task3/task2/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task3/task2/task1/index-fr.html
+++ b/templates/lowest-topic/task3/task2/task1/index-fr.html
@@ -11,11 +11,12 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 3]", "link": "templates/localnav/task3/index-fr.html" },
-		{ "title": "[Sub tâche 2]", "link": "templates/localnav/task3/task2/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 3]", "link": "templates/lowest-topic/task3/index-fr.html" },
+		{ "title": "[Sub tâche 2]", "link": "templates/lowest-topic/task3/task2/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task3/task2/task2/index-en.html
+++ b/templates/lowest-topic/task3/task2/task2/index-en.html
@@ -11,11 +11,12 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" },
-		{ "title": "[Sub task 2]", "link": "templates/localnav/task3/task2/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/lowest-topic/task3/index-en.html" },
+		{ "title": "[Sub task 2]", "link": "templates/lowest-topic/task3/task2/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task3/task2/task2/index-fr.html
+++ b/templates/lowest-topic/task3/task2/task2/index-fr.html
@@ -11,11 +11,12 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 3]", "link": "templates/localnav/task3/index-fr.html" },
-		{ "title": "[Sub tâche 2]", "link": "templates/localnav/task3/task2/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 3]", "link": "templates/lowest-topic/task3/index-fr.html" },
+		{ "title": "[Sub tâche 2]", "link": "templates/lowest-topic/task3/task2/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task3/task3/index-en.html
+++ b/templates/lowest-topic/task3/task3/index-en.html
@@ -12,10 +12,11 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" },
-		{ "title": "[Task 3]", "link": "templates/localnav/task3/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" },
+		{ "title": "[Task 3]", "link": "templates/lowest-topic/task3/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task3/task3/index-fr.html
+++ b/templates/lowest-topic/task3/task3/index-fr.html
@@ -12,10 +12,11 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" },
-		{ "title": "[Tâche 3]", "link": "templates/localnav/task3/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" },
+		{ "title": "[Tâche 3]", "link": "templates/lowest-topic/task3/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/lowest-topic/task4/index-en.html
+++ b/templates/lowest-topic/task4/index-en.html
@@ -13,9 +13,10 @@
 	},
 	"language": "en",
 	"altLangPage": "index-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Institution name]", "link": "templates/institutional/institution-en.html" },
-		{ "title": "[Topic - Local navigation]", "link": "templates/localnav/index-en.html" }
+		{ "title": "[Topic - Local navigation]", "link": "templates/lowest-topic/index-en.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2015-01-11",

--- a/templates/lowest-topic/task4/index-fr.html
+++ b/templates/lowest-topic/task4/index-fr.html
@@ -13,9 +13,10 @@
 	},
 	"language": "fr",
 	"altLangPage": "index-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "[Nom de l'institution]", "link": "templates/institutional/institution-fr.html" },
-		{ "title": "[Sujet - Navigation locale]", "link": "templates/localnav/index-fr.html" }
+		{ "title": "[Sujet - Navigation locale]", "link": "templates/lowest-topic/index-fr.html" }
 	],
 	"tag": "GCWeb",
 	"dateModified": "2016-01-19",

--- a/templates/organizational/organizational-arms-en.html
+++ b/templates/organizational/organizational-arms-en.html
@@ -5,6 +5,7 @@
 	"altLangPage": "organizational-arms-fr.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],

--- a/templates/organizational/organizational-arms-fr.html
+++ b/templates/organizational/organizational-arms-fr.html
@@ -5,6 +5,7 @@
 	"altLangPage": "organizational-arms-en.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],

--- a/templates/organizational/organizational-en.html
+++ b/templates/organizational/organizational-en.html
@@ -5,6 +5,7 @@
 	"altLangPage": "organizational-fr.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],

--- a/templates/organizational/organizational-fr.html
+++ b/templates/organizational/organizational-fr.html
@@ -5,6 +5,7 @@
 	"altLangPage": "organizational-en.html",
 	"pageType": "organization",
 	"pageclass": "page-type-nav",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],

--- a/templates/search/api-en.html
+++ b/templates/search/api-en.html
@@ -2,9 +2,6 @@
 {
 	"title": "Search results",
 	"language": "en",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-fr.html" }
-	],
 	"secondlevel": false,
 	"altLangPage": "api-fr.html",
 	"dateModified": "2023-04-18",

--- a/templates/search/api-fr.html
+++ b/templates/search/api-fr.html
@@ -2,9 +2,6 @@
 {
 	"title": "Résultats de recherche",
 	"language": "fr",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" }
-	],
 	"secondlevel": false,
 	"altLangPage": "api-en.html",
 	"dateModified": "2023-04-18",

--- a/templates/search/test-pagination.html
+++ b/templates/search/test-pagination.html
@@ -2,8 +2,8 @@
 {
 	"title": "Test - Pagination for search template",
 	"language": "en",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "index-en.html" },
 		{ "title": "Search templat", "link": "templates/search/api.html" }
 	],
 	"secondlevel": false,

--- a/templates/service-en.html
+++ b/templates/service-en.html
@@ -3,6 +3,7 @@
 	"title": "[Service name]",
 	"language": "en",
 	"altLangPage": "service-fr.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Institution name", "link": "templates/institutional/institution-en.html" },
 		{ "title": "Topic name", "link": "templates/topic/topic-en.html" }

--- a/templates/service-fr.html
+++ b/templates/service-fr.html
@@ -3,6 +3,7 @@
 	"title": "[Nom du service]",
 	"language": "fr",
 	"altLangPage": "service-en.html",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Nom de l'institution", "link": "templates/institutional/institution-fr.html" },
 		{ "title": "Nom du sujet", "link": "templates/topic/topic-fr.html" }

--- a/templates/splash/api-en.html
+++ b/templates/splash/api-en.html
@@ -3,9 +3,6 @@
 	"title": "Splash page - Meta information",
 	"language": "en",
 	"altLangPage": "api-fr.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-10-31",
 	"share": "false"

--- a/templates/splash/api-fr.html
+++ b/templates/splash/api-fr.html
@@ -3,9 +3,6 @@
 	"title": "Page d'entrée - Meta information",
 	"language": "fr",
 	"altLangPage": "api-en.html",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2022-10-31",
 	"share": "false"

--- a/templates/thematic/dark-theme-en.html
+++ b/templates/thematic/dark-theme-en.html
@@ -4,9 +4,6 @@
 	"language": "en",
 	"altLangPage": "dark-theme-fr.html",
 	"pageclass": "provisional dark-theme",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-15",
 	"share": "true"

--- a/templates/thematic/dark-theme-fr.html
+++ b/templates/thematic/dark-theme-fr.html
@@ -4,9 +4,6 @@
 	"language": "fr",
 	"altLangPage": "dark-theme-en.html",
 	"pageclass": "provisional dark-theme",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-15",
 	"share": "true"

--- a/templates/thematic/pink-day-en.html
+++ b/templates/thematic/pink-day-en.html
@@ -4,9 +4,6 @@
 	"language": "en",
 	"altLangPage": "pink-day-fr.html",
 	"pageclass": "provisional pnkDy-theme",
-	"breadcrumbs": [
-		{ "title": "GCWeb home", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-en.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-15",
 	"share": "true"

--- a/templates/thematic/pink-day-fr.html
+++ b/templates/thematic/pink-day-fr.html
@@ -4,9 +4,6 @@
 	"language": "fr",
 	"altLangPage": "pink-day-en.html",
 	"pageclass": "provisional pnkDy-theme",
-	"breadcrumbs": [
-		{ "title": "Accueil GCWeb", "link": "https://wet-boew.github.io/themes-dist/GCWeb/index-fr.html" }
-	],
 	"secondlevel": false,
 	"dateModified": "2019-05-15",
 	"share": "true"

--- a/templates/widgets-en.html
+++ b/templates/widgets-en.html
@@ -4,6 +4,7 @@
 	"language": "en",
 	"altLangPage": "widgets-fr.html",
 	"pageclass": "theme",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Environment & natural resources", "link": "https://www.canada.ca/en/services/environment.html" }
 	],

--- a/templates/widgets-fr.html
+++ b/templates/widgets-fr.html
@@ -4,6 +4,7 @@
 	"language": "fr",
 	"altLangPage": "widgets-en.html",
 	"pageclass": "theme",
+	"overwriteBreadcrumbs": true,
 	"breadcrumbs": [
 		{ "title": "Environnement et ressources naturelles", "link": "https://www.canada.ca/fr/services/environnement.html" }
 	],


### PR DESCRIPTION
Adding link to GCWeb homepage in breadcrumbs for all pages with a way to overwrite it using "`overwriteBreadcrumbs: true`".

Relevant files:
- Gruntfile.coffee
- _config.yml
- sites/breadcrumbs/includes/breadcrumbs.html
- sites/includes/settings.liquid