### PR TITLE
Components: Add French "Code sample" translations

### DIFF
--- a/common/button/button-fr.html
+++ b/common/button/button-fr.html
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"altLangPage": "button-en.html",
 	"description": "Page des boutons comprenant des exemples de travail pour tester l'apparence et le fonctionnement de divers styles de boutons.",
-	"dateModified": "2023-09-01"
+	"dateModified": "2024-07-11"
 }
 ---
 
@@ -86,7 +86,7 @@
 <button type="button" class="btn btn-link">Lien</button>
 <a href="#" class="btn btn-default">Ancre <code>&lt;a></code> sous forme de bouton</a>
 
-<h4>Code sample</h4>
+<h4>Exemple de code</h4>
 <pre><code>
 	// Défaut:
 	&lt;button type="button" class="btn <strong>btn-default</strong>"&gt;
@@ -342,7 +342,7 @@ Lien
 </div>
 </div>
 
-<h4>Code sample</h4>
+<h4>Exemple de code</h4>
 <pre><code>// Barres à outils:
 &lt;div class="<strong>btn-toolbar</strong>" role="toolbar" aria-label="Barres à outils avec groupes de boutons"&gt;
 	&lt;div class="btn-group" role="group" aria-label="Premier groupe"&gt;

--- a/components/gc-minister/gc-minister-fr.html
+++ b/components/gc-minister/gc-minister-fr.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministre ou chef d'institution - Documentation", "link": "components/gc-minister/gc-minister-doc-fr.html" }
 	],
-	"dateModified": "2024-03-11"
+	"dateModified": "2024-07-11"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -16,6 +16,6 @@
 
 {% include_relative samples/gc-minister.html %}
 <details>
-	<summary>Code sample</summary>
+	<summary>Exemple de code</summary>
 	{% highlight html %}{% include_relative samples/gc-minister.html %}{% endhighlight %}
 </details>

--- a/components/gc-minister/gc-minister-special-cases-fr.html
+++ b/components/gc-minister/gc-minister-special-cases-fr.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministre ou chef d'institution - Documentation", "link": "components/gc-minister/gc-minister-doc-fr.html" }
 	],
-	"dateModified": "2024-03-11"
+	"dateModified": "2024-07-11"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -16,6 +16,6 @@
 
 {% include_relative samples/gc-minister-special-cases.html %}
 <details>
-	<summary>Code sample</summary>
+	<summary>Exemple de code</summary>
 	{% highlight html %}{% include_relative samples/gc-minister-special-cases.html %}{% endhighlight %}
 </details>

--- a/components/gc-minister/gc-minister-two-ministers-fr.html
+++ b/components/gc-minister/gc-minister-two-ministers-fr.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministre ou chef d'institution - Documentation", "link": "components/gc-minister/gc-minister-doc-fr.html" }
 	],
-	"dateModified": "2024-03-11"
+	"dateModified": "2024-07-11"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -16,6 +16,6 @@
 
 {% include_relative samples/gc-minister-two-ministers.html %}
 <details>
-	<summary>Code sample</summary>
+	<summary>Exemple de code</summary>
 	{% highlight html %}{% include_relative samples/gc-minister-two-ministers.html %}{% endhighlight %}
 </details>

--- a/components/gc-most-requested/gc-most-requested-fr.html
+++ b/components/gc-most-requested/gc-most-requested-fr.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "gc-most-requested-en.html",
-	"dateModified": "2024-02-14",
+	"dateModified": "2024-07-11",
 	"description": "Exemples pratiques pour la composante En demande",
 	"language": "fr",
 	"title": "En demande",
@@ -22,7 +22,7 @@
 
 <div class="container">
 	<details>
-		<summary>Code sample</summary>
+		<summary>Exemple de code</summary>
 		{% highlight html %}{% include_relative samples/gc-most-requested.html %}{% endhighlight %}
 	</details>
 </div>


### PR DESCRIPTION
Some French component pages were using English "Code sample" headings/summaries written without language switches. The rest of their content was fully written in French.

This revises the headings/summaries in question to "Exemple de code".