### PR TITLE
Update steps.css

### DIFF
--- a/méli-mélo/2021-05-steps/index-fr.html
+++ b/méli-mélo/2021-05-steps/index-fr.html
@@ -20,7 +20,7 @@ css:
       <li><a href="#souslistes">Sous-listes (imbriquées)</a></li>
       <li><a href="#rayee">Conception rayée</a></li>
       <li><a href="#rayeesousliste">Conception rayée pour la sous-liste</a></li>
-	  <li><a href="#startattr">Début (start) de l'attribut</a></li>
+	  <li><a href="#startattr">Attribut de début (<span lang="en">start</span>)</a></li>
     </ul>
   </section>
   <section>
@@ -449,25 +449,25 @@ css:
     </details>
   </section>
 <section>
-    <h2 id="startattr">Début (start) de l'attribut</h2>
-    <p>Le modèle de liste est personnalisé pour suivre la valeur de l'attribut <code>start</code> de 2 jusqu'au nombre 10.</p>
+    <h2 id="startattr">Attribut de début (<span lang="en">start</span>)</h2>
+    <p>Le modèle de liste est personnalisé pour suivre la valeur de l'attribut <code lang="en">start</code> de 2 jusqu'au nombre 9.</p>
     <h3>Modèle de liste d'étapes par défaut</h3>
     <p>Dans cet exemple, la valeur de l'attribut <code>start</code> est de 3.</p>
     <ol class="lst-stps" start="3">
       <li>
-        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 1</a></h3>
+        <h4><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 1</a></h4>
         <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
       </li>
       <li>
-        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 2</a></h3>
+        <h4><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 2</a></h4>
         <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
       </li>
       <li>
-        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 3</a></h3>
+        <h4><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 3</a></h4>
         <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
       </li>
       <li>
-        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 4</a></h3>
+        <h4><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 4</a></h4>
         <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
       </li>
     </ol>
@@ -522,7 +522,7 @@ css:
 		<section>
 			<h4>Exemple avec titre et section débutant de l'étape 6</h4>
 			<p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
-              <ol class="lst-stps-sub">
+            <ol class="lst-stps-sub">
                 <li>
                   <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 6a</a></h5>
                   <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
@@ -535,8 +535,8 @@ css:
                   <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 6c</a></h5>
                   <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
                 </li>
-              </ol>
-            </section>
+            </ol>
+        </section>
       </li>
       <li>
         <h4>Exemple avec titre et section suivant l'étape 6, attendu à être l'étape 7</h4>

--- a/méli-mélo/2021-05-steps/index-fr.html
+++ b/méli-mélo/2021-05-steps/index-fr.html
@@ -3,6 +3,7 @@ title: Liste des étapes
 dateModified: 2024-05-30
 description: "Stylisez la liste ordonnée et les divs avec le numéro d’étapes en cercles."
 lang: fr
+altLangPage: index.html
 css:
 - steps.css
 ---
@@ -114,11 +115,11 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub">
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2a</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2a</a></h5>
                   <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2b</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2b</a></h5>
                   <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
                 </li>
                 <li>
@@ -138,10 +139,10 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub">
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4a</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4a</a></h5>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4b</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4b</a></h5>
                 </li>
               </ol>
             </section>
@@ -322,11 +323,11 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub stps-strpd">
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2a</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2a</a></h5>
                   <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2b</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 2b</a></h5>
                   <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
                 </li>
                 <li>
@@ -346,10 +347,10 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub">
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4a</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4a</a></h5>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4b</a></h5>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 4b</a></h5>
                 </li>
               </ol>
             </section>
@@ -479,4 +480,112 @@ css:
   &lt;li&gt;...&lt;/li&gt;
 &lt;/ol&gt;</code></pre>
     </details>
