### PR TITLE
Theme: Revert normalize.css' link outline styles

### DIFF
--- a/sites/theme.scss
+++ b/sites/theme.scss
@@ -21,6 +21,7 @@
 
 /*! Reset and dependencies */
 @import "bootstrap-sass/assets/stylesheets/bootstrap/normalize";
+@import "wet-boew/src/base/bootstrap-overrides/normalize";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/print";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
 


### PR DESCRIPTION
Imports WET's normalize.css overrides to obtain the fix.

Depends on wet-boew/wet-boew#9737.