### PR TITLE
Field flow: Handle HTML tags in unlinked list items

### DIFF
--- a/components/wb-fieldflow/alternative-en.html
+++ b/components/wb-fieldflow/alternative-en.html
@@ -6,7 +6,7 @@ category: "Plugins"
 description: "Find styling alternatives for field flow."
 tag: "fieldflow"
 parentdir: "fieldflow"
-dateModified: "2021-04-28"
+dateModified: "2023-12-01"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-en.html">Documentation</a></li>
@@ -99,7 +99,7 @@ dateModified: "2021-04-28"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 
@@ -110,7 +110,7 @@ dateModified: "2021-04-28"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;</code></pre>
 
@@ -122,7 +122,7 @@ dateModified: "2021-04-28"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 
@@ -133,7 +133,7 @@ dateModified: "2021-04-28"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;</code></pre>
 

--- a/components/wb-fieldflow/alternative-fr.html
+++ b/components/wb-fieldflow/alternative-fr.html
@@ -6,7 +6,7 @@ category: "Plugiciels"
 description: "Trouver des alternatives de styles pour le déroulement de champs."
 tag: "fieldflow"
 parentdir: "fieldflow"
-dateModified: "2021-04-28"
+dateModified: "2023-12-01"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-fr.html">Documentation</a></li>
@@ -100,7 +100,7 @@ dateModified: "2021-04-28"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 
@@ -111,7 +111,7 @@ dateModified: "2021-04-28"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;</code></pre>
 
@@ -123,7 +123,7 @@ dateModified: "2021-04-28"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 
@@ -134,7 +134,7 @@ dateModified: "2021-04-28"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;</code></pre>
 

--- a/components/wb-fieldflow/basic-en.html
+++ b/components/wb-fieldflow/basic-en.html
@@ -7,7 +7,7 @@ description: "How to use field flow to create small scale user interaction."
 tag: "fieldflow"
 parentdir: "fieldflow"
 altLangPage: "basic-fr.html"
-dateModified: "2016-11-30"
+dateModified: "2023-12-01"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-en.html">Documentation</a></li>
@@ -108,7 +108,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -119,7 +119,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-2.html">ajax/ajax-2.html</a>&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-3.html">ajax/ajax-3.html</a>&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-4.html">ajax/ajax-4.html</a>&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -182,7 +182,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html"}'>(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html"}'>(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html"}'>(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html"}'>(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html"}'>(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/filtering-hash.html ul"}'>Ajax filtering, ul (selector)</li>
 	</ul>
 </div>
@@ -194,7 +194,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;}'&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;}'&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;}'&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html ul&quot;}'&gt;Ajax filtering, ul (selector)&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
@@ -211,7 +211,7 @@ dateModified: "2016-11-30"
 			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html", "live":true}'>(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html", "live":true}'>(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html", "live":true}'>(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html", "live":true}'>(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html", "live":true}'>(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 </form></div>
@@ -224,7 +224,7 @@ dateModified: "2016-11-30"
 			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;, &quot;live&quot;:true}'&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;live&quot;:true}'&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;live&quot;:true}'&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;live&quot;:true}'&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;live&quot;:true}'&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;
 &lt;/form&gt;&lt;/div&gt;</code></pre>
@@ -342,7 +342,7 @@ dateModified: "2016-11-30"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 </form></div>
@@ -355,7 +355,7 @@ dateModified: "2016-11-30"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;
 &lt;/form&gt;&lt;/div&gt;</code></pre>
@@ -427,7 +427,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -438,7 +438,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -458,7 +458,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -474,7 +474,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -490,7 +490,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -501,7 +501,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -519,7 +519,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -530,7 +530,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -547,7 +547,7 @@ dateModified: "2016-11-30"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 	<input class="btn btn-default btn-lg mrgn-bttm-md" type="submit" value="My custom submit button" />
@@ -561,7 +561,7 @@ dateModified: "2016-11-30"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;
 	&lt;input class=&quot;btn btn-default btn-lg mrgn-bttm-md&quot; type=&quot;submit&quot; value=&quot;My custom submit button&quot; /&gt;
