### PR TITLE
Theme: Fix placeholder image references

### DIFF
--- a/_data/design-patterns.json
+++ b/_data/design-patterns.json
@@ -128,7 +128,7 @@
 		"en": "Guidance about using the introduction block component on Canada.ca.",
 		"fr": "Orientation sur l’utilisation du composant bloc d’introduction sur Canada.ca."
 	},
-	"modified": "2024-06-12",
+	"modified": "2024-12-05",
 	"componentName": "gc-intro",
 	"pages": {
 		"docs": [
@@ -416,14 +416,14 @@
 					{
 						"@type": "source-code",
 						"description": "Code sample:",
-						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Introduction block with half-width image</h1>\n\t\t<p>The introduction block pattern introduces the content of a landing page.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Supertask button</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://via.placeholder.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
+						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Introduction block with half-width image</h1>\n\t\t<p>The introduction block pattern introduces the content of a landing page.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Supertask button</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://dummyimage.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
 					}
 				],
 				"fr": [
 					{
 						"@type": "source-code",
 						"description": "Exemple de code :",
-						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Bloc d'introduction avec image demi-largeur</h1>\n\t\t<p>La configuration de conception du bloc d'introduction introduit le contenu d'une page de destination.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Bouton de super-tâche</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://via.placeholder.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
+						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Bloc d'introduction avec image demi-largeur</h1>\n\t\t<p>La configuration de conception du bloc d'introduction introduit le contenu d'une page de destination.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Bouton de super-tâche</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://dummyimage.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
 					}
 				]
 			}

--- a/_includes/components/gc-corporate/inst-info.html
+++ b/_includes/components/gc-corporate/inst-info.html
@@ -46,7 +46,7 @@
 					<h3>Ministre</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[L’honorable (nom du ministre)]</figcaption>
 						</figure>
 					</a>
@@ -57,7 +57,7 @@
 					<h3>Minister</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[(Honourable) first and last name of Minister]</figcaption>
 						</figure>
 					</a>

--- a/_includes/components/gc-corporate/org-info.html
+++ b/_includes/components/gc-corporate/org-info.html
@@ -39,7 +39,7 @@
 					<h3 class="wb-inv">Chef de l’organisme</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[Président]</figcaption>
 						</figure>
 					</a>
@@ -50,7 +50,7 @@
 					<h3 class="wb-inv">Organization head</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[Chairperson]</figcaption>
 						</figure>
 					</a>

--- a/_includes/components/gc-minister/gc-minister-special-cases.html
+++ b/_includes/components/gc-minister/gc-minister-special-cases.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>
@@ -20,7 +20,7 @@
 					<h3><a href="#">The Honourable [Minister 2 name with a very long name]</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="The Honourable [Minister 2 name with a very long name]">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="The Honourable [Minister 2 name with a very long name]">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/_includes/components/gc-minister/gc-minister-two-ministers.html
+++ b/_includes/components/gc-minister/gc-minister-two-ministers.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>
@@ -24,7 +24,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/_includes/components/gc-minister/gc-minister.html
+++ b/_includes/components/gc-minister/gc-minister.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/common/alignment/alignment-en.html
+++ b/common/alignment/alignment-en.html
@@ -3,7 +3,7 @@
 	"title": "GCWeb Alignment example",
 	"language": "en",
 	"altLangPage": "alignment-fr.html",
-	"dateModified": "2023-06-19"
+	"dateModified": "2024-12-05"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -30,7 +30,7 @@
 <h3> Center content blocks <code>center-block</code></h3>
 <div class="panel panel-default">
 	<div class="panel-body">
-	<img src="https://placehold.it/140x140" class="img-rounded center-block" alt="A generic square placeholder image with rounded corners">
+	<img src="https://dummyimage.com/140x140" class="img-rounded center-block" alt="A generic square placeholder image with rounded corners">
 	</div>
 </div>
 <h4>Code</h4>

--- a/common/alignment/alignment-fr.html
+++ b/common/alignment/alignment-fr.html
@@ -3,7 +3,7 @@
 	"title": "Alignement",
 	"language": "fr",
 	"altLangPage": "alignment-en.html",
-	"dateModified": "2023-06-19"
+	"dateModified": "2024-12-05"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -30,7 +30,7 @@
 <h3>Centrer des blocs de contenu (<code>center-block</code>)</h3>
 <div class="panel panel-default">
 	<div class="panel-body">
-	<img src="https://placehold.it/140x140" class="img-rounded center-block" alt="Une image de paramètre fictif carré dont les coins sont arrondis">
+	<img src="https://dummyimage.com/140x140" class="img-rounded center-block" alt="Une image de paramètre fictif carré dont les coins sont arrondis">
 	</div>
 </div>
 <h4>Code</h4>

--- a/components/components-en.html
+++ b/components/components-en.html
@@ -5,7 +5,7 @@
 	"altLangPage": "components-fr.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"secondlevel": false,
-	"dateModified": "2021-09-28",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---
@@ -55,7 +55,7 @@
 		<div class="col-md-3 col-sm-6">
 			<a href="#">
 				<figure>
-					<img src="https://via.placeholder.com/218x291?text=[President]" alt="" class="img-responsive thumbnail">
+					<img src="https://dummyimage.com/218x291&text=[President]" alt="" class="img-responsive thumbnail">
 					<figcaption>[Chairperson]</figcaption>
 				</figure>
 			</a>

--- a/components/components-fr.html
+++ b/components/components-fr.html
@@ -5,7 +5,7 @@
 	"altLangPage": "components-en.html",
 	"pageclass": "cnt-wdth-lmtd",
 	"secondlevel": false,
-	"dateModified": "2021-09-28",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---
@@ -53,7 +53,7 @@
 		<div class="col-md-3 col-sm-6">
 			<a href="#">
 				<figure>
-					<img src="https://via.placeholder.com/218x291?text=[Président]" alt="" class="img-responsive thumbnail">
+					<img src="https://dummyimage.com/218x291&text=[Président]" alt="" class="img-responsive thumbnail">
 					<figcaption>[Président]</figcaption>
 				</figure>
 			</a>

--- a/components/gc-corporate/samples/inst-info.html
+++ b/components/gc-corporate/samples/inst-info.html
@@ -46,7 +46,7 @@
 					<h3>Ministre</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[L’honorable (nom du ministre)]</figcaption>
 						</figure>
 					</a>
