### PR TITLE
Field flow: Detect anchors via firstElementChild

### DIFF
--- a/components/wb-fieldflow/fieldflow-en.html
+++ b/components/wb-fieldflow/fieldflow-en.html
@@ -6,7 +6,7 @@ description: Transform a basic list into a selectable list.
 tag: fieldflow
 parentdir: fieldflow
 altLangPage: fieldflow-fr.html
-dateModified: 2024-03-06
+dateModified: 2024-04-08
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-en.html">Documentation</a></li>
@@ -48,8 +48,10 @@ dateModified: 2024-03-06
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
-		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
-		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+		<li><!--test comment--><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+		<li>
+			<a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a>
+		</li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html"><strong>Popup</strong> content</a></li>
 	</ul>
 </div>
@@ -61,8 +63,10 @@ dateModified: 2024-03-06
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;!--test comment--&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;
+			&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;
+		&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;&lt;strong&gt;Popup&lt;/strong&gt; content&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>

--- a/components/wb-fieldflow/fieldflow-fr.html
+++ b/components/wb-fieldflow/fieldflow-fr.html
@@ -6,7 +6,7 @@ description: "Transforme une simple liste en un liste de choix."
 tag: "fieldflow"
 parentdir: "fieldflow"
 altLangPage: fieldflow-en.html
-dateModified: "2024-03-06"
+dateModified: "2024-04-08"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-fr.html">Documentation</a></li>
@@ -47,8 +47,10 @@ dateModified: "2024-03-06"
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
-		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
-		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+		<li><!--test comment--><a href="https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+		<li>
+			<a href="https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a>
+		</li>
 		<li><a href="https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu <strong>superposé</strong></a></li>
 	</ul>
 </div>
@@ -60,8 +62,10 @@ dateModified: "2024-03-06"
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;!--test comment--&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;
+			&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;
+		&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;https://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu &lt;strong&gt;superposé&lt;/strong&gt;&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -762,7 +762,7 @@ var componentName = "wb-fieldflow",
 		var arrItems = $items.get(),
 			i, i_len = arrItems.length, itmCached,
 			itmLabel, itmValue, grpItem,
-			j, j_len, childNodes, firstNode, childNode, $childNode, childNodeID,
+			j, j_len, childNodes, firstNode, firstElmNode, childNode, $childNode, childNodeID,
 			parsedItms = [],
 			actions;
 
@@ -774,6 +774,7 @@ var componentName = "wb-fieldflow",
 			itmLabel = "";
 
 			firstNode = itmCached.firstChild;
+			firstElmNode = itmCached.firstElementChild;
 			childNodes = itmCached.childNodes;
 			j_len = childNodes.length;
 
@@ -783,10 +784,10 @@ var componentName = "wb-fieldflow",
 
 			actions = [];
 
-			// Is firstNode an anchor?
-			if ( firstNode.nodeName === "A" ) {
-				itmValue = firstNode.getAttribute( "href" );
-				itmLabel = $( firstNode ).html().trim();
+			// Is firstElmNode an anchor?
+			if ( firstElmNode && firstElmNode.nodeName === "A" ) {
+				itmValue = firstElmNode.getAttribute( "href" );
+				itmLabel = $( firstElmNode ).html().trim();
 				j_len = 1; // Force following elements to be ignored
 
 				actions.push( {


### PR DESCRIPTION
Anchors were previously detected by evaluating ``firstChild``'s node name... which only worked if the very first node was an anchor element.

As a result, if the first node was something other than an element (e.g. comment or text node with empty space)... they'd be evaluated instead of the real anchor and consequently mess up the redirection action.

This resolves it by evaluating ``firstElementChild`` instead of ``firstChild``. Also adds a comment and empty space to some of the redirection examples.