### PR TITLE
Docs: Render HTML in JSON description variables

### DIFF
--- a/sites/layouts/documentation.html
+++ b/sites/layouts/documentation.html
@@ -376,7 +376,7 @@ layout: default
 															"assess": "/collapsed",
 															"expect": true,
 															"mapping": [
-																{ "selector": "summary", "value": "/description" },
+																{ "selector": "summary", "value": "/description", "isHTML": true },
 																{ "selector": "code", "value": "/code", "encode": true }
 															]
 														},
@@ -386,7 +386,7 @@ layout: default
 															"assess": "/collapsed",
 															"expect": false,
 															"mapping": [
-																{ "selector": "figcaption", "value": "/description" },
+																{ "selector": "figcaption", "value": "/description", "isHTML": true },
 																{ "selector": "code", "value": "/code", "encode": true }
 															]
 														},
@@ -396,7 +396,7 @@ layout: default
 															"assess": "/collapsed",
 															"expect": "undefined",
 															"mapping": [
-																{ "selector": "figcaption", "value": "/description" },
+																{ "selector": "figcaption", "value": "/description", "isHTML": true },
 																{ "selector": "code", "value": "/code", "encode": true }
 															]
 														}
@@ -421,7 +421,7 @@ layout: default
 													"assess": "/collapsed",
 													"expect": true,
 													"mapping": [
-														{ "selector": "summary", "value": "/description" },
+														{ "selector": "summary", "value": "/description", "isHTML": true },
 														{ "selector": "code", "value": "/code", "encode": true }
 													]
 												},
@@ -431,7 +431,7 @@ layout: default
 													"assess": "/collapsed",
 													"expect": false,
 													"mapping": [
-														{ "selector": "figcaption", "value": "/description" },
+														{ "selector": "figcaption", "value": "/description", "isHTML": true },
 														{ "selector": "code", "value": "/code", "encode": true }
 													]
 												},
@@ -441,7 +441,7 @@ layout: default
 													"assess": "/collapsed",
 													"expect": "undefined",
 													"mapping": [
-														{ "selector": "figcaption", "value": "/description" },
+														{ "selector": "figcaption", "value": "/description", "isHTML": true },
 														{ "selector": "code", "value": "/code", "encode": true }
 													]
 												}
@@ -742,7 +742,7 @@ layout: default
 	"mapping": [
 		{ "selector": "details > summary", "value": "/name" },
 		{ "selector": "[data-status]", "value": "/status" },
-		{ "selector": "[data-description]", "value": "/description" },
+		{ "selector": "[data-description]", "value": "/description", "isHTML": true },
 		{ "selector": "[data-detectability]", "value": "/detectableBy" },
 		{ "selector": "[data-iteration]", "value": "/baseOnIteration/name" },
 
@@ -871,7 +871,7 @@ layout: default
 									"assess": "/collapsed",
 									"expect": true,
 									"mapping": [
-										{ "selector": "summary", "value": "/description" },
+										{ "selector": "summary", "value": "/description", "isHTML": true },
 										{ "selector": "code", "value": "/code", "encode": true }
 									]
 								},
@@ -881,7 +881,7 @@ layout: default
 									"assess": "/collapsed",
 									"expect": false,
 									"mapping": [
-										{ "selector": "figcaption", "value": "/description" },
+										{ "selector": "figcaption", "value": "/description", "isHTML": true },
 										{ "selector": "code", "value": "/code", "encode": true }
 									]
 								},
@@ -891,7 +891,7 @@ layout: default
 									"assess": "/collapsed",
 									"expect": "undefined",
 									"mapping": [
-										{ "selector": "figcaption", "value": "/description" },
+										{ "selector": "figcaption", "value": "/description", "isHTML": true },
 										{ "selector": "code", "value": "/code", "encode": true }
 									]
 								}