@@ -57,7 +57,7 @@
 					<h3>Minister</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[(Honourable) first and last name of Minister]</figcaption>
 						</figure>
 					</a>

--- a/components/gc-corporate/samples/org-info.html
+++ b/components/gc-corporate/samples/org-info.html
@@ -39,7 +39,7 @@
 					<h3 class="wb-inv">Chef de l’organisme</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[Président]</figcaption>
 						</figure>
 					</a>
@@ -50,7 +50,7 @@
 					<h3 class="wb-inv">Organization head</h3>
 					<a href="#">
 						<figure>
-							<img src="https://via.placeholder.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
+							<img src="https://dummyimage.com/218x291/000000/FFFFFF.png" alt="" class="img-responsive thumbnail">
 							<figcaption>[Chairperson]</figcaption>
 						</figure>
 					</a>

--- a/components/gc-minister/gc-minister-en.html
+++ b/components/gc-minister/gc-minister-en.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Minister or institutional head - Documentation", "link": "components/gc-minister/gc-minister-doc-en.html" }
 	],
-	"dateModified": "2024-03-11",
+	"dateModified": "2024-12-05",
 }
 ---
 <div class="wb-prettify all-pre hide"></div>

--- a/components/gc-minister/gc-minister-fr.html
+++ b/components/gc-minister/gc-minister-fr.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministre ou chef d'institution - Documentation", "link": "components/gc-minister/gc-minister-doc-fr.html" }
 	],
-	"dateModified": "2024-07-11"
+	"dateModified": "2024-12-05"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>

--- a/components/gc-minister/gc-minister-special-cases-en.html
+++ b/components/gc-minister/gc-minister-special-cases-en.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Minister or institutional head - Documentation", "link": "components/gc-minister/gc-minister-doc-en.html" }
 	],
-	"dateModified": "2024-03-11",
+	"dateModified": "2024-12-05",
 }
 ---
 <div class="wb-prettify all-pre hide"></div>

--- a/components/gc-minister/gc-minister-special-cases-fr.html
+++ b/components/gc-minister/gc-minister-special-cases-fr.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministre ou chef d'institution - Documentation", "link": "components/gc-minister/gc-minister-doc-fr.html" }
 	],
-	"dateModified": "2024-07-11"
+	"dateModified": "2024-12-05"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>

--- a/components/gc-minister/gc-minister-two-ministers-en.html
+++ b/components/gc-minister/gc-minister-two-ministers-en.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Minister or institutional head - Documentation", "link": "components/gc-minister/gc-minister-doc-en.html" }
 	],
-	"dateModified": "2024-03-11",
+	"dateModified": "2024-12-05",
 }
 ---
 <div class="wb-prettify all-pre hide"></div>

--- a/components/gc-minister/gc-minister-two-ministers-fr.html
+++ b/components/gc-minister/gc-minister-two-ministers-fr.html
@@ -7,7 +7,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministre ou chef d'institution - Documentation", "link": "components/gc-minister/gc-minister-doc-fr.html" }
 	],
-	"dateModified": "2024-07-11"
+	"dateModified": "2024-12-05"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>

--- a/components/gc-minister/samples/gc-minister-special-cases.html
+++ b/components/gc-minister/samples/gc-minister-special-cases.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>
@@ -20,7 +20,7 @@
 					<h3><a href="#">The Honourable [Minister 2 name with a very long name]</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="The Honourable [Minister 2 name with a very long name]">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="The Honourable [Minister 2 name with a very long name]">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/components/gc-minister/samples/gc-minister-two-ministers.html
+++ b/components/gc-minister/samples/gc-minister-two-ministers.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>
@@ -24,7 +24,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/components/gc-minister/samples/gc-minister.html
+++ b/components/gc-minister/samples/gc-minister.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-md-5">
-					<img src="https://via.placeholder.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/components/images/images-en.html
+++ b/components/images/images-en.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "images-fr.html",
-	"dateModified": "2023-07-12",
+	"dateModified": "2024-12-05",
 	"description": "Images WET-BOEW Component",
 	"language": "en",
 	"title": "Images"
@@ -15,32 +15,32 @@
 <div class="row">
 	<div class="col-sm-6 col-lg-3">
 		<p>Default:</p>
-		<img src="https://placehold.it/250x250" alt="" />
+		<img src="https://dummyimage.com/250x250" alt="" />
 	</div>
 	<div class="col-sm-6 col-lg-3">
 		<p>Rounded:</p>
-		<img src="https://placehold.it/250x250" class="img-rounded" alt="" />
+		<img src="https://dummyimage.com/250x250" class="img-rounded" alt="" />
 	</div>
 	<div class="col-sm-6 col-lg-3">
 		<p>Circle:</p>
-		<img src="https://placehold.it/250x250" class="img-circle" alt="" />
+		<img src="https://dummyimage.com/250x250" class="img-circle" alt="" />
 	</div>
 	<div class="col-sm-6 col-lg-3">
 		<p>Thumbnail (hyperlinked):</p>
-		<a href="#"><img src="https://placehold.it/250x250" class="img-thumbnail" alt="" /></a>
+		<a href="#"><img src="https://dummyimage.com/250x250" class="img-thumbnail" alt="" /></a>
 	</div>
 </div>
 
 <h3>Source code</h3>
 <dl>
 	<dt>Default:</dt>
-	<dd><pre><code>&lt;img src=&quot;https://placehold.it/250x250&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
+	<dd><pre><code>&lt;img src=&quot;https://dummyimage.com/250x250&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
 	<dt>Rounded:</dt>
-	<dd><pre><code>&lt;img src=&quot;https://placehold.it/250x250&quot; class=&quot;img-rounded&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
+	<dd><pre><code>&lt;img src=&quot;https://dummyimage.com/250x250&quot; class=&quot;img-rounded&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
 	<dt>Circle:</dt>
-	<dd><pre><code>&lt;img src=&quot;https://placehold.it/250x250&quot; class=&quot;img-circle&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
+	<dd><pre><code>&lt;img src=&quot;https://dummyimage.com/250x250&quot; class=&quot;img-circle&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
 	<dt>Thumbnail (hyperlinked):</dt>