+
+	<h3>Débutant à l'étape 2</h3>
+	<ol class="lst-stps" start="2">
+      <li>
+        Exemple sans titre débutant de l'étape 2.
+      </li>
+      <li>
+		Exemple sans titre suivant l'étape 2, attendu à être l'étape 3.
+      </li>
+	</ol>
+	<h3>Débutant à l'étape 4</h3>
+	<ol class="lst-stps" start="4">
+      <li>
+        <h4>Exemple avec titre débutant de l'étape 4</h4>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+      <li>
+        <h4>Exemple avec titre suivant l'étape 4, attendu à être l'étape 5</h4>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+	</ol>
+	<h3>Débutant à l'étape 5</h3>
+	<ol class="lst-stps" start="5">
+      <li>
+		<section>
+			<h4>Exemple avec titre et section débutant de l'étape 5</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Exemple avec titre et section suivant l'étape 5, attendu à être l'étape 6</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+	</ol>
+	<h3>Débutant à l'étape 6</h3>
+	<ol class="lst-stps" start="6">
+      <li>
+		<section>
+			<h4>Exemple avec titre et section débutant de l'étape 6</h4>
+			<p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
+              <ol class="lst-stps-sub">
+                <li>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 6a</a></h5>
+                  <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+                </li>
+                <li>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 6b</a></h5>
+                  <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+                </li>
+                <li>
+                  <h5><a href="#">Texte de lien hypertexte pour le sujet/la tâche du sous-étape 6c</a></h5>
+                  <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+                </li>
+              </ol>
+            </section>
+      </li>
+      <li>
+        <h4>Exemple avec titre et section suivant l'étape 6, attendu à être l'étape 7</h4>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+	</ol>
+	<h3>Débutant à l'étape 7</h3>
+	<ol class="lst-stps ld-zr" start="7">
+      <li>
+		<section>
+			<h4>Exemple avec titre et section débutant de l'étape 7</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Exemple avec titre et section suivant l'étape 7, attendu à être l'étape 8</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+	</ol>
+	<h3>Débutant à l'étape 8</h3>
+	<ol class="lst-stps" start="8">
+      <li>
+		<section>
+			<h4>Exemple avec titre et section débutant de l'étape 8</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Exemple avec titre et section suivant l'étape 8, attendu à être l'étape 9</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+	</ol>
+	<h3>Débutant à l'étape 9</h3>
+	<ol class="lst-stps" start="9">
+      <li>
+		<section>
+			<h4>Exemple avec titre et section débutant de l'étape 9</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Exemple avec titre et section suivant l'étape 9, attendu à être l'étape 10</h4>
+			<p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+		</section>
+      </li>
+	</ol>
   </section>

--- a/méli-mélo/2021-05-steps/index-fr.html
+++ b/méli-mélo/2021-05-steps/index-fr.html
@@ -19,6 +19,7 @@ css:
       <li><a href="#souslistes">Sous-listes (imbriquées)</a></li>
       <li><a href="#rayee">Conception rayée</a></li>
       <li><a href="#rayeesousliste">Conception rayée pour la sous-liste</a></li>
+	  <li><a href="#startattr">Début (start) de l'attribut</a></li>
     </ul>
   </section>
   <section>
@@ -443,6 +444,39 @@ css:
 	 &lt;li&gt;...&lt;/li&gt;
     &lt;/ol&gt;
   &lt;/li&gt;
