### PR TITLE
GC Home Page: WCAG 2.1 AA Assessment

### DIFF
--- a/templates/home/index.json-ld
+++ b/templates/home/index.json-ld
@@ -44,14 +44,14 @@
 		],
 		"reports": [
 			{
-				"title": "Pre-accessibility assessment #1",
+				"title": "Accessibility assessment #1 - GC Home Page",
 				"language": "en",
-				"path": "reports/pre-a11y-1-en.html"
+				"path": "reports/a11y-1-en.html"
 			},
 			{
-				"title": "Évaluation de pré-accessibilité #1",
+				"title": "Évaluation d'accessibilité #1 - Page d'accueil du GC",
 				"language": "fr",
-				"path": "reports/pre-a11y-1-fr.html"
+				"path": "reports/a11y-1-fr.html"
 			}
 		]
 	}

--- a/templates/home/reports/a11y-1-en.html
+++ b/templates/home/reports/a11y-1-en.html
@@ -1,15 +1,15 @@
 ---
 {
-	"title": "Pre-accessibility assessment #1",
+	"title": "Accessibility assessment #1 - GC Home Page",
 	"language": "en",
 	"description": "Assessing the main content of the GC Home Page template",
 	"tag": "home",
 	"parentdir": "home",
 	"parentPage": "Home - Canada.ca",
 	"parentPageURL": "home-en.html",
-	"altLangPage": "pre-a11y-1-fr.html",
-	"dateModified": "2023-07-14",
+	"altLangPage": "a11y-1-fr.html",
+	"dateModified": "2024-04-04",
 	"layout": "assessment_wrote_en-en",
-	"reportURL": "pre-a11y-1.json"
+	"reportURL": "a11y-1.json"
 }
 ---

--- a/templates/home/reports/a11y-1-fr.html
+++ b/templates/home/reports/a11y-1-fr.html
@@ -1,15 +1,15 @@
 ---
 {
-	"title": "Évaluation de pré-accessibilité #1",
+	"title": "Évaluation d'accessibilité #1 - Page d'accueil du GC",
 	"language": "fr",
 	"description": "Évaluation du contenu principal du modèle de page d'accueil du GC",
 	"tag": "home",
 	"parentdir": "home",
 	"parentPage": "Accueil - Canada.ca",
 	"parentPageURL": "home-fr.html",
-	"altLangPage": "pre-a11y-1-en.html",
-	"dateModified": "2023-07-14",
+	"altLangPage": "a11y-1-en.html",
+	"dateModified": "2024-04-04",
 	"layout": "assessment_wrote_en-fr",
-	"reportURL": "pre-a11y-1.json"
+	"reportURL": "a11y-1.json"
 }
 ---

--- a/templates/home/reports/a11y-1.json
+++ b/templates/home/reports/a11y-1.json
@@ -22,13 +22,13 @@
     "foaf:homepage": "https://github.com/ServiceCanada",
     "@type": ["earl:Assertor", "foaf:Organization"],
     "earl:mainAssertor": {
-      "foaf:name": "Jonas Graham (Github: @jonasg-gc)",
-      "foaf:homepage": "https://github.com/jonasg-gc",
+      "foaf:name": "Brahim Mahadi Wachilli (Github: @BrahimMahadi)",
+      "foaf:homepage": "https://github.com/BrahimMahadi",
       "@type": ["earl:Assertor", "foaf:Person"]
     }
   },
 
-  "dct:date": "2023-07-14",
+  "dct:date": "2024-04-04",
   "dct:description": "Analyzing and exploring the subject and produce a pre-evaluation of all WCAG 2.1 SC at level AA.",
   "acr:involvesExpertise": [ ],
   "dct:source": "act:rulesets/wcag2x/wcag21_all_levelAA.json",