-	<dd><pre><code>&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://placehold.it/250x250&quot; class=&quot;img-thumbnail&quot; alt=&quot;&quot; /&gt;&lt;/a&gt;</code></pre></dd>
+	<dd><pre><code>&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://dummyimage.com/250x250&quot; class=&quot;img-thumbnail&quot; alt=&quot;&quot; /&gt;&lt;/a&gt;</code></pre></dd>
 </dl>
 
 <h2>Responsive images</h2>
@@ -51,16 +51,16 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<p>Image is too large for the available space: </p>
-				<img src="https://placehold.it/400x100" alt="Generic placeholder image">
+				<img src="https://dummyimage.com/400x100" alt="Generic placeholder image">
 				<p class="mrgn-tp-lg">Same image is now responsive, and fits the parent container:</p>
-				<img src="https://placehold.it/400x100" class="img-responsive" alt="Generic placeholder image">
+				<img src="https://dummyimage.com/400x100" class="img-responsive" alt="Generic placeholder image">
 			</div>
 		</div>
 	</div>
 </div>
 
 <h3>Source code</h3>
-<pre><code>&lt;img src=&quot;https://placehold.it/400x100&quot; class=&quot;img-responsive&quot; alt=&quot;Generic placeholder image&quot;&gt;</code></pre>
+<pre><code>&lt;img src=&quot;https://dummyimage.com/400x100&quot; class=&quot;img-responsive&quot; alt=&quot;Generic placeholder image&quot;&gt;</code></pre>
 
 <h2>Stretching images</h2>
 <p>Use to stretch a smaller image to the width of the container. Ensure the image is still clear and easy to see in the larger resolutions.</p>
@@ -70,20 +70,20 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<p>Image (100x25)  is too small  and blurry: </p>
-				<img src="https://placehold.it/100x25" alt="Generic placeholder image">
+				<img src="https://dummyimage.com/100x25" alt="Generic placeholder image">
 				<p class="mrgn-tp-md">Image (200x50) is still too small for the space:</p>
-				<img src="https://placehold.it/200x50" alt="Generic placeholder image">
+				<img src="https://dummyimage.com/200x50" alt="Generic placeholder image">
 				<p class="mrgn-tp-lg">Stretched image (100x25) is blurry:</p>
-				<img src="https://placehold.it/100x25" class="full-width" alt="Generic placeholder image">
+				<img src="https://dummyimage.com/100x25" class="full-width" alt="Generic placeholder image">
 				<p class="mrgn-tp-lg">Stretched, clear image (200x50)  fits space: </p>
-				<img src="https://placehold.it/200x50" class="full-width" alt="A generic square placeholder image">
+				<img src="https://dummyimage.com/200x50" class="full-width" alt="A generic square placeholder image">
 			</div>
 		</div>
 	</div>
 </div>
 
 <h3>Source code</h3>
-<pre><code>&lt;img src=&quot;https://placehold.it/200x50&quot; class=&quot;full-width&quot; alt=&quot;A generic square placeholder image&quot;&gt;</code></pre>
+<pre><code>&lt;img src=&quot;https://dummyimage.com/200x50&quot; class=&quot;full-width&quot; alt=&quot;A generic square placeholder image&quot;&gt;</code></pre>
 
 <h2>Thumbnail tiles</h2>
 <p>Use to add any kind of content like headings, paragraphs, or buttons into a thumbnail, to create a thumbnail tile effect.</p>
@@ -92,7 +92,7 @@
 	<div class="col-md-4">
 		<div class="panel panel-default">
 			<div class="panel-body">
-				<section class="thumbnail"><a href="#"><img src="https://placehold.it/350x200" alt="Generic placeholder thumbnail"></a>
+				<section class="thumbnail"><a href="#"><img src="https://dummyimage.com/350x200" alt="Generic placeholder thumbnail"></a>
 					<div class="caption">
 						<h3>Title (caption) </h3>
 						<p>Content</p>
@@ -108,7 +108,7 @@
 </div>
 
 <h3>Source code</h3>
-<pre><code>&lt;section class=&quot;thumbnail&quot;&gt;&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://placehold.it/350x200&quot; alt=&quot;Generic placeholder thumbnail&quot;&gt;&lt;/a&gt;
+<pre><code>&lt;section class=&quot;thumbnail&quot;&gt;&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://dummyimage.com/350x200&quot; alt=&quot;Generic placeholder thumbnail&quot;&gt;&lt;/a&gt;
 	&lt;div class=&quot;caption&quot;&gt;
 		&lt;h3&gt;Title (caption) &lt;/h3&gt;
 		&lt;p&gt;Content&lt;/p&gt;
@@ -128,14 +128,14 @@
 			<div class="panel-body">
 				<h3>Default:</h3>
 				<section class="media"> <a class="pull-left" href="#">
-					<img class="media-object" src="https://placehold.it/64x64" alt="Generic placeholder image"> </a>
+					<img class="media-object" src="https://dummyimage.com/64x64" alt="Generic placeholder image"> </a>
 					<div class="media-body">
 						<h4 class="media-heading">Media heading</h4>
 						<p>Content, image pulls left </p>
 					</div>
 				</section>
 				<section class="media mrgn-tp-xl"> <a class="pull-right" href="#">
-					<img class="media-object" src="https://placehold.it/64x64" alt="Generic placeholder image"> </a>
+					<img class="media-object" src="https://dummyimage.com/64x64" alt="Generic placeholder image"> </a>
 					<div class="media-body">
 						<h4 class="media-heading">Media heading</h4>
 						<p>Content, image pulls right </p>
@@ -144,14 +144,14 @@
 				<h3 class="mrgn-tp-xl">As lists:</h3>
 				<ul class="media-list">
 					<li class="media"> <a class="pull-left" href="#">
-						<img class="media-object" src="https://placehold.it/64x64" alt="Generic placeholder image"> </a>
+						<img class="media-object" src="https://dummyimage.com/64x64" alt="Generic placeholder image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">Heading</h4>
 							<p>Content, image pulls left </p>
 						</div>
 					</li>
 					<li class="media">
-						<a class="pull-left" href="#"> <img class="media-object" src="https://placehold.it/64x64" alt="Generic placeholder image"> </a>
+						<a class="pull-left" href="#"> <img class="media-object" src="https://dummyimage.com/64x64" alt="Generic placeholder image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">Heading</h4>
 							<p>Content, image pulls left </p>
