### PR TITLE
Clipboard plugin (méli-mélo): Restore space indents

### DIFF
--- a/méli-mélo/2023-10-clipboard/js/clipboard.js
+++ b/méli-mélo/2023-10-clipboard/js/clipboard.js
@@ -358,18 +358,18 @@
         if ( "noButton" in data === false ) {
             buttonId = wb.getId();
             switch ( data.btnAlign ) {
-				case "left":
-					btnAlign = "text-left ";
-					break;
-				case "right":
-					btnAlign = "text-right ";
-					break;
-				case "center":
-					btnAlign = "text-center ";
-					break;
-				case "none":
-				default:
-					btnAlign = "";
+                case "left":
+                    btnAlign = "text-left ";
+                    break;
+                case "right":
+                    btnAlign = "text-right ";
+                    break;
+                case "center":
+                    btnAlign = "text-center ";
+                    break;
+                case "none":
+                default:
+                    btnAlign = "";
             }
             if ( getDisplayType( elm ) === true ) {
                 containTag = "span";


### PR DESCRIPTION
#2411 accidentally-introduced tab indents into the plugin's JS file.

It was caused by a clash of EditorConfig settings (which apply GCWeb's basic linting settings to all méli-mélo files) vs ESLint (which excludes méli-mélo). The added indents adhered to the EditorConfig settings, but the file itself was using a different kind of indent style (groups of 4 spaces).

This changes the tab characters back into spaces.