### PR TITLE
Méli-mélo Charts: mobile table, canvas container

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2377,6 +2377,28 @@
 				"language": "fr",
 				"path": "page-details-pft-share-fr.html"
 			}
+		],
+		"reports": [
+			{
+				"title": "Accessibility (Only new SC WCAG 2.1/2.2 Level AA)- Page Details - English report",
+				"language": "en",
+				"path": "reports/pre-a11y-1-en.html"
+			},
+			{
+				"title": "Accessibility (Only new SC WCAG 2.1/2.2 Level AA)- Page Details - French report",
+				"language": "fr",
+				"path": "reports/pre-a11y-1-fr.html"
+			},
+			{
+				"title": "Accessibility (Only new SC WCAG 2.1/2.2 Level AA)- Page Details (Basic Html version)- English report",
+				"language": "en",
+				"path": "reports/pre-a11y-basic-html-1-en.html"
+			},
+			{
+				"title": "Accessibility (Only new SC WCAG 2.1/2.2 Level AA)- Page Details (Basic Html version)- French report",
+				"language": "fr",
+				"path": "reports/pre-a11y-basic-html-1-fr.html"
+			}
 		]
 	},
 	"dependencies": [
@@ -3100,11 +3122,12 @@
 		"en": "Documentation and working example on how to use the skiplinks.",
 		"fr": "Documentation et example pratique sur l'utilisation des liens de saut de page."
 	},
-	"modified": "2022-01-12",
+	"modified": "2024-02-27",
 	"componentName": "skiplinks",
+	"processing": "baseline",
 	"status": "stable",
 	"pages": {
-		"docs": [
+		"examples": [
 			{
 				"title": "Skip links",
 				"language": "en",
@@ -3114,6 +3137,18 @@
 				"title": "Liens de saut de page",
 				"language": "fr",
 				"path": "skiplinks-fr.html"
+			}
+		],
+		"reports": [
+			{
+				"title": "Accessibility assessment #1 - Skip links",
+				"language": "en",
+				"path": "reports/a11y-1-en.html"
+			},
+			{
+				"title": "Évaluation d'accessibilité #1 - Liens de saut de page",
+				"language": "fr",
+				"path": "reports/a11y-1-fr.html"
 			}
 		]
 	}

--- a/méli-mélo/2024-02-charts/demo.html
+++ b/méli-mélo/2024-02-charts/demo.html
@@ -303,3 +303,49 @@ script:
 		<tr><th>Infrastructure</th><td>8</td><td>6</td><td>1</td><td>9</td></tr>
 	</tbody>
 </table>
+
+<h2>Line chart with table visible</h2>
+<p>This example demonstrates the use of the following configuration options: <code>data-chart-details-open</code>.</p>
+<table class="text-right table table-striped" data-chart="line" data-chart-details-open="true">
+	<caption>Account holdings by type (line chart)</caption>
+	<thead>
+		<tr>
+			<th class="text-left">Years</th>
+			<th class="text-right">Amounts contributed or transferred</th>
+			<th class="text-right" data-chart-set-ignore="true">Investment income</th>
+			<th class="text-right">Total account holdings</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th data-chart-value="Year 1">1</th>
+			<td>$4,000</td>
+			<td>$240</td>
+			<td>$4,240</td>
+		</tr>
+		<tr>
+			<th data-chart-value="Year 2">2</th>
+			<td>$8,000</td>
+			<td>$734</td>
+			<td>$8,734</td>
+		</tr>
+		<tr>
+			<th data-chart-value="Year 3">3</th>
+			<td>$12,000</td>
+			<td>$1,498</td>
+			<td>$13,498</td>
+		</tr>
+		<tr>
+			<th data-chart-value="Year 4">4</th>
+			<td>$16,000</td>
+			<td>$2,548</td>
+			<td>$18,548</td>
+		</tr>
+		<tr>
+			<th data-chart-value="Year 5">5</th>
+			<td>$20,000</td>
+			<td>$3,901</td>
+			<td>$23,901</td>
+		</tr>
+	</tbody>
+</table>

--- a/méli-mélo/2024-02-charts/index.html
+++ b/méli-mélo/2024-02-charts/index.html
@@ -111,6 +111,14 @@ script:
 				<td><code>String</code></td>
 				<td>No default value.</td>
 			</tr>
+			<tr>
+				<td><code>data-chart-details-open</code></td>
+				<td>
+					<p>Defines if the dynamically created <code>&lt;details></code> element should be open by default.</p>
+				</td>
+				<td><code>Boolean</code></td>
+				<td><p>If not defined, the <code>&lt;details></code> element will be closed.</p><p>If defined, the <code>&lt;details></code> element will be open.</p></td>
+			</tr>
 		</tbody>
 	</table>
 </section>

--- a/méli-mélo/2024-02-charts/js/charts.js
+++ b/méli-mélo/2024-02-charts/js/charts.js
@@ -32,8 +32,9 @@ var componentName = "chart",
 				tableObserver,
 				elmChartType, supportedChartTypes, defaults,
 				chartType, chartOpts, chartData,
-				chartCntnr, canvasElm, detailsElm,
-				i18n, i18nText;
+				chartCntnr, canvasElm, tableContainer,
+				i18n, i18nText,
+				detailsOpen = "";
 
 			// Define default options
 			defaults = {
@@ -61,17 +62,23 @@ var componentName = "chart",
 				};
 			}
 
+			// Check if <details> element should be open or closed
+			if ( elm.dataset.chartDetailsOpen ) {
+				detailsOpen = "open";
+			}
+
 			// Creating UI template
 			chartCntnr = document.createElement( "figure" );
 			chartCntnr.innerHTML = `<figcaption class="h3">` + elm.caption.innerHTML + `</figcaption>
-				<canvas aria-label="` + elm.caption.innerHTML + i18nText.tableFollowing + `" role="img"></canvas>
-				<details class="mrgn-tp-md">
+				<div><canvas aria-label="` + elm.caption.innerHTML + i18nText.tableFollowing + `" role="img"></canvas></div>
+				<details class="mrgn-tp-md"`+ detailsOpen +`>
 					<summary>` + elm.caption.innerHTML + i18nText.tableMention + `</summary>
+					<div class="table-responsive"></div>
 				</details>`;
 			elm.parentNode.insertBefore( chartCntnr, elm );
 			canvasElm = chartCntnr.querySelector( "canvas" );
-			detailsElm = chartCntnr.querySelector( "details" );
-			detailsElm.appendChild( elm );
+			tableContainer = chartCntnr.querySelector( ".table-responsive" );
+			tableContainer.appendChild( elm );
 
 			// Set Chart options
 			chartType = elm.dataset.chart;


### PR DESCRIPTION
Adding the following:
- Ability to display the table by default using the attribute "data-chart-details-open".
- Wrapping the <canvas> element in a container to allow for custom styling.
- Adding a <div class="table-responsive"> around the table to fix overflow issue on mobile.