@@ -38,7 +38,7 @@
   "earl:result": [
     {
       "earl:test": "WCAG21:non-text-content",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "earl:subject": "_:subject",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
@@ -87,7 +87,7 @@
     {
       "earl:test": "WCAG21:info-and-relationships",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -95,7 +95,7 @@
     {
       "earl:test": "WCAG21:meaningful-sequence",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -103,7 +103,7 @@
     {
       "earl:test": "WCAG21:sensory-characteristics",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -111,7 +111,7 @@
     {
       "earl:test": "WCAG21:orientation",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -119,7 +119,7 @@
     {
       "earl:test": "WCAG21:identify-input-purpose",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -127,7 +127,7 @@
     {
       "earl:test": "WCAG21:use-of-color",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -143,7 +143,7 @@
     {
       "earl:test": "WCAG21:contrast-minimum",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -151,7 +151,7 @@
     {
       "earl:test": "WCAG21:resize-text",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -159,7 +159,7 @@
     {
       "earl:test": "WCAG21:image-of-text",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -167,7 +167,7 @@
     {
       "earl:test": "WCAG21:reflow",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -175,7 +175,7 @@
     {
       "earl:test": "WCAG21:non-text-contrast",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -183,7 +183,7 @@
     {
       "earl:test": "WCAG21:text-spacing",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -191,7 +191,7 @@
     {
       "earl:test": "WCAG21:content-on-hover-or-focus",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:inapplicable",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -199,7 +199,7 @@
     {
       "earl:test": "WCAG21:keyboard",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -207,7 +207,7 @@
     {
       "earl:test": "WCAG21:no-keyboard-trap",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -239,7 +239,7 @@
     {
       "earl:test": "WCAG21:three-flashes-or-below-threshold",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -247,7 +247,7 @@
     {
       "earl:test": "WCAG21:bypass-blocks",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -255,7 +255,7 @@
     {
       "earl:test": "WCAG21:page-titled",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -263,7 +263,7 @@
     {
       "earl:test": "WCAG21:focus-order",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -271,7 +271,7 @@
     {
       "earl:test": "WCAG21:link-purpose-in-context",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -279,7 +279,7 @@
     {
       "earl:test": "WCAG21:multiple-ways",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -287,7 +287,7 @@
     {
       "earl:test": "WCAG21:headings-and-labels",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -295,7 +295,7 @@
     {
       "earl:test": "WCAG21:focus-visible",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -303,7 +303,7 @@
     {
       "earl:test": "WCAG21:pointer-gestures",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "menu and submenus",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -311,7 +311,7 @@
     {
       "earl:test": "WCAG21:pointer-cancellation",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -319,7 +319,7 @@
     {
       "earl:test": "WCAG21:label-in-name",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -335,7 +335,7 @@
     {
       "earl:test": "WCAG21:language-of-page",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -343,7 +343,7 @@
     {
       "earl:test": "WCAG21:language-of-parts",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -351,7 +351,7 @@
     {
       "earl:test": "WCAG21:on-focus",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -359,7 +359,7 @@
     {
       "earl:test": "WCAG21:on-input",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -367,7 +367,7 @@
     {
       "earl:test": "WCAG21:consistent-navigation",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -375,7 +375,7 @@
     {
       "earl:test": "WCAG21:consistent-identification",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -383,7 +383,7 @@
     {
       "earl:test": "WCAG21:error-identification",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -391,7 +391,7 @@
     {
       "earl:test": "WCAG21:labels-or-instructions",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -399,7 +399,7 @@
     {
       "earl:test": "WCAG21:error-suggestion",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -415,7 +415,7 @@
     {
       "earl:test": "WCAG21:parsing",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]
@@ -423,7 +423,7 @@
     {
       "earl:test": "WCAG21:name-role-value",
       "earl:subject": "_:subject",
-      "earl:outcome": "earl:untested",
+      "earl:outcome": "earl:passed",
       "dct:description": "",
       "earl:mode": "earl:unknownMode",
       "@type": ["earl:TestResult", "earl:Assertion"]


### PR DESCRIPTION
### This pull request includes the WCAG 2.1 Accessibility assessment done for the GC home page template.


General checklist
- [x] Updated GC home page template documentation to include the accessibility assessment reports
- [x] GC home page template was assessed against WCAG for accessibility
- [x] Documentation is bilingual 
