### PR TITLE
Field flow: Cleanup optgroup labels

### DIFF
--- a/components/wb-fieldflow/fieldflow-en.html
+++ b/components/wb-fieldflow/fieldflow-en.html
@@ -6,7 +6,7 @@ description: Transform a basic list into a selectable list.
 tag: fieldflow
 parentdir: fieldflow
 altLangPage: fieldflow-fr.html
-dateModified: 2023-12-01
+dateModified: 2024-03-06
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-en.html">Documentation</a></li>
@@ -114,7 +114,7 @@ dateModified: 2023-12-01
 <div class="wb-fieldflow">
 	<p>Find the plugin for the action you need.</p>
 	<ul>
-		<li>Layout and rendering
+		<li>Layout <strong>and</strong> rendering
 			<ul>
 				<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
 				<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
@@ -135,7 +135,7 @@ dateModified: 2023-12-01
 <pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
 	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
 	&lt;ul&gt;
-		&lt;li&gt;Layout and rendering
+		&lt;li&gt;Layout &lt;strong&gt;and&lt;/strong&gt; rendering
 			&lt;ul&gt;
 				&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
@@ -163,7 +163,7 @@ dateModified: 2023-12-01
 <div class="wb-fieldflow">
 	<p>Find the plugin for the action you need.</p>
 	<ul>
-		<li>+ Layout and rendering
+		<li>+ Layout <strong>and</strong> rendering
 			<div class="wb-fieldflow-sub">
 				<p>It is for?..</p>
 				<ul>
@@ -196,7 +196,7 @@ dateModified: 2023-12-01
 <pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
 	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
 	&lt;ul&gt;
-		&lt;li&gt;+ Layout and rendering
+		&lt;li&gt;+ Layout &lt;strong&gt;and&lt;/strong&gt; rendering
 			<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
 				&lt;p&gt;It is for?..&lt;/p&gt;
 				&lt;ul&gt;

--- a/components/wb-fieldflow/fieldflow-fr.html
+++ b/components/wb-fieldflow/fieldflow-fr.html
@@ -6,7 +6,7 @@ description: "Transforme une simple liste en un liste de choix."
 tag: "fieldflow"
 parentdir: "fieldflow"
 altLangPage: fieldflow-en.html
-dateModified: "2023-12-01"
+dateModified: "2024-03-06"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-fr.html">Documentation</a></li>
@@ -113,7 +113,7 @@ dateModified: "2023-12-01"
 	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
 
 	<ul>
-		<li>Mise en page et présentation
+		<li>Mise en page <strong>et</strong> présentation
 			<ul>
 				<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
 				<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
@@ -135,7 +135,7 @@ dateModified: "2023-12-01"
 	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
 
 	&lt;ul&gt;
-		&lt;li&gt;Mise en page et présentation
+		&lt;li&gt;Mise en page &lt;strong&gt;et&lt;/strong&gt; présentation
 			&lt;ul&gt;
 				&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
 				&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
@@ -163,7 +163,7 @@ dateModified: "2023-12-01"
 <div class="wb-fieldflow">
 	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
 	<ul>
-		<li>+ Mise en page et présentation
+		<li>+ Mise en page <strong>et</strong> présentation
 			<div class="wb-fieldflow-sub">
 				<p>Et c'est pour?</p>
 				<ul>
@@ -197,7 +197,7 @@ dateModified: "2023-12-01"
 <pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
 	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
 	&lt;ul&gt;
-		&lt;li&gt;+ Mise en page et présentation
+		&lt;li&gt;+ Mise en page &lt;strong&gt;et&lt;/strong&gt; présentation
 			<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
 				&lt;p&gt;Et c'est pour?&lt;/p&gt;
 				&lt;ul&gt;

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -619,7 +619,7 @@ var componentName = "wb-fieldflow",
 			} else {
 
 				// We have a group of sub-items, the cur_itm are a group
-				selectOut += "<optgroup label='" + cur_itm.label + "'>";
+				selectOut += "<optgroup label='" + wb.escapeAttribute( stripHtml( cur_itm.label ) ) + "'>";
 				j_len = cur_itm.group.length;
 				for ( j = 0; j !== j_len; j += 1 ) {
 					selectOut += buildSelectOption( cur_itm.group[ j ] );


### PR DESCRIPTION
Removes HTML tags and escapes quotes from ``optgroup`` ``label`` attributes.

Also adds a ``strong`` element to the grouping example to demonstrate it in action.

Overlooked leftover from #2291.