+&lt;/ol&gt;</code></pre>
+    </details>
+  </section>
+<section>
+    <h2 id="startattr">Début (start) de l'attribut</h2>
+    <p>Le modèle de liste est personnalisé pour suivre la valeur de l'attribut <code>start</code> de 2 jusqu'au nombre 10.</p>
+    <h3>Modèle de liste d'étapes par défaut</h3>
+    <p>Dans cet exemple, la valeur de l'attribut <code>start</code> est de 3.</p>
+    <ol class="lst-stps" start="3">
+      <li>
+        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 1</a></h3>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+      <li>
+        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 2</a></h3>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+      <li>
+        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 3</a></h3>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+      <li>
+        <h3><a href="#">Texte de lien hypertexte pour le sujet/la tâche de l'étape 4</a></h3>
+        <p>Utilisez des verbes d'action, ou énumérez simplement des mots-clés pour résumer les informations ou les tâches pouvant être accomplies sur la page vers laquelle il pointe</p>
+      </li>
+    </ol>
+    <details>
+      <summary>Visualiser le code</summary>
+      <pre><code>&lt;ol class="lst-stps" start="3"&gt;
+  &lt;li&gt;...&lt;/li&gt;
+  &lt;li&gt;...&lt;/li&gt;
+  &lt;li&gt;...&lt;/li&gt;
+  &lt;li&gt;...&lt;/li&gt;
 &lt;/ol&gt;</code></pre>
     </details>
   </section>

--- a/méli-mélo/2021-05-steps/index.html
+++ b/méli-mélo/2021-05-steps/index.html
@@ -468,24 +468,24 @@ css:
   </section>
 <section>
     <h2 id="startattr">Start attribute</h2>
-    <p>The list pattern is customized to follow the value of the <code>start</code> attribute from 2 up to the number 10.</p>
+    <p>The list pattern is customized to follow the value of the <code>start</code> attribute from 2 up to the number 9.</p>
     <h3>Default steps list design</h3>
     <p>This example has the <code>start</code> attribute value of 3.</p>
     <ol class="lst-stps" start="3">
       <li>
-        <h3><a href="#">Topic/task hyperlink text for step 1</a></h3>
+        <h4><a href="#">Topic/task hyperlink text for step 1</a></h4>
         <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
       </li>
       <li>
-        <h3><a href="#">Topic/task hyperlink text for step 2</a></h3>
+        <h4><a href="#">Topic/task hyperlink text for step 2</a></h4>
         <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
       </li>
       <li>
-        <h3><a href="#">Topic/task hyperlink text for step 3</a></h3>
+        <h4><a href="#">Topic/task hyperlink text for step 3</a></h4>
         <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
       </li>
       <li>
-        <h3><a href="#">Topic/task hyperlink text for step 4</a></h3>
+        <h4><a href="#">Topic/task hyperlink text for step 4</a></h4>
         <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
       </li>
     </ol>

--- a/méli-mélo/2021-05-steps/index.html
+++ b/méli-mélo/2021-05-steps/index.html
@@ -3,6 +3,7 @@ title: List steps
 dateModified: 2024-05-30
 description: "Style ordered list and divs with steps number in circles."
 lang: en
+altLangPage: index-fr.html
 css:
 - steps.css
 ---
@@ -132,11 +133,11 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub">
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 2a</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 2a</a></h5>
                   <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 2b</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 2b</a></h5>
                   <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
                 </li>
                 <li>
@@ -156,10 +157,10 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub">
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 4a</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 4a</a></h5>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 4b</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 4b</a></h5>
                 </li>
               </ol>
             </section>
@@ -340,11 +341,11 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub stps-strpd">
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 2a</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 2a</a></h5>
                   <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 2b</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 2b</a></h5>
                   <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
                 </li>
                 <li>
@@ -364,10 +365,10 @@ css:
               <p>Lorem ipsum dolor sit amet, esse autem per ex, nec in magna lorem. Ea nec error scriptorem referrentur, patrioque torquatos conclusionemque pri in. Sed sint debitis ad, mazim vitae temporibus qui ut, vel erat ponderum efficiendi ei. In idque euismod sed.</p>
               <ol class="lst-stps-sub">
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 4a</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 4a</a></h5>
                 </li>
                 <li>
-                  <h5 class="h4"><a href="#">Topic/task hyperlink text for sub-step 4b</a></h5>
+                  <h5><a href="#">Topic/task hyperlink text for sub-step 4b</a></h5>
                 </li>
               </ol>
             </section>
@@ -497,4 +498,112 @@ css:
   &lt;li&gt;...&lt;/li&gt;
 &lt;/ol&gt;</code></pre>
     </details>