@@ -160,14 +160,14 @@
 				</ul>
 				<ul class="media-list   mrgn-tp-xl">
 					<li class="media"> <a class="pull-right" href="#">
-						<img class="media-object" src="https://placehold.it/64x64" alt="Generic placeholder image"> </a>
+						<img class="media-object" src="https://dummyimage.com/64x64" alt="Generic placeholder image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">Heading</h4>
 							<p>Content, image pulls right </p>
 						</div>
 					</li>
 					<li class="media"> <a class="pull-right" href="#">
-						<img class="media-object" src="https://placehold.it/64x64" alt="Generic placeholder image"> </a>
+						<img class="media-object" src="https://dummyimage.com/64x64" alt="Generic placeholder image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">Heading</h4>
 							<p>Content, image pulls right </p>
@@ -186,14 +186,14 @@
 			&lt;div class=&quot;panel-body&quot;&gt;
 				&lt;h3&gt;Default:&lt;/h3&gt;
 				&lt;section class=&quot;media&quot;&gt; &lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt;
-					&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
+					&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
 					&lt;div class=&quot;media-body&quot;&gt;
 						&lt;h4 class=&quot;media-heading&quot;&gt;Media heading&lt;/h4&gt;
 						&lt;p&gt;Content, image pulls left &lt;/p&gt;
 					&lt;/div&gt;
 				&lt;/section&gt;
 				&lt;section class=&quot;media mrgn-tp-xl&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt;
-					&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
+					&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
 					&lt;div class=&quot;media-body&quot;&gt;
 						&lt;h4 class=&quot;media-heading&quot;&gt;Media heading&lt;/h4&gt;
 						&lt;p&gt;Content, image pulls right &lt;/p&gt;
@@ -202,14 +202,14 @@
 				&lt;h3 class=&quot;mrgn-tp-xl&quot;&gt;As lists:&lt;/h3&gt;
 				&lt;ul class=&quot;media-list&quot;&gt;
 					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt;
-						&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
+						&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;Heading&lt;/h4&gt;
 							&lt;p&gt;Content, image pulls left &lt;/p&gt;
 						&lt;/div&gt;
 					&lt;/li&gt;
 					&lt;li class=&quot;media&quot;&gt;
-						&lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt; &lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
+						&lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt; &lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;Heading&lt;/h4&gt;
 							&lt;p&gt;Content, image pulls left &lt;/p&gt;
@@ -218,14 +218,14 @@
 				&lt;/ul&gt;
 				&lt;ul class=&quot;media-list   mrgn-tp-xl&quot;&gt;
 					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt;
-						&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
+						&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;Heading&lt;/h4&gt;
 							&lt;p&gt;Content, image pulls right &lt;/p&gt;
 						&lt;/div&gt;
 					&lt;/li&gt;
 					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt;
-						&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
+						&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Generic placeholder image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;Heading&lt;/h4&gt;
 							&lt;p&gt;Content, image pulls right &lt;/p&gt;