@@ -952,7 +952,7 @@ layout: default
 									"assess": "/collapsed",
 									"expect": true,
 									"mapping": [
-										{ "selector": "summary", "value": "/description" },
+										{ "selector": "summary", "value": "/description", "isHTML": true },
 										{ "selector": "code", "value": "/code", "encode": true }
 									]
 								},
@@ -962,7 +962,7 @@ layout: default
 									"assess": "/collapsed",
 									"expect": false,
 									"mapping": [
-										{ "selector": "figcaption", "value": "/description" },
+										{ "selector": "figcaption", "value": "/description", "isHTML": true },
 										{ "selector": "code", "value": "/code", "encode": true }
 									]
 								},
@@ -972,7 +972,7 @@ layout: default
 									"assess": "/collapsed",
 									"expect": "undefined",
 									"mapping": [
-										{ "selector": "figcaption", "value": "/description" },
+										{ "selector": "figcaption", "value": "/description", "isHTML": true },
 										{ "selector": "code", "value": "/code", "encode": true }
 									]
 								}
@@ -2103,7 +2103,7 @@ layout: default
 							"expect": "source-code",
 							"assess": "/",
 							"mapping": [
-								{ "selector": "summary", "value": "/description" },
+								{ "selector": "summary", "value": "/description", "isHTML": true },
 								{ "selector": "code", "value": "/code", "encode": "true" },
 								{ "selector": "details", "attr": "lang", "value": "/@language" }
 							]

--- a/sites/layouts/documentation_pattern.html
+++ b/sites/layouts/documentation_pattern.html
@@ -323,7 +323,7 @@ layout: default
 															"assess": "/collapsed",
 															"expect": true,
 															"mapping": [
-																{ "selector": "summary", "value": "/description" },
+																{ "selector": "summary", "value": "/description", "isHTML": true },
 																{ "selector": "code", "value": "/code", "encode": true }
 															]
 														},
@@ -333,7 +333,7 @@ layout: default
 															"assess": "/collapsed",
 															"expect": false,
 															"mapping": [
-																{ "selector": "figcaption", "value": "/description" },
+																{ "selector": "figcaption", "value": "/description", "isHTML": true },
 																{ "selector": "code", "value": "/code", "encode": true }
 															]
 														},
@@ -343,7 +343,7 @@ layout: default
 															"assess": "/collapsed",
 															"expect": "undefined",
 															"mapping": [
-																{ "selector": "figcaption", "value": "/description" },
+																{ "selector": "figcaption", "value": "/description", "isHTML": true },
 																{ "selector": "code", "value": "/code", "encode": true }
 															]
 														}
@@ -368,7 +368,7 @@ layout: default
 													"assess": "/collapsed",
 													"expect": true,
 													"mapping": [
-														{ "selector": "summary", "value": "/description" },
+														{ "selector": "summary", "value": "/description", "isHTML": true },
 														{ "selector": "code", "value": "/code", "encode": true }
 													]
 												},
@@ -378,7 +378,7 @@ layout: default
 													"assess": "/collapsed",
 													"expect": false,
 													"mapping": [
-														{ "selector": "figcaption", "value": "/description" },
+														{ "selector": "figcaption", "value": "/description", "isHTML": true },
 														{ "selector": "code", "value": "/code", "encode": true }
 													]
 												},
@@ -388,7 +388,7 @@ layout: default
 													"assess": "/collapsed",
 													"expect": "undefined",
 													"mapping": [
-														{ "selector": "figcaption", "value": "/description" },
+														{ "selector": "figcaption", "value": "/description", "isHTML": true },
 														{ "selector": "code", "value": "/code", "encode": true }
 													]
 												}


### PR DESCRIPTION
The French versions of certain documentation pages contain named entities for non-breaking spaces (``&nbsp;``)... which were previously being rendered as separate characters instead of being interpreted.

This resolves it by setting the Data JSON plugin's ``isHTML`` option to ``true`` for all ``description`` variables. Mostly impacts ``summary`` and ``figcaption`` elements.