@@ -617,7 +617,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -634,6 +634,6 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>

--- a/components/wb-fieldflow/basic-fr.html
+++ b/components/wb-fieldflow/basic-fr.html
@@ -7,7 +7,7 @@ description: "Comment utiliser le déroulement de champs afin de créer des inte
 tag: "fieldflow"
 parentdir: "fieldflow"
 altLangPage: "basic-en.html"
-dateModified: "2016-11-30"
+dateModified: "2023-12-01"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-fr.html">Documentation</a></li>
@@ -106,7 +106,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -117,7 +117,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-2.html">ajax/ajax-2.html</a>&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-3.html">ajax/ajax-3.html</a>&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-4.html">ajax/ajax-4.html</a>&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -180,7 +180,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html"}'>(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html"}'>(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html"}'>(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html"}'>(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html"}'>(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -191,7 +191,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;}'&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;}'&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;}'&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -207,7 +207,7 @@ dateModified: "2016-11-30"
 			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html", "live":true}'>(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html", "live":true}'>(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html", "live":true}'>(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html", "live":true}'>(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html", "live":true}'>(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 </form></div>
@@ -221,7 +221,7 @@ dateModified: "2016-11-30"
 			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;
 &lt;/form&gt;&lt;/div&gt;</code></pre>
@@ -339,7 +339,7 @@ dateModified: "2016-11-30"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 </form></div>
@@ -352,7 +352,7 @@ dateModified: "2016-11-30"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;
 &lt;/form&gt;&lt;/div&gt;</code></pre>
@@ -424,7 +424,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -435,7 +435,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -455,7 +455,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -470,7 +470,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -486,7 +486,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -497,7 +497,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -515,7 +515,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -526,7 +526,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -543,7 +543,7 @@ dateModified: "2016-11-30"
 			<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 			<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 			<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 		</ul>
 	</div>
 	<input class="btn btn-default btn-lg mrgn-bttm-md" type="submit" value="Mon bouton soumettre personalisé" />
@@ -557,7 +557,7 @@ dateModified: "2016-11-30"
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 		&lt;/ul&gt;
 	&lt;/div&gt;
 	&lt;input class=&quot;btn btn-default btn-lg mrgn-bttm-md&quot; type=&quot;submit&quot; value=&quot;Mon bouton soumettre personalisé&quot; /&gt;
@@ -613,7 +613,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -630,6 +630,6 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>

--- a/components/wb-fieldflow/fieldflow-en.html
+++ b/components/wb-fieldflow/fieldflow-en.html
@@ -6,7 +6,7 @@ description: Transform a basic list into a selectable list.
 tag: fieldflow
 parentdir: fieldflow
 altLangPage: fieldflow-fr.html
-dateModified: 2016-11-30
+dateModified: 2023-12-01
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-en.html">Documentation</a></li>
@@ -50,7 +50,7 @@ dateModified: 2016-11-30
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
-		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html"><strong>Popup</strong> content</a></li>
 	</ul>
 </div>
 
@@ -63,7 +63,7 @@ dateModified: 2016-11-30
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;&lt;strong&gt;Popup&lt;/strong&gt; content&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -83,7 +83,7 @@ dateModified: 2016-11-30
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -98,7 +98,7 @@ dateModified: 2016-11-30
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-2.html">ajax/ajax-2.html</a>&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-3.html">ajax/ajax-3.html</a>&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-4.html">ajax/ajax-4.html</a>&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Set 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;
 

--- a/components/wb-fieldflow/fieldflow-fr.html
+++ b/components/wb-fieldflow/fieldflow-fr.html
@@ -6,7 +6,7 @@ description: "Transforme une simple liste en un liste de choix."
 tag: "fieldflow"
 parentdir: "fieldflow"
 altLangPage: fieldflow-en.html
-dateModified: "2016-11-30"
+dateModified: "2023-12-01"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-fr.html">Documentation</a></li>
@@ -49,7 +49,7 @@ dateModified: "2016-11-30"
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
-		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu <strong>superposé</strong></a></li>
 	</ul>
 </div>
 
