### PR TITLE
Updating TC links to https://tc.canada.ca/ instead of https://www.tc.gc.ca/

### DIFF
--- a/sites/gcweb-menu/ajax/sitemenu-v5-en.hbs
+++ b/sites/gcweb-menu/ajax/sitemenu-v5-en.hbs
@@ -263,7 +263,7 @@ language: "en"
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence/nationalsecurity.html">National security</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence/caf.html">Canadian Armed Forces</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence/defence-equipment-purchases-upgrades.html">Defence equipment purchases and upgrades</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/transportation-security.html">Transportation security</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/corporate-services/transportation-security">Transportation security</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence/securingborder.html">Securing the border</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence/cybersecurity.html">Cyber security</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence/jobs.html">Jobs in national security and defence</a></li>
@@ -350,22 +350,22 @@ language: "en"
 			<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport<span class="hidden-xs hidden-sm"> and infrastructure</span><span class="visible-xs-inline visible-sm-inline">: home</span></a>
 		</li>
 		<li role="separator"></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/aviation.html">Aviation</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/marine.html">Marine transportation</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/road.html">Road transportation</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/rail.html">Rail transportation</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/dangerous-goods.html">Dangerous goods</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/infrastructure.html">Infrastructure</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/aviation">Aviation</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/marine-transportation">Marine transportation</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/road-transportation">Road transportation</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/rail-transportation">Rail transportation</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/dangerous-goods">Dangerous goods</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/infrastructure">Infrastructure</a></li>
 		<li role="separator" aria-orientation="vertical"></li>
 		<li role="presentation">
 			<a data-keep-expanded="md-min" href="#" role="menuitem" tabindex="-1" aria-haspopup="true" aria-controls="gc-mnu-trans-sub" aria-expanded="true">Most requested</a>
 			<ul id="gc-mnu-trans-sub" role="menu" aria-orientation="vertical">
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/aviation/drone-safety.html">Drone safety</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/eng/aviationsecurity/page-147.htm">What you can't bring on an airplane</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/eng/marinesafety/oep-vesselreg-menu-728.htm">Register your vessel</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/en/services/road/child-car-seat-safety.html">Child car seat safety</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/eng/tdg/clear-tofc-211.htm">Transporting dangerous goods - Regulations</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/eng/acts-regulations/regulations-sor96-433.htm">Canadian Aviation Regulations</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/aviation/drone-safety">Drone safety</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/aviation/aviation-security/what-you-can-t-bring-plane">What you can't bring on an airplane</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/marine-transportation/vessel-licensing-registration">Register your vessel</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/road-transportation/child-car-seat-safety">Child car seat safety</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/dangerous-goods/table-contents">Transporting dangerous goods - Regulations</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/en/corporate-services/acts-regulations/list-regulations/canadian-aviation-regulations-sor-96-433">Canadian Aviation Regulations</a></li>
 			</ul>
 		</li>
 	</ul>

--- a/sites/gcweb-menu/ajax/sitemenu-v5-fr.hbs
+++ b/sites/gcweb-menu/ajax/sitemenu-v5-fr.hbs
@@ -263,7 +263,7 @@
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense/securitenationale.html">Sécurité nationale</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense/fac.html">Forces armées canadiennes</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense/achat-mise-a-niveau-equipement-defense.html">Achat et mise à niveau d’équipement de la Défense</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/surete-transports.html">Sûreté des transports</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/services-generaux/surete-transports">Sûreté des transports</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense/securiserfrontiere.html">Sécuriser la frontière</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense/cybersecurite.html">Cybersécurité</a></li>
 		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/defense/emplois.html">Emplois en sécurité nationale et en défense</a></li>
@@ -348,22 +348,22 @@
 			<a role="menuitem" tabindex="-1" href="https://www.canada.ca/fr/services/transport.html">Transport<span class="hidden-xs hidden-sm"> et infrastructure</span><span class="visible-xs-inline visible-sm-inline"> : accueil</span></a>
 		</li>
 		<li role="separator"></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/aviation.html">Aviation</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/maritime.html">Transport maritime</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/routier.html">Transport routier</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/ferroviaire.html">Transport ferroviaire</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/marchandises-dangereuses.html">Marchandises dangereuses</a></li>
-		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/infrastructures.html">Infrastructure</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/aviation">Aviation</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/transport-maritime">Transport maritime</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/transport-routier">Transport routier</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/transport-ferroviaire">Transport ferroviaire</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/marchandises-dangereuses">Marchandises dangereuses</a></li>
+		<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/infrastructures">Infrastructure</a></li>
 		<li role="separator" aria-orientation="vertical"></li>
 		<li role="presentation">
 			<a data-keep-expanded="md-min" href="#" role="menuitem" tabindex="-1" aria-haspopup="true" aria-controls="gc-mnu-trans-sub" aria-expanded="true">En demande</a>
 			<ul id="gc-mnu-trans-sub" role="menu" aria-orientation="vertical">
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/aviation/securite-drones.html">Sécurité des drones</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/surete-transports/aerienne/articles-interdits-bord-avion.html">Articles interdits à bord d’un avion</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fra/securitemaritime/epe-immabatiments-menu-728.htm">Immatriculer votre bâtiment</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/services/routier/securite-sieges-auto-enfants.html">Sécurité des sièges d'auto pour enfants</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fra/tmd/clair-tdesm-211.htm">Transporter des marchandises dangereuses - Règlements</a></li>
-				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://www.tc.gc.ca/fr/transports-canada/organisation/lois-reglements/reglements/sor-96-433.html">Règlement de l’aviation canadien</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/aviation/securite-drones">Sécurité des drones</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/aviation/surete-aerienne/ce-que-vous-ne-pouvez-pas-apporter-dans-avion">Articles interdits à bord d’un avion</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/transport-maritime/permis-immatriculation-batiments">Immatriculer votre bâtiment</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/transport-routier/securite-sieges-auto-enfants">Sécurité des sièges d'auto pour enfants</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/marchandises-dangereuses/table-matieres">Transporter des marchandises dangereuses - Règlements</a></li>
+				<li role="presentation"><a role="menuitem" tabindex="-1" href="https://tc.canada.ca/fr/services-generaux/lois-reglements/liste-reglements/reglement-aviation-canadien-dors-96-433">Règlement de l’aviation canadien</a></li>
 			</ul>
 		</li>
 	</ul>


### PR DESCRIPTION
The menu does not use the new tc.canada.ca domain and might stop working in the future. 