### PR TITLE
CID - Update for the copy missing _sprite_share.scss

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Copy the missing _sprite_share.scss file - related to GCWeb#1737 about wet-boew#cc340a6 commit
         run: |
-          curl https://gist.githubusercontent.com/duboisp/d69787b300eb1f4d40f937508e10d013/raw/12cd8472baf6070d9868bdce3d961c3fb6320c83/_sprites_share.scss >> _sprites_share.scss
+          curl https://gist.githubusercontent.com/duboisp/d69787b300eb1f4d40f937508e10d013/raw/86e7a0b15ad6a695754599e9793e986b460bf514/_sprites_share.scss >> _sprites_share.scss
           mv _sprites_share.scss node_modules/wet-boew/src/plugins/share/sprites/_sprites_share.scss
 
       - name: Checkout wet-boew latest build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Copy the missing _sprite_share.scss file - related to GCWeb#1737 about wet-boew#cc340a6 commit
         run: |
-          curl https://gist.githubusercontent.com/duboisp/d69787b300eb1f4d40f937508e10d013/raw/12cd8472baf6070d9868bdce3d961c3fb6320c83/_sprites_share.scss >> _sprites_share.scss
+          curl https://gist.githubusercontent.com/duboisp/d69787b300eb1f4d40f937508e10d013/raw/86e7a0b15ad6a695754599e9793e986b460bf514/_sprites_share.scss >> _sprites_share.scss
           mv _sprites_share.scss node_modules/wet-boew/src/plugins/share/sprites/_sprites_share.scss
 
       - name: Checkout wet-boew latest build


### PR DESCRIPTION
Because 'Share this page' plugin was updated in wet-boew to add support for X social media.

Diff: https://gist.github.com/duboisp/d69787b300eb1f4d40f937508e10d013/revisions

Related to wet-boew PR # 9734

This need to be merged immediately before or after when we will update to the wet-boew version 4.0.80