@@ -62,7 +62,7 @@ dateModified: "2016-11-30"
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu &lt;strong&gt;superposé&lt;/strong&gt;&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
@@ -82,7 +82,7 @@ dateModified: "2016-11-30"
 		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
 		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
 		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
-		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) <em>Sed eget dui ac <strong>nunc mattis</strong> consequat</em> in a ex.</li>
 	</ul>
 </div>
 
@@ -97,7 +97,7 @@ dateModified: "2016-11-30"
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
 		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
-		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) &lt;em&gt;Sed eget dui ac &lt;strong&gt;nunc mattis&lt;/strong&gt; consequat&lt;/em&gt; in a ex.&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;
 

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -829,7 +829,12 @@ var componentName = "wb-fieldflow",
 			}
 
 			if ( !itmLabel ) {
-				itmLabel = firstNode.nodeValue;
+				const $itmCachedClean = $( itmCached ).clone();
+
+				// Remove nested structure in grouping (ul) and nesting (.wb-fieldflow-sub) scenarios
+				$itmCachedClean.children( "ul, .wb-fieldflow-sub" ).remove();
+
+				itmLabel = $itmCachedClean.html();
 			}
 
 			// Set an id on the element
@@ -848,7 +853,7 @@ var componentName = "wb-fieldflow",
 		return parsedItms;
 	},
 	buildSelectOption = function( data ) {
-		var label = data.label,
+		var label = stripHtml( data.label ),
 			out = "<option value='" + wb.escapeAttribute( label ) + "'";
 
 		out += buildDataAttribute( data );
@@ -876,7 +881,7 @@ var componentName = "wb-fieldflow",
 		var fieldID = wb.getId(),
 			labelTxt = data.label,
 			label = "<label for='" + fieldID + "'>",
-			input = "<input id='" + fieldID + "' type='" + inputType + "' name='" + fieldName + "' value='" + wb.escapeAttribute( labelTxt ) + "'" + buildDataAttribute( data ),
+			input = "<input id='" + fieldID + "' type='" + inputType + "' name='" + fieldName + "' value='" + wb.escapeAttribute( stripHtml( labelTxt ) ) + "'" + buildDataAttribute( data ),
 			tag = !isInline && isGcChckbxrdio ? "li" : "div",
 			out = "<" + tag + " class='" + inputType;
 
@@ -900,6 +905,12 @@ var componentName = "wb-fieldflow",
 		out += "</label>" + "</" + tag + ">";
 
 		return out;
+	},
+
+	// Strip HTML markup from strings
+	// Created by Chris Coyier via CSS-Tricks (https://css-tricks.com/snippets/javascript/strip-html-tags-in-javascript/)
+	stripHtml = function( str ) {
+		return str.replace( /(<([^>]+)>)/gi, "" );
 	};
 
 $document.on( resetActionEvent, selector + ", ." + subComponentName, function( event ) {


### PR DESCRIPTION
Previously, when the plugin encountered list items that didn't start off with an anchor, it used each item's first child node as a label/value. That was fine if the only child was a text node. But not when nested elements were in play...

For example:
* If a list item's first child node was an element node, ``wb.escapeAttribute()`` raised the following JS exception (since it expects strings - not element nodes):
  * Uncaught TypeError: can't access property "replace", str is null
* If a list item started off with a text node and was followed by any element nodes, only the text node's content would be retained... resulting in the rest of the content getting truncated

This fixes it by deriving list item labels from their inner HTML code (like what's already done for anchors), as well as stripping HTML tags out of ``option`` elements and ``value`` attributes. HTML formatting is retained for checkbox/radio button labels.

Nested structure that isn't meant to be shown in grouping (``ul``) and nesting (``.wb-fieldflow-sub``) scenarios is excluded.

Also updated examples to demonstrate affected scenarios:
* Redirection example:
  * Bold a link in a list item
* Other examples:
  * Add italics/bolding in all "(Set 5)"/"(Ensemble 5)" list items