### PR TITLE
Field flow: Trim auto-generated labels/values

### DIFF
--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -786,7 +786,7 @@ var componentName = "wb-fieldflow",
 			// Is firstNode an anchor?
 			if ( firstNode.nodeName === "A" ) {
 				itmValue = firstNode.getAttribute( "href" );
-				itmLabel = $( firstNode ).html();
+				itmLabel = $( firstNode ).html().trim();
 				j_len = 1; // Force following elements to be ignored
 
 				actions.push( {
@@ -834,7 +834,7 @@ var componentName = "wb-fieldflow",
 				// Remove nested structure in grouping (ul) and nesting (.wb-fieldflow-sub) scenarios
 				$itmCachedClean.children( "ul, .wb-fieldflow-sub" ).remove();
 
-				itmLabel = $itmCachedClean.html();
+				itmLabel = $itmCachedClean.html().trim();
 			}
 
 			// Set an id on the element


### PR DESCRIPTION
Leading/Trailing spaces are usually undesirable, so let's strip them out.

Doesn't affect labels that are explicitly-declared via the "wb-fieldflow-label" class. Those will be kept as-is so as not to interfere with an implementer's desire.

Affects grouping and nesting scenarios. Directly impacts the demo page's nesting example.

Spinoff of #2291.