### PR TITLE
Date modified: Fix iteration 1's code samples

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -479,7 +479,7 @@
 		"en": "Indicates the date on which the current page was last modified.",
 		"fr": "Indique la date à laquelle la page courante a été modifiée pour la dernière fois."
 	},
-	"modified": "2023-11-02",
+	"modified": "2024-07-11",
 	"componentName": "date-modified",
 	"status": "stable",
 	"version": "1.0",
@@ -590,13 +590,13 @@
 					"@type": "source-code",
 					"@language": "en",
 					"description": "Code sample",
-					"code": "&lt;dl id=\"wb-dtmd\">\n\t&lt;dt>Date modified:&lt;/dt>\n\t&lt;dd>&lt;time property=\"dateModified\">YYYY-MM-DD&lt;/time>&lt;/dd>\n&lt;/dl>"
+					"code": "<dl id=\"wb-dtmd\">\n\t<dt>Date modified:</dt>\n\t<dd><time property=\"dateModified\">YYYY-MM-DD</time></dd>\n</dl>"
 				},
 				{
 					"@type": "source-code",
-					"@language": "en",
-					"description": "Code sample with contact link",
-					"code": "&lt;dl id=\"wb-dtmd\">\n\t&lt;dt>Date de modification&nbsp;:&lt;/dt>\n\t&lt;dd>&lt;time property=\"dateModified\">YYYY-MM-DD&lt;/time>&lt;/dd>\n&lt;/dl>"
+					"@language": "fr",
+					"description": "Exemple de code",
+					"code": "<dl id=\"wb-dtmd\">\n\t<dt>Date de modification&nbsp;:</dt>\n\t<dd><time property=\"dateModified\">YYYY-MM-DD</time></dd>\n</dl>"
 				}
 			]
 		}

--- a/sites/date-modified/date-modified-en.html
+++ b/sites/date-modified/date-modified-en.html
@@ -2,7 +2,7 @@
 {
 	"layout": "documentation",
 	"altLangPage": "date-modified-fr.html",
-	"dateModified": "2023-11-02",
+	"dateModified": "2024-07-11",
 	"index_json": "index.json-ld",
 	"description": "Documentation on how to use the date modified.",
 	"language": "en",

--- a/sites/date-modified/date-modified-fr.html
+++ b/sites/date-modified/date-modified-fr.html
@@ -2,7 +2,7 @@
 {
 	"layout": "documentation",
 	"altLangPage": "date-modified-en.html",
-	"dateModified": "2023-11-02",
+	"dateModified": "2024-07-11",
 	"index_json": "index.json-ld",
 	"description": "Documentation sur l'utilisation de la date de modification.",
 	"language": "fr",

--- a/sites/date-modified/index.json-ld
+++ b/sites/date-modified/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "Indicates the date on which the current page was last modified.",
 		"fr": "Indique la date à laquelle la page courante a été modifiée pour la dernière fois."
 	},
-	"modified": "2023-11-02",
+	"modified": "2024-07-11",
 	"componentName": "date-modified",
 	"status": "stable",
 	"version": "1.0",
@@ -125,13 +125,13 @@
 					"@type": "source-code",
 					"@language": "en",
 					"description": "Code sample",
-					"code": "&lt;dl id=\"wb-dtmd\">\n\t&lt;dt>Date modified:&lt;/dt>\n\t&lt;dd>&lt;time property=\"dateModified\">YYYY-MM-DD&lt;/time>&lt;/dd>\n&lt;/dl>"
+					"code": "<dl id=\"wb-dtmd\">\n\t<dt>Date modified:</dt>\n\t<dd><time property=\"dateModified\">YYYY-MM-DD</time></dd>\n</dl>"
 				},
 				{
 					"@type": "source-code",
-					"@language": "en",
-					"description": "Code sample with contact link",
-					"code": "&lt;dl id=\"wb-dtmd\">\n\t&lt;dt>Date de modification&nbsp;:&lt;/dt>\n\t&lt;dd>&lt;time property=\"dateModified\">YYYY-MM-DD&lt;/time>&lt;/dd>\n&lt;/dl>"
+					"@language": "fr",
+					"description": "Exemple de code",
+					"code": "<dl id=\"wb-dtmd\">\n\t<dt>Date de modification&nbsp;:</dt>\n\t<dd><time property=\"dateModified\">YYYY-MM-DD</time></dd>\n</dl>"
 				}
 			]
 		}


### PR DESCRIPTION
That iteration's code samples had the following issues:
* Opening tags were coded as named entities (but not closing tags)... resulting in the named entities being literally shown in the samples
* French code sample wasn't categorized properly:
  * Language was set to English
  * Description was called "Code sample with contact link" (probably copied from one of the Page Feedback Tool [PFT]'s samples)

This resolves it by re-adding real opening tags and correcting French categorizations.