--- a/components/images/images-fr.html
+++ b/components/images/images-fr.html
@@ -1,7 +1,7 @@
 ---
 {
 	"altLangPage": "images-en.html",
-	"dateModified": "2023-07-12",
+	"dateModified": "2024-12-05",
 	"description": "Images WET-BOEW Composante",
 	"language": "fr",
 	"title": "Images"
@@ -15,32 +15,32 @@
 <div class="row">
 	<div class="col-sm-6 col-lg-3">
 		<p>Par défaut :</p>
-		<img src="https://placehold.it/250x250" alt="" />
+		<img src="https://dummyimage.com/250x250" alt="" />
 	</div>
 	<div class="col-sm-6 col-lg-3">
 		<p>Arrondi :</p>
-		<img src="https://placehold.it/250x250" class="img-rounded" alt="" />
+		<img src="https://dummyimage.com/250x250" class="img-rounded" alt="" />
 	</div>
 	<div class="col-sm-6 col-lg-3">
 		<p>Circle :</p>
-		<img src="https://placehold.it/250x250" class="img-circle" alt="" />
+		<img src="https://dummyimage.com/250x250" class="img-circle" alt="" />
 	</div>
 	<div class="col-sm-6 col-lg-3">
 		<p>Thumbnail (hyperlinked) :</p>
-		<a href="#"><img src="https://placehold.it/250x250" class="img-thumbnail" alt="" /></a>
+		<a href="#"><img src="https://dummyimage.com/250x250" class="img-thumbnail" alt="" /></a>
 	</div>
 </div>
 
 <h3>Code</h3>
 <dl>
 	<dt>Par défaut :</dt>
-	<dd><pre><code>&lt;img src=&quot;https://placehold.it/250x250&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
+	<dd><pre><code>&lt;img src=&quot;https://dummyimage.com/250x250&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
 	<dt>Arrondi :</dt>
-	<dd><pre><code>&lt;img src=&quot;https://placehold.it/250x250&quot; class=&quot;img-rounded&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
+	<dd><pre><code>&lt;img src=&quot;https://dummyimage.com/250x250&quot; class=&quot;img-rounded&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
 	<dt>Cercle :</dt>
-	<dd><pre><code>&lt;img src=&quot;https://placehold.it/250x250&quot; class=&quot;img-circle&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
+	<dd><pre><code>&lt;img src=&quot;https://dummyimage.com/250x250&quot; class=&quot;img-circle&quot; alt=&quot;&quot; /&gt;</code></pre></dd>
 	<dt>Miniature (en hyperlien) :</dt>
-	<dd><pre><code>&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://placehold.it/250x250&quot; class=&quot;img-thumbnail&quot; alt=&quot;&quot; /&gt;&lt;/a&gt;</code></pre></dd>
+	<dd><pre><code>&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://dummyimage.com/250x250&quot; class=&quot;img-thumbnail&quot; alt=&quot;&quot; /&gt;&lt;/a&gt;</code></pre></dd>
 </dl>
 
 <h2>Images réactives</h2>
@@ -51,16 +51,16 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<p>Image trop grande pour l'espace disponible : </p>
-				<img src="https://placehold.it/400x100" alt="Un espace générique pour une image">
+				<img src="https://dummyimage.com/400x100" alt="Un espace générique pour une image">
 				<p class="mrgn-tp-lg">La même image est maintenant réactive et entre dans le conteneur parent:</p>
-				<img src="https://placehold.it/400x100" class="img-responsive" alt="Un espace générique pour une image">
+				<img src="https://dummyimage.com/400x100" class="img-responsive" alt="Un espace générique pour une image">
 			</div>
 		</div>
 	</div>
 </div>
 
 <h3>Code</h3>
-<pre><code>&lt;img src=&quot;https://placehold.it/400x100&quot; class=&quot;img-responsive&quot; alt=&quot;Un espace générique pour une image&quot;&gt;</code></pre>
+<pre><code>&lt;img src=&quot;https://dummyimage.com/400x100&quot; class=&quot;img-responsive&quot; alt=&quot;Un espace générique pour une image&quot;&gt;</code></pre>
 
 <h2>Étirement des images</h2>
 <p>Utilisez pour étirer une plus petite image à la largeur du conteneur. Assurez-vous que l'image est toujours claire et facile à voir dans les résolutions plus grandes.</p>
@@ -70,20 +70,20 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<p>L'image (100x25) est trop petite et brouillée:</p>
-				<img src="https://placehold.it/100x25" alt="Un espace générique pour une image">
+				<img src="https://dummyimage.com/100x25" alt="Un espace générique pour une image">
 				<p class="mrgn-tp-md">L'image (200x50) est toujours trop petite pour l'espace:</p>
-				<img src="https://placehold.it/200x50" alt="Un espace générique pour une image">
+				<img src="https://dummyimage.com/200x50" alt="Un espace générique pour une image">
 				<p class="mrgn-tp-lg">L'image étirée (100x25) est floue:</p>
-				<img src="https://placehold.it/100x25" class="full-width" alt="Un espace générique pour une image">
+				<img src="https://dummyimage.com/100x25" class="full-width" alt="Un espace générique pour une image">
 				<p class="mrgn-tp-lg">L'image étirée et claire (200x50) entre dans l'espace: </p>
-				<img src="https://placehold.it/200x50" class="full-width" alt="Un espace générique pour une image">
+				<img src="https://dummyimage.com/200x50" class="full-width" alt="Un espace générique pour une image">
 			</div>
 		</div>
 	</div>
 </div>
 
 <h3>Code</h3>
-<pre><code>&lt;img src=&quot;https://placehold.it/200x50&quot; class=&quot;full-width&quot; alt=&quot;Un espace générique pour une image&quot;&gt;</code></pre>
+<pre><code>&lt;img src=&quot;https://dummyimage.com/200x50&quot; class=&quot;full-width&quot; alt=&quot;Un espace générique pour une image&quot;&gt;</code></pre>
 
 <h2>Pavés de miniatures</h2>
 <p>Utilisez pour ajouter toute sorte de contenu tel que les en-têtes, les paragraphes ou les boutons dans une miniature afin de créer un effet de pavé de miniatures.</p>
@@ -92,7 +92,7 @@
 	<div class="col-md-4">
 		<div class="panel panel-default">
 			<div class="panel-body">
-				<section class="thumbnail"><a href="#"><img src="https://placehold.it/350x200" alt="Un espace générique pour une image"></a>
+				<section class="thumbnail"><a href="#"><img src="https://dummyimage.com/350x200" alt="Un espace générique pour une image"></a>
 					<div class="caption">
 						<h3>Titre (légende) </h3>
 						<p>Titre (légende)</p>
@@ -108,7 +108,7 @@
 </div>
 
 <h3>Source code</h3>
-<pre><code>&lt;section class=&quot;thumbnail&quot;&gt;&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://placehold.it/350x200&quot; alt=&quot;Un espace générique pour une image&quot;&gt;&lt;/a&gt;
+<pre><code>&lt;section class=&quot;thumbnail&quot;&gt;&lt;a href=&quot;#&quot;&gt;&lt;img src=&quot;https://dummyimage.com/350x200&quot; alt=&quot;Un espace générique pour une image&quot;&gt;&lt;/a&gt;
 	&lt;div class=&quot;caption&quot;&gt;
 		&lt;h3&gt;Titre (légende) &lt;/h3&gt;
 		&lt;p&gt;Titre (légende)&lt;/p&gt;
@@ -128,14 +128,14 @@
 			<div class="panel-body">
 				<h3>Par défaut&nbsp; :</h3>
 				<section class="media"> <a class="pull-left" href="#">
-					<img class="media-object" src="https://placehold.it/64x64" alt="Un espace générique pour une image"> </a>
+					<img class="media-object" src="https://dummyimage.com/64x64" alt="Un espace générique pour une image"> </a>
 					<div class="media-body">
 						<h4 class="media-heading">En-tête du média</h4>
 						<p>Contenu, image tirée vers la gauche</p>
 					</div>
 				</section>
 				<section class="media mrgn-tp-xl"> <a class="pull-right" href="#">
-					<img class="media-object" src="https://placehold.it/64x64" alt="Un espace générique pour une image"> </a>
+					<img class="media-object" src="https://dummyimage.com/64x64" alt="Un espace générique pour une image"> </a>
 					<div class="media-body">
 						<h4 class="media-heading">En-tête du média</h4>
 						<p>Contenu, image tirée vers la droite</p>
@@ -144,14 +144,14 @@
 				<h3 class="mrgn-tp-xl">Comme des listes :</h3>
 				<ul class="media-list">
 					<li class="media"> <a class="pull-left" href="#">
-						<img class="media-object" src="https://placehold.it/64x64" alt="Un espace générique pour une image"> </a>
+						<img class="media-object" src="https://dummyimage.com/64x64" alt="Un espace générique pour une image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">En-tête</h4>
 							<p>Contenu, image tirée vers la gauche</p>
 						</div>
 					</li>
 					<li class="media"> <a class="pull-left" href="#">
-						<img class="media-object" src="https://placehold.it/64x64" alt="Un espace générique pour une image"> </a>
+						<img class="media-object" src="https://dummyimage.com/64x64" alt="Un espace générique pour une image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">En-tête</h4>
 							<p>Contenu, image tirée vers la gauche</p>
@@ -159,13 +159,13 @@
 					</li>
 				</ul>
 				<ul class="media-list mrgn-tp-xl">
-					<li class="media"> <a class="pull-right" href="#"> <img class="media-object" src="https://placehold.it/64x64" alt="Un espace générique pour une image"> </a>
+					<li class="media"> <a class="pull-right" href="#"> <img class="media-object" src="https://dummyimage.com/64x64" alt="Un espace générique pour une image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">En-tête</h4>
 							<p>Contenu, image tirée vers la droite </p>
 						</div>
 					</li>
-					<li class="media"> <a class="pull-right" href="#"> <img class="media-object" src="https://placehold.it/64x64" alt="Un espace générique pour une image"> </a>
+					<li class="media"> <a class="pull-right" href="#"> <img class="media-object" src="https://dummyimage.com/64x64" alt="Un espace générique pour une image"> </a>
 						<div class="media-body">
 							<h4 class="media-heading">En-tête</h4>
 							<p>Contenu, image tirée vers la droite.</p>
@@ -184,14 +184,14 @@
 			&lt;div class=&quot;panel-body&quot;&gt;
 				&lt;h3&gt;Par d&eacute;faut&amp;nbsp; :&lt;/h3&gt;
 				&lt;section class=&quot;media&quot;&gt; &lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt;
-					&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
+					&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
 					&lt;div class=&quot;media-body&quot;&gt;
 						&lt;h4 class=&quot;media-heading&quot;&gt;En-t&ecirc;te du m&eacute;dia&lt;/h4&gt;
 						&lt;p&gt;Contenu, image tir&eacute;e vers la gauche&lt;/p&gt;
 					&lt;/div&gt;
 				&lt;/section&gt;
 				&lt;section class=&quot;media mrgn-tp-xl&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt;
-					&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
+					&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
 					&lt;div class=&quot;media-body&quot;&gt;
 						&lt;h4 class=&quot;media-heading&quot;&gt;En-t&ecirc;te du m&eacute;dia&lt;/h4&gt;
 						&lt;p&gt;Contenu, image tir&eacute;e vers la droite&lt;/p&gt;
@@ -200,14 +200,14 @@
 				&lt;h3 class=&quot;mrgn-tp-xl&quot;&gt;Comme des listes :&lt;/h3&gt;
 				&lt;ul class=&quot;media-list&quot;&gt;
 					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt;
-						&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
+						&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;En-t&ecirc;te&lt;/h4&gt;
 							&lt;p&gt;Contenu, image tir&eacute;e vers la gauche&lt;/p&gt;
 						&lt;/div&gt;
 					&lt;/li&gt;
 					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-left&quot; href=&quot;#&quot;&gt;
-						&lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
+						&lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;En-t&ecirc;te&lt;/h4&gt;
 							&lt;p&gt;Contenu, image tir&eacute;e vers la gauche&lt;/p&gt;
@@ -215,13 +215,13 @@
 					&lt;/li&gt;
 				&lt;/ul&gt;
 				&lt;ul class=&quot;media-list mrgn-tp-xl&quot;&gt;
-					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt; &lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
+					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt; &lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;En-t&ecirc;te&lt;/h4&gt;
 							&lt;p&gt;Contenu, image tir&eacute;e vers la droite &lt;/p&gt;
 						&lt;/div&gt;
 					&lt;/li&gt;
-					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt; &lt;img class=&quot;media-object&quot; src=&quot;https://placehold.it/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
+					&lt;li class=&quot;media&quot;&gt; &lt;a class=&quot;pull-right&quot; href=&quot;#&quot;&gt; &lt;img class=&quot;media-object&quot; src=&quot;https://dummyimage.com/64x64&quot; alt=&quot;Un espace g&eacute;n&eacute;rique pour une image&quot;&gt; &lt;/a&gt;
 						&lt;div class=&quot;media-body&quot;&gt;
 							&lt;h4 class=&quot;media-heading&quot;&gt;En-t&ecirc;te&lt;/h4&gt;
 							&lt;p&gt;Contenu, image tir&eacute;e vers la droite.&lt;/p&gt;

--- a/design-patterns/gc-intro/index.json-ld
+++ b/design-patterns/gc-intro/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "Guidance about using the introduction block component on Canada.ca.",
 		"fr": "Orientation sur l’utilisation du composant bloc d’introduction sur Canada.ca."
 	},
