### PR TITLE
Méli-mélo - 2021-05 Steps - Update css

### DIFF
--- a/méli-mélo/2021-05-steps/steps.css
+++ b/méli-mélo/2021-05-steps/steps.css
@@ -68,10 +68,10 @@ ol.lst-stps.ld-zr>li:before, ol.lst-stps.ld-zr>li ol.lst-stps-sub>li:before {
     margin-top: 0px;
     padding-bottom: 0.8em;
 }
-ol.lst-stps>li :first-of-type:is(h2, h3, h4, h5, h6, p), ol.lst-stps>li ol.lst-stps-sub>li :first-of-type:is(h2, h3, h4, h5, h6, p) {
+/*striped design */
+ol.lst-stps.stps-strpd>li :first-child:is(h2, h3, h4, h5, h6, p), ol.lst-stps-sub.stps-strpd>li :first-child:is(h2, h3, h4, h5, h6, p) {
 margin-top: auto;
-}
-/*striped design */	
+	}
 ol.lst-stps.stps-strpd>li, ol.lst-stps-sub.stps-strpd>li {
     min-height: 4em;
     padding-left: 3.6em;
@@ -97,6 +97,9 @@ ol.lst-stps.stps-strpd>li, ol.lst-stps.stps-strpd>li ol.lst-stps-sub.stps-strpd>
 ol.lst-stps:not(.stps-strpd)>li, ol.lst-stps-sub:not(.stps-strpd)>li {
     padding-left: 2.6em;
 }
+ol.lst-stps.ld-zr:not(.stps-strpd)>li, ol.lst-stps.ld-zr>li ol.lst-stps-sub:not(.stps-strpd)>li {
+    padding-left: 2.8em;
+}		
 ol.lst-stps>li:before {
     font-size: 0.8em;
 }


### PR DESCRIPTION
Update to avoid cut off of lead zero in expand/hides in mobile and only allow margin top 0 for first child items in striped pattern.