### PR TITLE
Most requested: display items in columns

### DIFF
--- a/_data/components.json
+++ b/_data/components.json
@@ -1465,10 +1465,10 @@
 		"en": "Features top tasks related to the page it is on.",
 		"fr": "Comprend des tâches principales liées à la page sur laquelle elles se trouvent."
 	},
-	"modified": "2024-02-14",
+	"modified": "2025-05-08",
 	"componentName": "gc-most-requested",
 	"status": "stable",
-	"version": "1.0",
+	"version": "1.1.0",
 	"pages": {
 		"docs": [
 			{
@@ -1521,7 +1521,7 @@
 				"en": "https://design.canada.ca/common-design-patterns/most-requested.html",
 				"fr": "https://conception.canada.ca/configurations-conception-communes/en-demande.html"
 			},
-			"iteration": "_:iteration_mostrequested_1",
+			"iteration": "_:iteration_mostrequested_2",
 			"example": [
 				{
 					"en": { "href": "gc-most-requested-en.html", "text": "Most requested" },
@@ -1537,6 +1537,10 @@
 			],
 			"history": [
 				{
+					"en": "May 2025 - Items are now distributed vertically instead of horizontally.",
+					"fr": "Mai 2025 - Les items sont maintenant distribués verticalement plutôt que horizontalement."
+				},
+				{
 					"en": "February 2024 - Initial implementation of the variation.",
 					"fr": "Février 2024 - Implémentation initiale de la variante."
 				},
@@ -1550,7 +1554,7 @@
 	"implementation": [
 		{
 			"@id": "_:implement_mostrequested",
-			"iteration": "_:iteration_mostrequested_1",
+			"iteration": "_:iteration_mostrequested_2",
 			"name": {
 				"en": "Standard",
 				"fr": "Standard"
@@ -1597,11 +1601,30 @@
 	],
 	"iteration": [
 		{
+			"@id": "_:iteration_mostrequested_2",
+			"name": "Most requested - Iteration 2",
+			"date": "2024-11",
+			"detectableBy": ".gc-most-requested:not(.provisional)",
+			"predecessor": "_:iteration_mostrequested_1",
+			"additions": [
+				"Changed display of items from flex to column-count. This change is perceptible and a user will notice that change but it won't change the component essential behaviour. So this is a Minor change."
+			],
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<section class=\"gc-most-requested\">\n\t<div class=\"container\">\n\t\t<h2>Most requested</h2>\n\t\t<ul>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 1]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 2]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 3]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 4]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 5]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 6]</a></li>\n\t\t</ul>\n\t</div>\n</section>"
+				}
+			]
+		},
+		{
 			"@id": "_:iteration_mostrequested_1",
 			"name": "Most requested - Iteration 1",
 			"date": "2024-02",
 			"detectableBy": ".gc-most-requested:not(.provisional)",
 			"predecessor": "_:iteration_mostrequested_0",
+			"successor": "_:iteration_mostrequested_2",
 			"assets": [
 				{
 					"@type": "source-code",
@@ -1620,6 +1643,28 @@
 		}
 	],
 	"changesets": [
+		{
+			"@id": "_:cs_mostrequested",
+			"name": "Most requested - columns",
+			"status": "stable",
+			"baseOnIteration": "_:iteration_mostrequested_2",
+			"detectableBy": ".gc-most-requested",
+			"layout": "On smaller screens, the title is on the top and links are stacked. On medium and larger, the title is on the left and links are distributed over two columns from top to bottom and left to right.",
+			"style": "The component has a light gray background.",
+			"semantic": "h2 + (ul > li > a)",
+			"static": [
+				"Most requested",
+				"En demande"
+			],
+			"context": "The component must not be located inside an element with the class \"container\"",
+			"schema": [
+				"arrays of 'MostRequestedLink'",
+				"'MostRequestedLink' object: [ \"task links\", \"task names\" ]"
+			],
+			"test": [
+				"<a href=\"gc-most-requested-provisional-en.html\">Most-requested (provisional)</a>"
+			]
+		},
 		{
 			"@id": "_:cs_mostrequested",
 			"name": "Most requested",

--- a/_includes/components/gc-most-requested/gc-most-requested.html
+++ b/_includes/components/gc-most-requested/gc-most-requested.html
@@ -2,11 +2,11 @@
 	<div class="container">
 		<h2>{% if page.language == "en" %}Most requested{% else %}En demande{% endif %}</h2>
 		<ul>
-			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 1]</a></li>
+			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink with a very long task name that spans over two lines{% else %}Lien vers une tâche principale avec un nom de tâche très long qui s'étend sur deux lignes{% endif %} 1]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 2]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 3]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 4]</a></li>
-			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink with a very long task name that spans over two lines{% else %}Lien vers une tâche principale avec un nom de tâche très long qui s'étend sur deux lignes{% endif %} 5]</a></li>
+			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 5]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink with a very long task name that spans over two lines{% else %}Lien vers une tâche principale avec un nom de tâche très long qui s'étend sur deux lignes{% endif %} 6]</a></li>
 		</ul>
 	</div>

--- a/components/gc-most-requested/_base.scss
+++ b/components/gc-most-requested/_base.scss
@@ -3,8 +3,7 @@
 */
 
 // Make sure the component is not inside a container
-main:not(.container) .gc-most-requested,
-div:not(.container) .gc-most-requested {
+.gc-most-requested {
 	background-color: #f5f5f5;
 	margin-bottom: 20px;
 	padding: 24px 0 12px;
@@ -22,6 +21,11 @@ div:not(.container) .gc-most-requested {
 			line-height: 1.8em;
 		}
 	}
+}
+
+// Styles to slightly break the layout for bad implementation
+.container .gc-most-requested {
+	background: transparent;
 }
 
 // To be removed when ILP version 1 is deprecated

--- a/components/gc-most-requested/_screen-md-min.scss
+++ b/components/gc-most-requested/_screen-md-min.scss
@@ -3,22 +3,55 @@
 */
 
 // Make sure the component is not inside a container
-main:not(.container) .gc-most-requested,
-div:not(.container) .gc-most-requested {
+.gc-most-requested {
 	h2 {
 		float: left;
 		width: 16.666667%;
 	}
 
 	ul {
-		display: flex;
-		flex-wrap: wrap;
-		padding-left: 2.5em;
+		column-count: 2;
+		column-gap: 0;
+		margin-bottom: 0;
+		padding-left: 1.55em;
 
 		li {
-			flex-basis: 50%;
+			display: inline-block;
 			font-size: $small-size;
-			padding-right: 1.3em;
+			line-height: 1.25em;
+			margin-bottom: 10px;
+			padding-left: 1.15em;
+			padding-right: 1em;
+			position: relative;
+
+			&::before {
+				content: "\2022";
+				font-size: .8em;
+				left: 0;
+				position: absolute;
+				top: 0;
+			}
+
+			&::after {
+				content: "";
+				display: block;
+				width: 335px;
+			}
+		}
+	}
+}
+
+// Styles to slightly break the layout for bad implementation
+.container .gc-most-requested {
+	h2 {
+		float: none;
+	}
+
+	ul {
+		column-count: 1;
+
+		li {
+			display: block;
 		}
 	}
 }

--- a/components/gc-most-requested/gc-most-requested-bad-en.html
+++ b/components/gc-most-requested/gc-most-requested-bad-en.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "gc-most-requested-bad-fr.html",
-	"dateModified": "2024-02-14",
+	"dateModified": "2025-05-08",
 	"description": "Bad implementation example for the Most requested component.",
 	"language": "en",
 	"title": "Most requested - bad implementation",

--- a/components/gc-most-requested/gc-most-requested-bad-fr.html
+++ b/components/gc-most-requested/gc-most-requested-bad-fr.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "gc-most-requested-bad-en.html",
-	"dateModified": "2024-02-14",
+	"dateModified": "2025-05-08",
 	"description": "Exemple de mauvaise implémentation pour la composante En demande",
 	"language": "fr",
 	"title": "En demande",

--- a/components/gc-most-requested/gc-most-requested-doc-en.html
+++ b/components/gc-most-requested/gc-most-requested-doc-en.html
@@ -3,7 +3,7 @@ title: Most requested - Documentation
 description: Documentation for Most requested component
 language: en
 altLangPage: gc-most-requested-doc-fr.html
-dateModified: 2024-02-14
+dateModified: 2025-05-08
 layout: documentation
 index_json: index.json-ld
 ---

--- a/components/gc-most-requested/gc-most-requested-doc-fr.html
+++ b/components/gc-most-requested/gc-most-requested-doc-fr.html
@@ -3,7 +3,7 @@ title: En demande - Documentation
 description: Documentation de la composante En demande
 language: fr
 altLangPage: gc-most-requested-doc-en.html
-dateModified: 2024-02-14
+dateModified: 2025-05-08
 layout: documentation
 index_json: index.json-ld
 ---

--- a/components/gc-most-requested/gc-most-requested-en.html
+++ b/components/gc-most-requested/gc-most-requested-en.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "gc-most-requested-fr.html",
-	"dateModified": "2024-02-14",
+	"dateModified": "2025-05-08",
 	"description": "Working examples for the Most requested component.",
 	"language": "en",
 	"title": "Most requested",

--- a/components/gc-most-requested/gc-most-requested-fr.html
+++ b/components/gc-most-requested/gc-most-requested-fr.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "gc-most-requested-en.html",
-	"dateModified": "2024-07-11",
+	"dateModified": "2025-05-08",
 	"description": "Exemples pratiques pour la composante En demande",
 	"language": "fr",
 	"title": "En demande",

--- a/components/gc-most-requested/gc-most-requested-provisional-en.html
+++ b/components/gc-most-requested/gc-most-requested-provisional-en.html
@@ -1,6 +1,6 @@
 ---
 {
-	"dateModified": "2024-04-17",
+	"dateModified": "2025-05-08",
 	"description": "Working examples for the Most requested component provisional.",
 	"language": "en",
 	"title": "Most requested (provisional)",

--- a/components/gc-most-requested/index.json-ld
+++ b/components/gc-most-requested/index.json-ld
@@ -14,10 +14,10 @@
 		"en": "Features top tasks related to the page it is on.",
 		"fr": "Comprend des tâches principales liées à la page sur laquelle elles se trouvent."
 	},
-	"modified": "2024-02-14",
+	"modified": "2025-05-08",
 	"componentName": "gc-most-requested",
 	"status": "stable",
-	"version": "1.0",
+	"version": "1.1.0",
 	"pages": {
 		"docs": [
 			{
@@ -70,7 +70,7 @@
 				"en": "https://design.canada.ca/common-design-patterns/most-requested.html",
 				"fr": "https://conception.canada.ca/configurations-conception-communes/en-demande.html"
 			},
-			"iteration": "_:iteration_mostrequested_1",
+			"iteration": "_:iteration_mostrequested_2",
 			"example": [
 				{
 					"en": { "href": "gc-most-requested-en.html", "text": "Most requested" },
@@ -86,6 +86,10 @@
 			],
 			"history": [
 				{
+					"en": "May 2025 - Items are now distributed vertically instead of horizontally.",
+					"fr": "Mai 2025 - Les items sont maintenant distribués verticalement plutôt que horizontalement."
+				},
+				{
 					"en": "February 2024 - Initial implementation of the variation.",
 					"fr": "Février 2024 - Implémentation initiale de la variante."
 				},
@@ -99,7 +103,7 @@
 	"implementation": [
 		{
 			"@id": "_:implement_mostrequested",
-			"iteration": "_:iteration_mostrequested_1",
+			"iteration": "_:iteration_mostrequested_2",
 			"name": {
 				"en": "Standard",
 				"fr": "Standard"
@@ -146,11 +150,30 @@
 	],
 	"iteration": [
 		{
+			"@id": "_:iteration_mostrequested_2",
+			"name": "Most requested - Iteration 2",
+			"date": "2024-11",
+			"detectableBy": ".gc-most-requested:not(.provisional)",
+			"predecessor": "_:iteration_mostrequested_1",
+			"additions": [
+				"Changed display of items from flex to column-count. This change is perceptible and a user will notice that change but it won't change the component essential behaviour. So this is a Minor change."
+			],
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<section class=\"gc-most-requested\">\n\t<div class=\"container\">\n\t\t<h2>Most requested</h2>\n\t\t<ul>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 1]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 2]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 3]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 4]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 5]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 6]</a></li>\n\t\t</ul>\n\t</div>\n</section>"
+				}
+			]
+		},
+		{
 			"@id": "_:iteration_mostrequested_1",
 			"name": "Most requested - Iteration 1",
 			"date": "2024-02",
 			"detectableBy": ".gc-most-requested:not(.provisional)",
 			"predecessor": "_:iteration_mostrequested_0",
+			"successor": "_:iteration_mostrequested_2",
 			"assets": [
 				{
 					"@type": "source-code",
@@ -169,6 +192,28 @@
 		}
 	],
 	"changesets": [
+		{
+			"@id": "_:cs_mostrequested",
+			"name": "Most requested - columns",
+			"status": "stable",
+			"baseOnIteration": "_:iteration_mostrequested_2",
+			"detectableBy": ".gc-most-requested",
+			"layout": "On smaller screens, the title is on the top and links are stacked. On medium and larger, the title is on the left and links are distributed over two columns from top to bottom and left to right.",
+			"style": "The component has a light gray background.",
+			"semantic": "h2 + (ul > li > a)",
+			"static": [
+				"Most requested",
+				"En demande"
+			],
+			"context": "The component must not be located inside an element with the class \"container\"",
+			"schema": [
+				"arrays of 'MostRequestedLink'",
+				"'MostRequestedLink' object: [ \"task links\", \"task names\" ]"
+			],
+			"test": [
+				"<a href=\"gc-most-requested-provisional-en.html\">Most-requested (provisional)</a>"
+			]
+		},
 		{
 			"@id": "_:cs_mostrequested",
 			"name": "Most requested",

--- a/components/gc-most-requested/samples/gc-most-requested.html
+++ b/components/gc-most-requested/samples/gc-most-requested.html
@@ -2,11 +2,11 @@
 	<div class="container">
 		<h2>{% if page.language == "en" %}Most requested{% else %}En demande{% endif %}</h2>
 		<ul>
-			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 1]</a></li>
+			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink with a very long task name that spans over two lines{% else %}Lien vers une tâche principale avec un nom de tâche très long qui s'étend sur deux lignes{% endif %} 1]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 2]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 3]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 4]</a></li>
-			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink with a very long task name that spans over two lines{% else %}Lien vers une tâche principale avec un nom de tâche très long qui s'étend sur deux lignes{% endif %} 5]</a></li>
+			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink{% else %}Lien vers une tâche principale{% endif %} 5]</a></li>
 			<li><a href="#">[{% if page.language == "en" %}Top task hyperlink with a very long task name that spans over two lines{% else %}Lien vers une tâche principale avec un nom de tâche très long qui s'étend sur deux lignes{% endif %} 6]</a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
This PR changes the distribution of Most requested items from top to bottom and from left to right instead of from left to right and top to bottom.

Before:
1 2
3 4
5 6

After:
1 4
2 5
3 6


Changes related to WET-488