+
+	<h3>Starting at step 2</h3>
+	<ol class="lst-stps" start="2">
+      <li>
+        Example without heading of step starting at 2
+      </li>
+      <li>
+        Example without heading of step following a step started at 2, expected to be 3.
+      </li>
+	</ol>
+	<h3>Starting at step 4</h3>
+	<ol class="lst-stps" start="4">
+      <li>
+        <h4>Example with heading of step starting at 4</h4>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+      <li>
+        <h4>Example with heading of step following a step started at 4, expected to be 5</h4>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+	</ol>
+	<h3>Starting at step 5</h3>
+	<ol class="lst-stps" start="5">
+      <li>
+		<section>
+			<h4>Example with heading and section of step starting at 5</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Example with heading and section of step following a step started at 5, expected to be 6</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+	</ol>
+	<h3>Starting at step 6</h3>
+	<ol class="lst-stps" start="6">
+      <li>
+		<section>
+			<h4>Example with heading of step starting at 6</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+            <ol class="lst-stps-sub stps-strpd">
+              <li>
+                <h5><a href="#">Topic/task hyperlink text for sub-step 6a</a></h5>
+                <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+              </li>
+              <li>
+                <h5><a href="#">Topic/task hyperlink text for sub-step 6b</a></h5>
+                <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+              </li>
+              <li>
+                <h5><a href="#">Topic/task hyperlink text for sub-step 6c</a></h5>
+                <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+              </li>
+            </ol>
+		</section>
+      </li>
+      <li>
+        <h4>Example with heading of step following a step started at 6, expected to be 7</h4>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+	</ol>
+	<h3>Starting at step 7</h3>
+	<ol class="lst-stps ld-zr" start="7">
+      <li>
+		<section>
+			<h4>Example with heading and section of step starting at 7</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Example with heading and section of step following a step started at 7, expected to be 8</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+	</ol>
+	<h3>Starting at step 8</h3>
+	<ol class="lst-stps" start="8">
+      <li>
+		<section>
+			<h4>Example with heading and section of step starting at 8</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Example with heading and section of step following a step started at 8, expected to be 9</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+	</ol>
+	<h3>Starting at step 9</h3>
+	<ol class="lst-stps" start="9">
+      <li>
+		<section>
+			<h4>Example with heading and section of step starting at 9</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+      <li>
+		<section>
+			<h4>Example with heading and section of step following a step started at 9, expected to be 10</h4>
+			<p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+		</section>
+      </li>
+	</ol>
   </section>

--- a/méli-mélo/2021-05-steps/index.html
+++ b/méli-mélo/2021-05-steps/index.html
@@ -37,6 +37,7 @@ css:
       <li><a href="#sublist">Sub (nested) lists</a></li>
       <li><a href="#striped">Striped design</a></li>
       <li><a href="#stripedsub">Striped design for sub list</a></li>
+	  <li><a href="#startattr">Start attribute</a></li>
     </ul>
   </section>
   <section>
@@ -461,6 +462,39 @@ css:
 	 &lt;li&gt;...&lt;/li&gt;
     &lt;/ol&gt;
   &lt;/li&gt;
+&lt;/ol&gt;</code></pre>
+    </details>
+  </section>
+<section>
+    <h2 id="startattr">Start attribute</h2>
+    <p>The list pattern is customized to follow the value of the <code>start</code> attribute from 2 up to the number 10.</p>
+    <h3>Default steps list design</h3>
+    <p>This example has the <code>start</code> attribute value of 3.</p>
+    <ol class="lst-stps" start="3">
+      <li>
+        <h3><a href="#">Topic/task hyperlink text for step 1</a></h3>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+      <li>
+        <h3><a href="#">Topic/task hyperlink text for step 2</a></h3>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+      <li>
+        <h3><a href="#">Topic/task hyperlink text for step 3</a></h3>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+      <li>
+        <h3><a href="#">Topic/task hyperlink text for step 4</a></h3>
+        <p>Use action verbs, or simply list keywords to summarize the information or tasks that can be accomplished on the page it links to</p>
+      </li>
+    </ol>
+    <details>
+      <summary>View code</summary>
+      <pre><code>&lt;ol class="lst-stps" start="3"&gt;
+  &lt;li&gt;...&lt;/li&gt;
+  &lt;li&gt;...&lt;/li&gt;
+  &lt;li&gt;...&lt;/li&gt;
+  &lt;li&gt;...&lt;/li&gt;
 &lt;/ol&gt;</code></pre>
     </details>
   </section>