-	"modified": "2024-06-12",
+	"modified": "2024-12-05",
 	"componentName": "gc-intro",
 	"pages": {
 		"docs": [
@@ -302,14 +302,14 @@
 					{
 						"@type": "source-code",
 						"description": "Code sample:",
-						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Introduction block with half-width image</h1>\n\t\t<p>The introduction block pattern introduces the content of a landing page.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Supertask button</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://via.placeholder.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
+						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Introduction block with half-width image</h1>\n\t\t<p>The introduction block pattern introduces the content of a landing page.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Supertask button</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://dummyimage.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
 					}
 				],
 				"fr": [
 					{
 						"@type": "source-code",
 						"description": "Exemple de code :",
-						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Bloc d'introduction avec image demi-largeur</h1>\n\t\t<p>La configuration de conception du bloc d'introduction introduit le contenu d'une page de destination.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Bouton de super-tâche</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://via.placeholder.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
+						"code": "<div class=\"row\">\n\t<div class=\"col-md-6\">\n\t\t<h1 property=\"name\" id=\"wb-cont\">Bloc d'introduction avec image demi-largeur</h1>\n\t\t<p>La configuration de conception du bloc d'introduction introduit le contenu d'une page de destination.</p>\n\t\t<p><a class=\"btn btn-call-to-action\" href=\"#\">Bouton de super-tâche</a></p>\n\t</div>\n\t<div class=\"col-md-6 hidden-sm hidden-xs\">\n\t\t<img src=\"https://dummyimage.com/520x200/000000/FFFFFF.png\" alt=\"\" class=\"img-responsive pull-right mrgn-tp-lg\">\n\t</div>\n</div>"
 					}
 				]
 			}

--- a/templates/institutional-landing/deprecated/institution-en.html
+++ b/templates/institutional-landing/deprecated/institution-en.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---
@@ -28,7 +28,7 @@
 			<div class="row">
 				<div class="col-md-6">
 					<a href="#">
-						<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
+						<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
 						<p>[News title]</p>
 					</a>
 					<small>YYYY-MM-DD hh:mm - Type of news product</small>
@@ -36,7 +36,7 @@
 				</div>
 				<div class="col-md-6">
 					<a href="#">
