### PR TITLE
Patch - Most Requested: fix link word wrapping

### DIFF
--- a/components/gc-most-requested/_screen-md-min.scss
+++ b/components/gc-most-requested/_screen-md-min.scss
@@ -13,12 +13,12 @@ div:not(.container) .gc-most-requested {
 	ul {
 		display: flex;
 		flex-wrap: wrap;
-		list-style-position: inside;
-		padding-left: 1.3em;
+		padding-left: 2.5em;
 
 		li {
 			flex-basis: 50%;
 			font-size: $small-size;
+			padding-right: 1.3em;
 		}
 	}
 }


### PR DESCRIPTION
Fixes when links are wrapping on two lines.

Before fix: 
![Screen Shot 2024-06-07 at 3 15 32 PM](https://github.com/wet-boew/GCWeb/assets/4456887/f5b6cba7-f81f-4739-abe4-52ba101333e4)

After fix:
![Screen Shot 2024-06-07 at 3 15 25 PM](https://github.com/wet-boew/GCWeb/assets/4456887/08d814d7-98d3-4445-919f-60b3d505caf7)
