### PR TITLE
Main page title: Show breaking change in VU 2024 iteration

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2325,9 +2325,9 @@
 			"name": "Visual update 2024",
 			"date": "2024-01",
 			"detectableBy": "Visual inspection can be used to detect the size of the line. The width of the line should be 71px (3.55em) long and the thickness should be 3.6px (0.18em), with the color #af3c43.",
-			"breaking": {
-				"style": "Width of the line should 70px and the thickness .18em #af3c43. Followed by optional byline, tagline or subtitle"
-			},
+			"breaking": [
+				"Style: Width of the line should 70px and the thickness .18em #af3c43. Followed by optional byline, tagline or subtitle"
+			],
 			"predecessor": "_:iteration_mpt_1"
 		}
 	]

--- a/sites/main-page-title/index.json-ld
+++ b/sites/main-page-title/index.json-ld
@@ -160,9 +160,9 @@
 			"name": "Visual update 2024",
 			"date": "2024-01",
 			"detectableBy": "Visual inspection can be used to detect the size of the line. The width of the line should be 71px (3.55em) long and the thickness should be 3.6px (0.18em), with the color #af3c43.",
-			"breaking": {
-				"style": "Width of the line should 70px and the thickness .18em #af3c43. Followed by optional byline, tagline or subtitle"
-			},
+			"breaking": [
+				"Style: Width of the line should 70px and the thickness .18em #af3c43. Followed by optional byline, tagline or subtitle"
+			],
 			"predecessor": "_:iteration_mpt_1"
 		}
 	]


### PR DESCRIPTION
The visual update 2024 iteration's breaking change previously wasn't appearing.

It seems to have been related to structure issues in the JSON-LD file's "breaking" object:
* Array using curly brackets ( ``{...}`` )
* Key/value pair placed in the array (key was named "style")

This fixes it by:
* Using square brackets ( ``[...]`` ) for the array
* Replacing the "style" key with a "Style: " prefix in the value