--- a/méli-mélo/2021-05-steps/meta.md
+++ b/méli-mélo/2021-05-steps/meta.md
@@ -17,7 +17,7 @@ title:
 description:
   en: Style ordered list and divs with steps number in circles.
   fr: Mise en style d'une liste ordonnée et de divs avec des numéros d'étape dans un cercle
-modified: 2024-05-30
+modified: 2024-10-31
 componentName: 2021-05-steps
 sponsor: CRA - Christopher Oakes (@christopher-o)
 
@@ -56,5 +56,9 @@ changes:
     description: Fixed issue with printing pages as some text would be cut off 
     departmentImpact: No change from a departmental perspective.
     publicImpact: Improved look of print document
+  - date: 2024-10-30
+    description: Added customized option to use start attribute for items 2 to 10
+    departmentImpact: No change from a departmental perspective.
+    publicImpact: Enhanced flexibility to better mimic ordered lists using HTML
 output: false
 ---

--- a/méli-mélo/2021-05-steps/steps-doc-en.html
+++ b/méli-mélo/2021-05-steps/steps-doc-en.html
@@ -132,3 +132,8 @@ css:
     <h2>Source code</h2>
     <p><a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">Source code for the list steps plugin on GitHub</a></p>
   </section>
+<section>
+    <h3>Start attribute</h3>
+    <p>Follow the <code>&lt;ol&gt;</code> attribute <code>start</code> value from 2 to 10.</p>
+    <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
+  </section>

--- a/méli-mélo/2021-05-steps/steps-doc-en.html
+++ b/méli-mélo/2021-05-steps/steps-doc-en.html
@@ -3,6 +3,7 @@ title: List steps - documentation
 dateModified: 2024-05-30
 description: "Style ordered list and divs with steps number in circles."
 lang: en
+altLangPage: steps-doc-fr.html
 css:
 - steps.css
 ---
@@ -134,6 +135,6 @@ css:
   </section>
 <section>
     <h3>Start attribute</h3>
-    <p>Follow the <code>&lt;ol&gt;</code> attribute <code>start</code> value from 2 to 10.</p>
+    <p>Follow the <code>&lt;ol&gt;</code> attribute <code>start</code> value from 2 to 9.</p>
     <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
   </section>

--- a/méli-mélo/2021-05-steps/steps-doc-en.html
+++ b/méli-mélo/2021-05-steps/steps-doc-en.html
@@ -128,13 +128,11 @@ css:
 </pre>
       </div>
     </div>
+    <h3>Start attribute</h3>
+    <p>Follow the <code>&lt;ol&gt;</code> attribute <code>start</code> value from 2 to 9.</p>
+    <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
   </section>
   <section>
     <h2>Source code</h2>
     <p><a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">Source code for the list steps plugin on GitHub</a></p>
-  </section>
-<section>
-    <h3>Start attribute</h3>
-    <p>Follow the <code>&lt;ol&gt;</code> attribute <code>start</code> value from 2 to 9.</p>
-    <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
   </section>

--- a/méli-mélo/2021-05-steps/steps-doc-fr.html
+++ b/méli-mélo/2021-05-steps/steps-doc-fr.html
@@ -128,13 +128,11 @@ css:
 </pre>
       </div>
     </div>
