### PR TITLE
GC Table of Contents: WCAG 2.1 AA Assessment

### DIFF
--- a/components/gc-toc/index.json-ld
+++ b/components/gc-toc/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "Table of Contents to navigate on same page subsections",
 		"fr": "Table des matières pour naviguer vers les sous-sections de la page"
 	},
-	"modified": "2023-06-16",
+	"modified": "2024-05-01",
 	"componentName": "gc-toc",
 	"status": "stable",
 	"pages": {
@@ -28,6 +28,18 @@
 				"title": "Table des matières",
 				"language": "fr",
 				"path": "toc-fr.html"
+			}
+		],
+		"reports": [
+			{
+				"title": "Accessibility assessment #1 - In-page table of contents",
+				"language": "en",
+				"path": "reports/a11y-1-en.html"
+			},
+			{
+				"title": "Assessment d'accessibilité #1 - Table des matières",
+				"language": "fr",
+				"path": "reports/a11y-1-fr.html"
 			}
 		]
 	}

--- a/components/gc-toc/reports/a11y-1-en.html
+++ b/components/gc-toc/reports/a11y-1-en.html
@@ -1,0 +1,11 @@
+---
+{
+	"title": "Accessibility assessment #1 - In-page table of contents",
+	"language": "en",
+	"description": "Evaluation of the GC in-page table of contents in order to determine if they are aligned with our design and are compliant to our accessibility guideline when used as is without any special customization.",
+	"altLangPage": "a11y-1-fr.html",
+	"dateModified": "2024-04-30",
+	"layout": "assessment_wrote_en-en",
+	"reportURL": "a11y-1.json"
+}
+---

--- a/components/gc-toc/reports/a11y-1-fr.html
+++ b/components/gc-toc/reports/a11y-1-fr.html
@@ -1,0 +1,11 @@
+---
+{
+	"title": "Assessment d'accessibilité #1 - Table des matières à l'intérieur de la page",
+	"language": "fr",
+	"description": "Évaluation du table des matières à l'intérieur de la page GC afin de déterminer si elles sont alignées avec notre conception et sont conformes à nos lignes directrices en matière d'accessibilité lorsqu'elles sont utilisées telles quelles sans aucune personnalisation particulière.",
+	"altLangPage": "a11y-1-en.html",
+	"dateModified": "2024-04-30",
+	"layout": "assessment_wrote_en-fr",
+	"reportURL": "a11y-1.json"
+}
+---

--- a/components/gc-toc/reports/a11y-1.json
+++ b/components/gc-toc/reports/a11y-1.json
@@ -1,0 +1,441 @@
+{
+  "@context": "https://wet-boew.github.io/vocab/context/2023/assessment-report-en.json-ld",
+
+  "@type": [ "earl:Assertion", "acr:AssessmentReport" ],
+
+  "earl:subject": {
+    "@id": "_:subject",
+    "dct:references": "https://wet-boew.github.io/GCWeb/components/components-en.html",
+    "@type": [
+      "earl:TestSubject",
+      "schema:WebPage"
+    ],
+    "dct:description": "Evaluation of the GC in-page table of contents in order to determine if they are aligned with our design and are compliant to our accessibility guideline when used as is without any special customization.",
+    "earl:pointer": {
+      "@type": "oa:CssSelector",
+      "@value": ""
+    }
+  },
+
+  "earl:assertedBy": {
+    "foaf:name": "Service Canada - Principal Publisher",
+    "foaf:homepage": "https://github.com/ServiceCanada",
+    "@type": ["earl:Assertor", "foaf:Organization"],
+    "earl:mainAssertor": {
+      "foaf:name": "Brahim Mahadi Wachilli (Github: @BrahimMahadi)",
+      "foaf:homepage": "https://github.com/BrahimMahadi",
+      "@type": ["earl:Assertor", "foaf:Person"]
+    }
+  },
+
+  "dct:date": "2024-04-30",
+  "dct:description": "Analyzing and exploring the subject and produce an evaluation of all WCAG 2.1 SC at level AA.",
+  "acr:involvesExpertise": [],
+
+  "dct:source": "act:rulesets/wcag2x/wcag21_all_levelAA.json",
+  "acr:standard": "https://www.w3.org/TR/WCAG21",
+  "acr:conformanceOption": "act:standard/profiles/wcag#levelAA",
+
+  "earl:result": [
+    {
+      "earl:test": "WCAG21:non-text-content",
+      "earl:outcome": "earl:passed",
+      "earl:subject": "_:subject",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:audio-only-and-video-only-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:captions-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:audio-description-or-media-alternative-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:captions-live",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:audio-description-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:info-and-relationships",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:meaningful-sequence",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:sensory-characteristics",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:orientation",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:identify-input-purpose",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:use-of-color",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:audio-control",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:contrast-minimum",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:resize-text",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:image-of-text",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:reflow",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:non-text-contrast",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:text-spacing",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:content-on-hover-or-focus",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:keyboard",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:no-keyboard-trap",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:character-key-shortcuts",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:timing-adjustable",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:pause-stop-hide",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:three-flashes-or-below-threshold",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:bypass-blocks",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:page-titled",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:focus-order",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:link-purpose-in-context",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:multiple-ways",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:headings-and-labels",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:focus-visible",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:pointer-gestures",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:pointer-cancellation",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:label-in-name",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:motion-actuation",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:language-of-page",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:language-of-parts",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:on-focus",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:on-input",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:consistent-navigation",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:consistent-identification",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:error-identification",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:labels-or-instructions",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:error-suggestion",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:error-prevention-legal-financial-data)",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:parsing",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:name-role-value",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:passed",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    },
+    {
+      "earl:test": "WCAG21:status-messages",
+      "earl:subject": "_:subject",
+      "earl:outcome": "earl:inapplicable",
+      "dct:description": "",
+      "earl:mode": "earl:unknownMode",
+      "@type": ["earl:TestResult", "earl:Assertion"]
+    }
+  ]
+}


### PR DESCRIPTION
### This pull request includes the WCAG 2.1 Accessibility assessment done for the GC in-page table of contents.


General checklist
- [x] Updated GC in-page table of contents documentation to include the accessibility assessment reports
- [x] GC in-page table of contents was assessed against WCAG for accessibility
- [x] Documentation is bilingual 