-						<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
+						<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
 						<p>[News title]</p>
 					</a>
 					<small>YYYY-MM-DD hh:mm - Type of news product</small>

--- a/templates/institutional-landing/deprecated/institution-fr.html
+++ b/templates/institutional-landing/deprecated/institution-fr.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---
@@ -28,7 +28,7 @@
 			<div class="row">
 				<div class="col-md-6">
 					<a href="#">
-						<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
+						<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
 						<p>[Titre de l’article]</p>
 					</a>
 					<small>AAAA-MM-JJ hh:mm - Type de produit médiatique</small>
@@ -36,7 +36,7 @@
 				</div>
 				<div class="col-md-6">
 					<a href="#">
-						<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
+						<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail"/>
 						<p>[Titre de l’article]</p>
 					</a>
 					<small>AAAA-MM-JJ hh:mm - Type de produit médiatique</small>

--- a/templates/institutional-landing/deprecated/institution-landing-en.html
+++ b/templates/institutional-landing/deprecated/institution-landing-en.html
@@ -7,7 +7,7 @@ overwriteBreadcrumbs: true
 breadcrumbs: [
 	{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 ]
-dateModified: "2021-06-03"
+dateModified: "2024-12-05"
 share: true
 ---
 {%- include variable-core.liquid -%}
@@ -165,14 +165,14 @@ share: true
 			<div class="row wb-eqht">
 				<div class="col-sm-6">
 					<div class="well well-sm brdr-rds-0 eqht-trgt">
-						<img class="img-responsive full-width" src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" />
+						<img class="img-responsive full-width" src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" />
 						<h3 class="h5"><a class="stretched-link" href="#">[Feature hyperlink text]</a></h3>
 						<p>Brief description of the feature being promoted.</p>
 					</div>
 				</div>
 				<div class="col-sm-6">
 					<div class="well well-sm brdr-rds-0 eqht-trgt">
-						<img class="img-responsive full-width" src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" />
+						<img class="img-responsive full-width" src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" />
 						<h3 class="h5"><a class="stretched-link" href="#">[Feature hyperlink text]</a></h3>
 						<p>Brief description of the feature being promoted.</p>
 					</div>

--- a/templates/institutional-landing/deprecated/institution-landing-fr.html
+++ b/templates/institutional-landing/deprecated/institution-landing-fr.html
@@ -7,7 +7,7 @@ overwriteBreadcrumbs: true
 breadcrumbs: [
 	{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 ]
-dateModified: "2021-06-03"
+dateModified: "2024-12-05"
 share: true
 ---
 {%- include variable-core.liquid -%}
@@ -165,14 +165,14 @@ share: true
 			<div class="row wb-eqht">
 				<div class="col-sm-6">
 					<div class="well well-sm brdr-rds-0 eqht-trgt">
-						<img class="img-responsive full-width" src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" />
+						<img class="img-responsive full-width" src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" />
 						<h3 class="h5"><a class="stretched-link" href="#">[Feature hyperlink text]</a></h3>
 						<p>Brief description of the feature being promoted.</p>
 					</div>
 				</div>
 				<div class="col-sm-6">
 					<div class="well well-sm brdr-rds-0 eqht-trgt">
-						<img class="img-responsive full-width" src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" />
+						<img class="img-responsive full-width" src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" />
 						<h3 class="h5"><a class="stretched-link" href="#">[Feature hyperlink text]</a></h3>
 						<p>Brief description of the feature being promoted.</p>
 					</div>

--- a/templates/institutional/institution-arms-en.html
+++ b/templates/institutional/institution-arms-en.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true",
 	"armslength": true
 }

--- a/templates/institutional/institution-arms-fr.html
+++ b/templates/institutional/institution-arms-fr.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true",
 	"armslength": true
 }

--- a/templates/ministerial/ministerial-en.html
+++ b/templates/ministerial/ministerial-en.html
@@ -3,7 +3,7 @@ title: The Honourable [Minister name], MP | [Parliamentary secretary’s name] |
 description: Working example for the Ministerial profile page template
 language: en
 altLangPage: ministerial-fr.html
-dateModified: 2021-09-16
+dateModified: 2024-12-05
 share: true
 ---
 
@@ -35,17 +35,17 @@ share: true
 	<div class="row wb-eqht">
 		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
 			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<p>Brief description of the feature being promoted.</p>
 		</div>
 		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
 			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<p>Brief description of the feature being promoted.</p>
 		</div>
 		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
 			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<p>Brief description of the feature being promoted.</p>
 		</div>
 	</div>

--- a/templates/ministerial/ministerial-fr.html
+++ b/templates/ministerial/ministerial-fr.html
@@ -3,7 +3,7 @@ title: L’honorable [nom du ministre], député | [Nom du secrétaire parlement
 description: Exemple pratique de la pages de profil des ministres
 language: fr
 altLangPage: ministerial-en.html
-dateModified: 2021-09-16
+dateModified: 2024-12-05
 share: true
 ---
 
@@ -35,17 +35,17 @@ share: true
 	<div class="row wb-eqht">
 		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
 			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<p>Brève descripton de l'élément en vedette</p>
 		</div>
 		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
 			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<p>Brève descripton de l'élément en vedette</p>
 		</div>
 		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
 			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<p>Brève descripton de l'élément en vedette</p>
 		</div>
 	</div>

--- a/templates/organizational/organizational-arms-en.html
+++ b/templates/organizational/organizational-arms-en.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---

--- a/templates/organizational/organizational-arms-fr.html
+++ b/templates/organizational/organizational-arms-fr.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---

--- a/templates/organizational/organizational-en.html
+++ b/templates/organizational/organizational-en.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Departments & agencies", "link": "https://www.canada.ca/en/government/dept.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---

--- a/templates/organizational/organizational-fr.html
+++ b/templates/organizational/organizational-fr.html
@@ -9,7 +9,7 @@
 	"breadcrumbs": [
 		{ "title": "Ministères et organismes", "link": "https://www.canada.ca/fr/gouvernement/min.html" }
 	],
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true"
 }
 ---

--- a/templates/theme-en.html
+++ b/templates/theme-en.html
@@ -6,7 +6,7 @@
 	"altLangPage": "theme-fr.html",
 	"pageclass": "page-type-nav",
 	"pageType": "theme",
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true",
 	"deptfeature": true
 }