+    <h3>Attribut de début (<span lang="en">start</span>)</h3>
+    <p>Suivez la valeur de l'attribut <code>&lt;ol&gt;</code> <code>start</code> de 2 à 9.</p>
+    <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
   </section>
   <section>
     <h2>Code source</h2>
     <p><a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">Code source du plugin d'étapes de liste sur GitHub</a> </p>
-  </section>
-<section>
-    <h3>Attribut de début (<span lang="en">start</span>)</h3>
-    <p>Suivez la valeur de l'attribut <code>&lt;ol&gt;</code> <code>start</code> de 2 à 9.</p>
-    <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
   </section>

--- a/méli-mélo/2021-05-steps/steps-doc-fr.html
+++ b/méli-mélo/2021-05-steps/steps-doc-fr.html
@@ -3,6 +3,7 @@ title: Liste des étapes - Documentation
 dateModified: 2024-05-30
 description: "Stylisez la liste ordonnée et les divs avec le numéro d’étapes en cercles."
 lang: fr
+altLangPage: steps-doc-en.html
 css:
 - steps.css
 ---
@@ -133,7 +134,7 @@ css:
     <p><a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">Code source du plugin d'étapes de liste sur GitHub</a> </p>
   </section>
 <section>
-    <h3>Début (start) de l'attribut</h3>
-    <p>Suivez la valeur de l'attribut <code>&lt;ol&gt;</code> <code>start</code> de 2 à 10.</p>
+    <h3>Attribut de début (<span lang="en">start</span>)</h3>
+    <p>Suivez la valeur de l'attribut <code>&lt;ol&gt;</code> <code>start</code> de 2 à 9.</p>
     <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
   </section>

--- a/méli-mélo/2021-05-steps/steps-doc-fr.html
+++ b/méli-mélo/2021-05-steps/steps-doc-fr.html
@@ -132,3 +132,8 @@ css:
     <h2>Code source</h2>
     <p><a href="https://github.com/wet-boew/GCWeb/tree/master/m%C3%A9li-m%C3%A9lo/2021-05-steps">Code source du plugin d'étapes de liste sur GitHub</a> </p>
   </section>
+<section>
+    <h3>Début (start) de l'attribut</h3>
+    <p>Suivez la valeur de l'attribut <code>&lt;ol&gt;</code> <code>start</code> de 2 à 10.</p>
+    <pre><code>&lt;ol class=&quot;lst-stps&quot; start=&quot;2&quot;&gt;</code></pre>
+  </section>

--- a/méli-mélo/2021-05-steps/steps.css
+++ b/méli-mélo/2021-05-steps/steps.css
@@ -119,3 +119,28 @@ ol.lst-stps.stps-strpd:not(.ld-zr) > li:before, ol.lst-stps.stps-strpd:not(.ld-z
 		padding-top:1em;
 	}
 }
+/* Increment (start) */
+ol.lst-stps[start="2"] {
+  counter-set: item 1;  
+}
+ol.lst-stps[start="3"] {
+  counter-set: item 2;  
+}
+ol.lst-stps[start="4"] {
+  counter-set: item 3;  
+}
+ol.lst-stps[start="5"] {
+  counter-set: item 4;  
+}
+ol.lst-stps[start="6"] {
+  counter-set: item 5;  
+}
+ol.lst-stps[start="7"] {
+  counter-set: item 6;  
+}
+ol.lst-stps[start="8"] {
+  counter-set: item 7;  
+}
+ol.lst-stps[start="9"] {
+  counter-set: item 8;  
+}


### PR DESCRIPTION
Clear and simple explanation of the change/update:

Additional CSS and example added to support basic use (for numbers 2 to 10) of the start attribute for ordered (ol) lists as the CSS design uses a CSS count method to display the numbers and not the generated numbers from the html element. 

Future design could include a javascript to allow any start number to exist.  

The impact on the sponsored department (CRA) for that change/update:

No impact.

The impact on the public for that change/update:

More flexibility of using the design in various situations.