### PR TITLE
update ruby to v.3.3.0, install webrick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG RUBY_VERSION=2.7.3
+ARG RUBY_VERSION=3.3.0
 FROM ruby:$RUBY_VERSION
 
 RUN apt-get update \
@@ -15,6 +15,7 @@ RUN apt-get update \
     jekyll-github-metadata \
     minitest \
   && gem install rake html-proofer \
+  && gem install webrick \
   && mkdir -p /usr/src/app \
   && rm -rf /usr/lib/ruby/gems/*/cache/*.gem
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem 'minitest'
 #gem "scss_lint"
 gem "html-proofer"
 gem "rake"
+gem "webrick"


### PR DESCRIPTION
These Dockerfile updates resolve the issues encountered when running GCWeb with the latest Docker Desktop for Windows version 4.30.1. 
The updates have also been tested successfully on Docker Desktop versions 4.30.0,  4.19.0 and 4.10.1.