@@ -22,19 +22,19 @@
 		<div class="wb-tabs carousel-s2 playing" data-speed="slow">
 			<ul role="tablist">
 				<li class="active">
-					<a href="#tab1" title="Tab 1: [Title of destination page – call to action]"><img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" /></a>
+					<a href="#tab1" title="Tab 1: [Title of destination page – call to action]"><img src="https://dummyimage.com/653x194/00008B/FFFFFF&text=Image+1" alt="" /></a>
 				</li>
 				<li>
-					<a href="#tab2" title="Tab 2: [Title of destination page – call to action]"><img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" /></a>
+					<a href="#tab2" title="Tab 2: [Title of destination page – call to action]"><img src="https://dummyimage.com/653x194/000000/FFFFFF&text=Image+2" alt="" /></a>
 				</li>
 				<li>
-					<a href="#tab3" title="Tab 3: [Title of destination page – call to action]"><img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" /></a>
+					<a href="#tab3" title="Tab 3: [Title of destination page – call to action]"><img src="https://dummyimage.com/653x194/023020/FFFFFF&text=Image+3" alt="" /></a>
 				</li>
 			</ul>
 			<div role="tabpanel" id="tab1" class="in fade">
 				<a href="#" class="learnmore">
 					<figure>
-						<img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" />
+						<img src="https://dummyimage.com/653x194/00008B/FFFFFF&text=Image+1" alt="" />
 						<figcaption>
 							<p>[Title of destination page – call to action]</p>
 						</figcaption>
@@ -44,7 +44,7 @@
 			<div role="tabpanel" id="tab2" class="out fade">
 				<a href="#" class="learnmore">
 					<figure>
-						<img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" />
+						<img src="https://dummyimage.com/653x194/000000/FFFFFF&text=Image+2" alt="" />
 						<figcaption>
 							<p>[Title of destination page – call to action]</p>
 						</figcaption>
@@ -54,7 +54,7 @@
 			<div role="tabpanel" id="tab3" class="out fade">
 				<a href="#" class="learnmore">
 					<figure>
-						<img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" />
+						<img src="https://dummyimage.com/653x194/023020/FFFFFF&text=Image+3" alt="" />
 						<figcaption>
 							<p>[Title of destination page – call to action]</p>
 						</figcaption>

--- a/templates/theme-fr.html
+++ b/templates/theme-fr.html
@@ -6,7 +6,7 @@
 	"altLangPage": "theme-en.html",
 	"pageclass": "page-type-nav",
 	"pageType": "theme",
-	"dateModified": "2023-09-01",
+	"dateModified": "2024-12-05",
 	"share": "true",
 	"deptfeature": true
 }
@@ -22,19 +22,19 @@
 		<div class="wb-tabs carousel-s2 playing" data-speed="slow">
 			<ul role="tablist">
 				<li class="active">
-					<a href="#tab1" title="Languette 1 : [Titre de la page de destination – appel à l’action]"><img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" /></a>
+					<a href="#tab1" title="Languette 1 : [Titre de la page de destination – appel à l’action]"><img src="https://dummyimage.com/653x194/00008B/FFFFFF&text=Image+1" alt="" /></a>
 				</li>
 				<li>
-					<a href="#tab2" title="Languette 2 : [Titre de la page de destination – appel à l’action]"><img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" /></a>
+					<a href="#tab2" title="Languette 2 : [Titre de la page de destination – appel à l’action]"><img src="https://dummyimage.com/653x194/000000/FFFFFF&text=Image+2" alt="" /></a>
 				</li>
 				<li>
-					<a href="#tab3" title="Languette 3 : [Titre de la page de destination – appel à l’action]"><img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" /></a>
+					<a href="#tab3" title="Languette 3 : [Titre de la page de destination – appel à l’action]"><img src="https://dummyimage.com/653x194/023020/FFFFFF&text=Image+3" alt="" /></a>
 				</li>
 			</ul>
 			<div role="tabpanel" id="tab1" class="in fade">
 				<a href="#" class="learnmore">
 					<figure>
-						<img src="https://via.placeholder.com/653x194/00008B/FFFFFF?text=Image+1" alt="" />
+						<img src="https://dummyimage.com/653x194/00008B/FFFFFF&text=Image+1" alt="" />
 						<figcaption>
 							<p>[Titre de la page de destination – appel à l’action]</p>
 						</figcaption>
@@ -44,7 +44,7 @@
 			<div role="tabpanel" id="tab2" class="out fade">
 				<a href="#" class="learnmore">
 					<figure>
-						<img src="https://via.placeholder.com/653x194/000000/FFFFFF?text=Image+2" alt="" />
+						<img src="https://dummyimage.com/653x194/000000/FFFFFF&text=Image+2" alt="" />
 						<figcaption>
 							<p>[Titre de la page de destination – appel à l’action]</p>
 						</figcaption>
@@ -54,7 +54,7 @@
 			<div role="tabpanel" id="tab3" class="out fade">
 				<a href="#" class="learnmore">
 					<figure>
-						<img src="https://via.placeholder.com/653x194/023020/FFFFFF?text=Image+3" alt="" />
+						<img src="https://dummyimage.com/653x194/023020/FFFFFF&text=Image+3" alt="" />
 						<figcaption>
 							<p>[Titre de la page de destination – appel à l’action]</p>
 						</figcaption>


### PR DESCRIPTION
Some of GCWeb's code samples from recent years were referencing placeholder images from [placeholder.com](https://placeholder.com/) and [placehold.it](https://placehold.it/). But those sites underwent changes in ownership in March 2023 and consequently ceased serving placeholder images.

This deals with it by replacing all references to via.placeholder.com and placehold.it with dummyimage.com (and swaps ? characters with & where custom text is specified to fit the latter's URL writing scheme).

GCWeb has historically used [dummyimage.com](https://dummyimage.com/) and that site still exists to this day.

Left the following references to [placeholder.com](https://placeholder.com/) "as-is" in the following WCAG assessments since they're meant to represent specific points in time:
* [templates/institutional-landing/reports/a11y-1.json](https://github.com/wet-boew/GCWeb/blob/master/templates/institutional-landing/reports/a11y-1.json)
* [templates/institutional-landing/reports/a11y-2.json](https://github.com/wet-boew/GCWeb/blob/master/templates/institutional-landing/reports/a11y-2.json)