### PR TITLE
Byline: adding documentation, moving to main title

### DIFF
--- a/_data/components.json
+++ b/_data/components.json
@@ -180,6 +180,210 @@
 		"modified": "dct:modified"
 	},
 	"title": {
+		"en": "Institutional byline",
+		"fr": "Institution responsable"
+	},
+	"description": {
+		"en": "The institutional byline provides people with a link to the institution or institutions responsible for the content.",
+		"fr": "La signature institutionnelle fournit aux personnes un lien vers l’institution ou les institutions responsables du contenu."
+	},
+	"modified": "2024-12-10",
+	"componentName": "byline",
+	"status": "demoted",
+	"version": "1.1.0",
+	"pages": {
+		"docs": [
+			{
+				"title": "Institutional byline",
+				"language": "en",
+				"path": "byline-doc-en.html"
+			},
+			{
+				"title": "Institution responsable",
+				"language": "fr",
+				"path": "byline-doc-fr.html"
+			}
+		]
+	},
+	"a11yGuidance": "No accessibility guidance.",
+	"variations": [
+		{
+			"name": {
+				"en": "Institutional byline - default",
+				"fr": "Institution responsable - par défaut"
+			},
+			"status": "demoted",
+			"description": {
+				"en": "The institutional byline provides people with a link to the institution or institutions responsible for the content.",
+				"fr": "La signature institutionnelle fournit aux personnes un lien vers l’institution ou les institutions responsables du contenu."
+			},
+			"iteration": "_:iteration_byline_2",
+			"example": [
+				{
+					"en": { "href": "../../templates/content-page/content-en.html", "text": "Content page (byline after the main title)" },
+					"fr": { "href": "../../templates/content-page/content-fr.html", "text": "Page de contenu (institution responsable sous le titre principal)" }
+				}
+			],
+			"implementation": [
+				"_:implement_byline"
+			],
+			"history": [
+				{
+					"en": "December 2024 - Demotion of the component - Moved to the Main title component. Use the Contributors component instead.",
+					"fr": "Décembre 2024 - Composante maintenant rétrogradée - Déplacée vers la componante Titre principal. Utilisez plutôt la composante Contributeurs."
+				},
+				{
+					"en": "April 2016 - Addition of the class <code>.gc-byline</code>.",
+					"fr": "Avril 2016 - Ajout de la classe <code>.gc-byline</code>."
+				},
+				{
+					"en": "January 2016 - Initial implementation of the component.",
+					"fr": "Janvier 2016 - Implémentation initiale pde la composante."
+				}
+			]
+		}
+	],
+	"implementation": [
+		{
+			"@id": "_:implement_byline",
+			"iteration": "_:iteration_byline_2",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the component manually.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement."
+			},
+			"instructions": {
+				"en": [
+					"Refer to the following code samples."
+				],
+				"fr": [
+					"Référez-vous au code qui suit."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Standard example:",
+						"code": "<h1>[Main title]</h1>\n<p class=\"gc-byline\">From <a href=\"#\">[Institution name]</a></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Standard example with &lt;strong&gt; element:",
+						"code": "<h1>[Main title]</h1>\n<p class=\"gc-byline\"><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Example without \"gc-byline\" class:",
+						"code": "<h1>[Main title]</h1>\n<p><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple de base :",
+						"code": "<h1>[Titre principal]</h1>\n<p class=\"gc-byline\">De <a href=\"#\">[Nom de l'institution]</a></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Exemple de base avec élément &lt;strong&gt; :",
+						"code": "<h1>[Titre principal]</h1>\n<p class=\"gc-byline\"><strong>De <a href=\"#\">[Nom de l'institution]</a></strong></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Exemple sans la classe  « gc-byline » :",
+						"code": "<h1>[Titre principal]</h1>\n<p><strong>De <a href=\"#\">[Nom de l'institution]</a></strong></p>"
+					}
+				]
+			}
+		}
+	],
+	"iteration": [
+		{
+			"@id": "_:iteration_byline_2",
+			"name": "Institutional byline - Iteration 2",
+			"date": "2016-04",
+			"detectableBy": "h1#wb-cont+p>strong>a",
+			"addition": [
+				"Added CSS class <code>.gc-byline</code>"
+			],
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<p class=\"gc-byline\"><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+				}
+			],
+			"predecessor": "_:iteration_byline"
+		},
+		{
+			"@id": "_:iteration_byline",
+			"name": "Institutional byline - Iteration 1",
+			"date": "2016-01",
+			"detectableBy": "h1#wb-cont+p>strong>a",
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<p><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+				}
+			],
+			"successor": "_:iteration_byline_2"
+		}
+	],
+	"changesets": [
+		{
+			"@id": "_:cs_byline_2",
+			"name": "Institutional byline - version 2",
+			"status": "demoted",
+			"baseOnIteration": "_:iteration_byline_2",
+			"detectableBy": ".gc-byline",
+			"guidance": "The component must be located directly after the first <h1> of the page.",
+			"style": "The whole byline is bolded.",
+			"semantic": "p>strong>a",
+			"static": [
+				"From",
+				"De"
+			],
+			"schema": [
+				"insitution name",
+				"insitution url"
+			]
+		},
+		{
+			"@id": "_:cs_byline",
+			"name": "Institutional byline",
+			"status": "demoted",
+			"baseOnIteration": "_:iteration_byline",
+			"detectableBy": "h1#wb-cont+p>strong>a",
+			"guidance": "The component must be located directly after the first <h1> of the page.",
+			"style": "The whole byline is bolded.",
+			"semantic": "p>strong>a",
+			"static": [
+				"From",
+				"De"
+			],
+			"schema": [
+				"insitution name",
+				"insitution url"
+			]
+		}
+	]
+}
+,{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
 		"en": "Checkboxes and radio buttons",
 		"fr": "Cases à cocher et boutons radio"
 	},

--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -25,7 +25,9 @@ component_status:
     provisional: Provisional
     stable: Stable
     deprecated: Deprecated
+    demoted: Demoted
   fr:
     provisional: Provisionel
     stable: Stable
     deprecated: Obsolète
+    demoted: Rétrogradé

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -2266,6 +2266,16 @@
 				"title": "Titre principal superposé aligné à droite",
 				"language": "fr",
 				"path": "main-page-title-stacked-align-right-fr.html"
+			},
+			{
+				"title": "Main page title with byline for news articles",
+				"language": "en",
+				"path": "main-page-title-byline-en.html"
+			},
+			{
+				"title": "Titre principal avec institution responsable pour les articles de nouvelles",
+				"language": "fr",
+				"path": "main-page-title-byline-fr.html"
 			}
 		]
 	},
@@ -2360,6 +2370,38 @@
 				{
 					"en": "2024-08 - Initial implementation of the variant.",
 					"fr": "2024-01 - Implémentation initiale de la variation."
+				}
+			]
+		},
+		{
+			"name": {
+				"en": "Main page title with byline for news articles",
+				"fr": "Titre principal avec institution responsable pour les articles de nouvelles"
+			},
+			"status": "stable",
+			"description": {
+				"en": "This variation is limited to news pages. It is not permitted on any other page.",
+				"fr": "Cette variante est limitée aux pages de nouvelles. Elle n'est permise sur aucune autre page."
+			},
+			"guidance": {
+				"en": "https://design.canada.ca/common-design-patterns/institutional-byline.html",
+				"fr": "https://conception.canada.ca/configurations-conception-communes/institution-responsable.html"
+			},
+			"iteration": "_:iteration_mptb_1",
+			"example": [
+				{
+					"en": { "href": "main-page-title-byline-en.html", "text": "Main page title with byline" },
+					"fr": { "href": "main-page-title-byline-fr.html", "text": "Titre principal avec institution responsable" }
+				}
+			],
+			"implementation": [
+				"_:implement_mptb",
+				"_:implement_mptb_gcweb"
+			],
+			"history": [
+				{
+					"en": "2024-12 - Initial implementation of the variant. This component is the successor of the Institution byline component.",
+					"fr": "2024-12 - Implémentation initiale de la variation. Cette composante succède à la composante Institution responsable."
 				}
 			]
 		}
@@ -2516,6 +2558,78 @@
 					}
 				]
 			}
+		},
+		{
+			"@id": "_:implement_mptb",
+			"iteration": "_:iteration_mptb_1",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the component manually.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement."
+			},
+			"instructions": {
+				"en": [
+					"Refer to the following code sample."
+				],
+				"fr": [
+					"Référez-vous au code qui suit."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "HTML sample",
+						"code":	"<hgroup id=\"wb-cont\">\n\t<h1>Main page title</h1>\n\t<p class=\"gc-byline\">From: <a href=\"https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html\">Service Canada</a></p>\n</hgroup>"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple HTML",
+						"code":	"<hgroup id=\"wb-cont\">\n\t<h1>Titre principal</h1>\n\t<p class=\"gc-byline\">De&nbsp;: <a href=\"https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html\">Service Canada</a></p>\n</hgroup>"
+					}
+				]
+			}
+		},
+		{
+			"@id": "_:implement_mptb_gcweb",
+			"iteration": "_:iteration_mptb_1",
+			"name": {
+				"en": "GCWeb Jekyll",
+				"fr": "GCWeb Jekyll"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers trying to implement this component within a GCWeb Jekyll site.",
+				"fr": "Cette implémentation est destinée aux développeurs essayant d'implémenter ce composant dans un site GCWeb Jekyll."
+			},
+			"instructions": {
+				"en": [
+					"In the page's front-matter do the following:<ul><li>set the variable <code>title</code> to the main title of the page.</li><li>set the variable <code>byline</code> to an object containing the following properties:<ul><li><code>institution</code>: which contains the name of the institution</li><li><code>url</code>: which contains the URL to the institution's page</li></ul></li></ul>"
+				],
+				"fr": [
+					"Dans l'en-tête de la page faites ce qui suit&nbsp;:<ul><li>définissez la variable <code>title</code> au titre principal de la page.</li><li>définissez la variable <code>byline</code> avec un objet contenant les propriétés suivantes&nbsp;:<ul><li><code>institution</code>&nbsp;: qui contient le nom de l'institution</li><li><code>url</code>&nbsp;: qui contient l'URL de la page de l'institution</li></ul></li></ul>"
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Code sample:",
+						"code": "---\n{\n\t\"title\": \"My page title\",\n\t\"byline\": {\n\t\t\"institution\": \"Service Canada\",\n\t\t\"url\": \"https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html\"\n\t}\n}\n---"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple de code :",
+						"code": "---\n{\n\t\"title\": \"Titre de la page\",\n\t\"byline\": {\n\t\t\"institution\": \"Service Canada\",\n\t\t\"url\": \"https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html\"\n\t}\n}\n---"
+					}
+				]
+			}
 		}
 	],
 	"changesets": [
@@ -2546,7 +2660,7 @@
 			"@id": "_:cs_smpt",
 			"name": "Stacked main page title",
 			"baseOnIteration": "_:iteration_smpt_2",
-			"detectableBy": "hgroup > h1#wb-cont",
+			"detectableBy": "hgroup#wb-cont > p:first-child + h1",
 			"layout": "The section page title is above the page title. The line is positioned below the page title.",
 			"semantic": "hgroup > p + h1",
 			"schema": "dct:title, sectionTitle",
@@ -2562,6 +2676,27 @@
 			"style": "The line has a width of 3.55em (71px) and a thickness of 0.18em (3.6px) with the color #af3c43. Optionally, include a byline, tagline, or subtitle. The section page title has a font-size of 26px and has a color of #555.",
 			"guidance": "https://design.canada.ca/styles/typography.html",
 			"context": "First semantic element inside the main"
+		},
+		{
+			"@id": "_:cs_mptb",
+			"name": "Main page title with byline",
+			"baseOnIteration": "_:iteration_mptb_1",
+			"detectableBy": "hgroup#wb-cont > h1 + p:last-child",
+			"layout": "The byline is below the page title. The line is positioned between the page title and the byline.",
+			"semantic": "hgroup > h1 + p",
+			"schema": "dct:title, institutionName, institutionUrl",
+			"include": {
+				"@type": "source-code",
+				"collapsed": true,
+				"description": "Include with logic in Liquid.",
+				"code": {
+					"@type": [ "@id", "rdf:HTML" ],
+					"@value": "includes/main-page-title.html"
+				}
+			},
+			"style": "The line has a width of 3.55em (71px) and a thickness of 0.18em (3.6px) with the color #af3c43. The byline is bolded.",
+			"guidance": "https://design.canada.ca/common-design-patterns/institutional-byline.html",
+			"context": "Page context: First semantic element inside the main. Site context: limited to news pages on Canada.ca."
 		}
 	],
 	"iteration": [
@@ -2609,18 +2744,25 @@
 			"@id": "_:iteration_smpt_1",
 			"name": "Stacked main page title - Iteration 1",
 			"date": "2024-08",
-			"detectableBy": "hgroup > h1#wb-cont",
+			"detectableBy": "hgroup#wb-cont > h1",
 			"successor": "_:iteration_smpt_2"
 		},
 		{
 			"@id": "_:iteration_smpt_2",
 			"name": "Stacked main page title - Iteration 2 (LTR support)",
 			"date": "2024-10",
-			"detectableBy": "hgroup > h1#wb-cont[dir='ltr'], [dir='ltr'] hgroup > h1#wb-cont",
+			"detectableBy": "hgroup#wb-cont > h1[dir='ltr'], [dir='ltr'] hgroup#wb-cont > h1",
 			"additions": [
 				"Added right to left support"
 			],
 			"predecessor": "_:iteration_smpt_1"
+		},
+		{
+			"@id": "_:iteration_mptb_1",
+			"name": "Main page title with byline - Iteration 1",
+			"date": "2024-12",
+			"detectableBy": "hgroup#wb-cont > h1 + p.gc-byline",
+			"successor": "_:iteration_mptb_1"
 		}
 	]
 }

--- a/_data/templates.json
+++ b/_data/templates.json
@@ -192,7 +192,7 @@
 			"name": "All services page - Iteration 2",
 			"date": "2025-01",
 			"additions": [ "Adding expand/collapse all buttons." ],
-			"detectableBy": "Three navigation bands followed by a series of <details> elements for all goc themes and topics."
+			"detectableBy": "Three navigation bands followed by an expand all and a collapse all button followed by a series of <details> elements for all goc themes and topics."
 		},
 		{
 			"@id": "_:iteration_allservices_1",

--- a/components/_base.scss
+++ b/components/_base.scss
@@ -45,11 +45,6 @@
 	}
 }
 
-.gc-byline { // byline text for linking to institution pages
-	font-weight: 700;
-	margin-bottom: 30px;
-}
-
 /*
  * Corporate information on Institution and Organization pages
 */

--- a/components/byline/_base.scss
+++ b/components/byline/_base.scss
@@ -1,0 +1,6 @@
+/* Byline */
+
+.gc-byline {
+	font-weight: 700;
+	margin-bottom: 30px;
+}

--- a/components/byline/byline-doc-en.html
+++ b/components/byline/byline-doc-en.html
@@ -1,0 +1,9 @@
+---
+title: Institutional byline
+description: Documentation for the Institutional byline component
+language: en
+altLangPage: byline-doc-fr.html
+dateModified: 2024-12-10
+layout: documentation
+index_json: index.json-ld
+---

--- a/components/byline/byline-doc-fr.html
+++ b/components/byline/byline-doc-fr.html
@@ -1,0 +1,9 @@
+---
+title: Institution responsable
+description: Documentation pour la composante Institution responsable
+language: fr
+altLangPage: byline-doc-en.html
+dateModified: 2024-12-10
+layout: documentation
+index_json: index.json-ld
+---

--- a/components/byline/includes/byline.html
+++ b/components/byline/includes/byline.html
@@ -1,4 +1,4 @@
-<p><strong>
+<p class="gc-byline"><strong>
 {%- if page.language == "fr" -%}
 	De <a href="#">[nom de l’institution]</a>
 {%- elsif page.language == "en" -%}

--- a/components/byline/index.json-ld
+++ b/components/byline/index.json-ld
@@ -1,0 +1,204 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "Institutional byline",
+		"fr": "Institution responsable"
+	},
+	"description": {
+		"en": "The institutional byline provides people with a link to the institution or institutions responsible for the content.",
+		"fr": "La signature institutionnelle fournit aux personnes un lien vers l’institution ou les institutions responsables du contenu."
+	},
+	"modified": "2024-12-10",
+	"componentName": "byline",
+	"status": "demoted",
+	"version": "1.1.0",
+	"pages": {
+		"docs": [
+			{
+				"title": "Institutional byline",
+				"language": "en",
+				"path": "byline-doc-en.html"
+			},
+			{
+				"title": "Institution responsable",
+				"language": "fr",
+				"path": "byline-doc-fr.html"
+			}
+		]
+	},
+	"a11yGuidance": "No accessibility guidance.",
+	"variations": [
+		{
+			"name": {
+				"en": "Institutional byline - default",
+				"fr": "Institution responsable - par défaut"
+			},
+			"status": "demoted",
+			"description": {
+				"en": "The institutional byline provides people with a link to the institution or institutions responsible for the content.",
+				"fr": "La signature institutionnelle fournit aux personnes un lien vers l’institution ou les institutions responsables du contenu."
+			},
+			"iteration": "_:iteration_byline_2",
+			"example": [
+				{
+					"en": { "href": "../../templates/content-page/content-en.html", "text": "Content page (byline after the main title)" },
+					"fr": { "href": "../../templates/content-page/content-fr.html", "text": "Page de contenu (institution responsable sous le titre principal)" }
+				}
+			],
+			"implementation": [
+				"_:implement_byline"
+			],
+			"history": [
+				{
+					"en": "December 2024 - Demotion of the component - Moved to the Main title component. Use the Contributors component instead.",
+					"fr": "Décembre 2024 - Composante maintenant rétrogradée - Déplacée vers la componante Titre principal. Utilisez plutôt la composante Contributeurs."
+				},
+				{
+					"en": "April 2016 - Addition of the class <code>.gc-byline</code>.",
+					"fr": "Avril 2016 - Ajout de la classe <code>.gc-byline</code>."
+				},
+				{
+					"en": "January 2016 - Initial implementation of the component.",
+					"fr": "Janvier 2016 - Implémentation initiale pde la composante."
+				}
+			]
+		}
+	],
+	"implementation": [
+		{
+			"@id": "_:implement_byline",
+			"iteration": "_:iteration_byline_2",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the component manually.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement."
+			},
+			"instructions": {
+				"en": [
+					"Refer to the following code samples."
+				],
+				"fr": [
+					"Référez-vous au code qui suit."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Standard example:",
+						"code": "<h1>[Main title]</h1>\n<p class=\"gc-byline\">From <a href=\"#\">[Institution name]</a></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Standard example with &lt;strong&gt; element:",
+						"code": "<h1>[Main title]</h1>\n<p class=\"gc-byline\"><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Example without \"gc-byline\" class:",
+						"code": "<h1>[Main title]</h1>\n<p><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple de base :",
+						"code": "<h1>[Titre principal]</h1>\n<p class=\"gc-byline\">De <a href=\"#\">[Nom de l'institution]</a></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Exemple de base avec élément &lt;strong&gt; :",
+						"code": "<h1>[Titre principal]</h1>\n<p class=\"gc-byline\"><strong>De <a href=\"#\">[Nom de l'institution]</a></strong></p>"
+					},
+					{
+						"@type": "source-code",
+						"description": "Exemple sans la classe  « gc-byline » :",
+						"code": "<h1>[Titre principal]</h1>\n<p><strong>De <a href=\"#\">[Nom de l'institution]</a></strong></p>"
+					}
+				]
+			}
+		}
+	],
+	"iteration": [
+		{
+			"@id": "_:iteration_byline_2",
+			"name": "Institutional byline - Iteration 2",
+			"date": "2016-04",
+			"detectableBy": "h1#wb-cont+p>strong>a",
+			"addition": [
+				"Added CSS class <code>.gc-byline</code>"
+			],
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<p class=\"gc-byline\"><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+				}
+			],
+			"predecessor": "_:iteration_byline"
+		},
+		{
+			"@id": "_:iteration_byline",
+			"name": "Institutional byline - Iteration 1",
+			"date": "2016-01",
+			"detectableBy": "h1#wb-cont+p>strong>a",
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<p><strong>From <a href=\"#\">[Institution name]</a></strong></p>"
+				}
+			],
+			"successor": "_:iteration_byline_2"
+		}
+	],
+	"changesets": [
+		{
+			"@id": "_:cs_byline_2",
+			"name": "Institutional byline - version 2",
+			"status": "demoted",
+			"baseOnIteration": "_:iteration_byline_2",
+			"detectableBy": ".gc-byline",
+			"guidance": "The component must be located directly after the first <h1> of the page.",
+			"style": "The whole byline is bolded.",
+			"semantic": "p>strong>a",
+			"static": [
+				"From",
+				"De"
+			],
+			"schema": [
+				"insitution name",
+				"insitution url"
+			]
+		},
+		{
+			"@id": "_:cs_byline",
+			"name": "Institutional byline",
+			"status": "demoted",
+			"baseOnIteration": "_:iteration_byline",
+			"detectableBy": "h1#wb-cont+p>strong>a",
+			"guidance": "The component must be located directly after the first <h1> of the page.",
+			"style": "The whole byline is bolded.",
+			"semantic": "p>strong>a",
+			"static": [
+				"From",
+				"De"
+			],
+			"schema": [
+				"insitution name",
+				"insitution url"
+			]
+		}
+	]
+}

--- a/index-en.md
+++ b/index-en.md
@@ -87,6 +87,8 @@ css:
 			<dd>Relatively stable, yet experimental; use at your own risks.</dd>
 			<dt><span class="label label-danger">{{comp_status.deprecated}}</span></dt>
 			<dd>Do not use because it's deprecated, but listed here for your information.</dd>
+      <dt><span class="label label-default">{{comp_status.demoted}}</span></dt>
+			<dd>Not recommended as it's going to be deprecated in the next major version.</dd>
 			<dt><span class="label label-default">Undefined</span></dt>
 			<dd>Missing State in the component documentation.</dd>
 			<!--<dt><span class="label label-success">Up to spec</span></dt>
@@ -118,6 +120,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ component.status ] }}</span>
 				{% elsif component.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ component.status ] }}</span>
+				{% elsif component.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ component.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>Undefined</span>
 				{% endif %}
@@ -207,6 +211,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ template.status ] }}</span>
 				{% elsif template.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ template.status ] }}</span>
+				{% elsif template.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ template.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>Undefined</span>
 				{% endif %}
@@ -401,6 +407,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ item.status ] }}</span>
 				{% elsif item.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ item.status ] }}</span>
+				{% elsif item.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ item.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>Undefined</span>
 				{% endif %}
@@ -489,6 +497,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ item.status ] }}</span>
 				{% elsif item.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ item.status ] }}</span>
+				{% elsif item.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ item.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>Undefined</span>
 				{% endif %}
@@ -577,6 +587,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ wetboew.status ] }}</span>
 				{% elsif wetboew.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ wetboew.status ] }}</span>
+				{% elsif wetboew.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ wetboew.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>Undefined</span>
 				{% endif %}

--- a/index-fr.md
+++ b/index-fr.md
@@ -87,6 +87,8 @@ css:
 			<dd>Plutôt stable, mais expérimental; utilisez à vos risques et périls.</dd>
 			<dt><span class="label label-danger">{{comp_status.deprecated}}</span></dt>
 			<dd>Ne pas utilisé car c'est obsolète, mais disponible pour votre information.</dd>
+      <dt><span class="label label-default">{{comp_status.demoted}}</span></dt>
+			<dd>Utilisation non recommandée puisque ce sera obsolète à la prochaine version manjeure.</dd>
 			<dt><span class="label label-default">Défaut</span></dt>
 			<dd>Manque le statut dans la documentation de la composante.</dd>
 			<!--<dt><span class="label label-success">Conforme</span></dt>
@@ -118,6 +120,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ component.status ] }}</span>
 				{% elsif component.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ component.status ] }}</span>
+				{% elsif component.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ component.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>Non défini</span>
 				{% endif %}
@@ -207,6 +211,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ template.status ] }}</span>
 				{% elsif template.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ template.status ] }}</span>
+				{% elsif template.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ template.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>Non défini</span>
 				{% endif %}
@@ -401,6 +407,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ item.status ] }}</span>
 				{% elsif item.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ item.status ] }}</span>
+				{% elsif item.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ item.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>Non défini</span>
 				{% endif %}
@@ -489,6 +497,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ item.status ] }}</span>
 				{% elsif item.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ item.status ] }}</span>
+				{% elsif item.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>{{ comp_status[ item.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">État: </span>Non défini</span>
 				{% endif %}
@@ -577,6 +587,8 @@ css:
 				<span class="label label-warning mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ wetboew.status ] }}</span>
 				{% elsif wetboew.status == "deprecated" %}
 				<span class="label label-danger mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ wetboew.status ] }}</span>
+				{% elsif wetboew.status == "demoted" %}
+				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>{{ comp_status[ wetboew.status ] }}</span>
 				{% else %}
 				<span class="label label-default mrgn-lft-sm"><span class="wb-inv">State: </span>Undefined</span>
 				{% endif %}

--- a/sites/main-page-title/_base.scss
+++ b/sites/main-page-title/_base.scss
@@ -22,7 +22,7 @@ h1#wb-cont[dir="rtl"], hgroup#wb-cont[dir="rtl"] h1, [dir="rtl"] h1#wb-cont, [di
 hgroup#wb-cont {
 	margin-top: 1em;
 
-	p {
+	p:first-child {
 		color: #555;
 		font-size: 26px;
 		font-weight: 500;
@@ -31,5 +31,10 @@ hgroup#wb-cont {
 
 	h1 {
 		margin-top: 0;
+	}
+
+	p.gc-byline {
+		font-weight: $bold-weight;
+		margin-bottom: 30px;
 	}
 }

--- a/sites/main-page-title/includes/main-page-title.html
+++ b/sites/main-page-title/includes/main-page-title.html
@@ -1,7 +1,12 @@
-{%- if page.sectionTitle -%}
+{%- if page.sectionTitle or page.byline -%}
 <hgroup id="wb-cont">
+	{%- if page.sectionTitle -%}
 	<p>{{ page.sectionTitle }}</p>
+	{%- endif -%}
 	<h1 property="name">{{ page.title }}</h1>
+	{%- if page.byline -%}
+	<p class="gc-byline">{% if page.language == "fr" %}De&nbsp;:{% else %}From:{% endif %} <a href="{{ page.byline.url }}">{{ page.byline.institution }}</a></p>
+	{%- endif -%}
 </hgroup>
 {%- else -%}
 <h1 property="name" id="wb-cont">{{ page.title }}</h1>

--- a/sites/main-page-title/index.json-ld
+++ b/sites/main-page-title/index.json-ld
@@ -91,6 +91,16 @@
 				"title": "Titre principal superposé aligné à droite",
 				"language": "fr",
 				"path": "main-page-title-stacked-align-right-fr.html"
+			},
+			{
+				"title": "Main page title with byline for news articles",
+				"language": "en",
+				"path": "main-page-title-byline-en.html"
+			},
+			{
+				"title": "Titre principal avec institution responsable pour les articles de nouvelles",
+				"language": "fr",
+				"path": "main-page-title-byline-fr.html"
 			}
 		]
 	},
@@ -185,6 +195,38 @@
 				{
 					"en": "2024-08 - Initial implementation of the variant.",
 					"fr": "2024-01 - Implémentation initiale de la variation."
+				}
+			]
+		},
+		{
+			"name": {
+				"en": "Main page title with byline for news articles",
+				"fr": "Titre principal avec institution responsable pour les articles de nouvelles"
+			},
+			"status": "stable",
+			"description": {
+				"en": "This variation is limited to news pages. It is not permitted on any other page.",
+				"fr": "Cette variante est limitée aux pages de nouvelles. Elle n'est permise sur aucune autre page."
+			},
+			"guidance": {
+				"en": "https://design.canada.ca/common-design-patterns/institutional-byline.html",
+				"fr": "https://conception.canada.ca/configurations-conception-communes/institution-responsable.html"
+			},
+			"iteration": "_:iteration_mptb_1",
+			"example": [
+				{
+					"en": { "href": "main-page-title-byline-en.html", "text": "Main page title with byline" },
+					"fr": { "href": "main-page-title-byline-fr.html", "text": "Titre principal avec institution responsable" }
+				}
+			],
+			"implementation": [
+				"_:implement_mptb",
+				"_:implement_mptb_gcweb"
+			],
+			"history": [
+				{
+					"en": "2024-12 - Initial implementation of the variant. This component is the successor of the Institution byline component.",
+					"fr": "2024-12 - Implémentation initiale de la variation. Cette composante succède à la composante Institution responsable."
 				}
 			]
 		}
@@ -341,6 +383,78 @@
 					}
 				]
 			}
+		},
+		{
+			"@id": "_:implement_mptb",
+			"iteration": "_:iteration_mptb_1",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the component manually.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement."
+			},
+			"instructions": {
+				"en": [
+					"Refer to the following code sample."
+				],
+				"fr": [
+					"Référez-vous au code qui suit."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "HTML sample",
+						"code":	"<hgroup id=\"wb-cont\">\n\t<h1>Main page title</h1>\n\t<p class=\"gc-byline\">From: <a href=\"https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html\">Service Canada</a></p>\n</hgroup>"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple HTML",
+						"code":	"<hgroup id=\"wb-cont\">\n\t<h1>Titre principal</h1>\n\t<p class=\"gc-byline\">De&nbsp;: <a href=\"https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html\">Service Canada</a></p>\n</hgroup>"
+					}
+				]
+			}
+		},
+		{
+			"@id": "_:implement_mptb_gcweb",
+			"iteration": "_:iteration_mptb_1",
+			"name": {
+				"en": "GCWeb Jekyll",
+				"fr": "GCWeb Jekyll"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers trying to implement this component within a GCWeb Jekyll site.",
+				"fr": "Cette implémentation est destinée aux développeurs essayant d'implémenter ce composant dans un site GCWeb Jekyll."
+			},
+			"instructions": {
+				"en": [
+					"In the page's front-matter do the following:<ul><li>set the variable <code>title</code> to the main title of the page.</li><li>set the variable <code>byline</code> to an object containing the following properties:<ul><li><code>institution</code>: which contains the name of the institution</li><li><code>url</code>: which contains the URL to the institution's page</li></ul></li></ul>"
+				],
+				"fr": [
+					"Dans l'en-tête de la page faites ce qui suit&nbsp;:<ul><li>définissez la variable <code>title</code> au titre principal de la page.</li><li>définissez la variable <code>byline</code> avec un objet contenant les propriétés suivantes&nbsp;:<ul><li><code>institution</code>&nbsp;: qui contient le nom de l'institution</li><li><code>url</code>&nbsp;: qui contient l'URL de la page de l'institution</li></ul></li></ul>"
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Code sample:",
+						"code": "---\n{\n\t\"title\": \"My page title\",\n\t\"byline\": {\n\t\t\"institution\": \"Service Canada\",\n\t\t\"url\": \"https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html\"\n\t}\n}\n---"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple de code :",
+						"code": "---\n{\n\t\"title\": \"Titre de la page\",\n\t\"byline\": {\n\t\t\"institution\": \"Service Canada\",\n\t\t\"url\": \"https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html\"\n\t}\n}\n---"
+					}
+				]
+			}
 		}
 	],
 	"changesets": [
@@ -371,7 +485,7 @@
 			"@id": "_:cs_smpt",
 			"name": "Stacked main page title",
 			"baseOnIteration": "_:iteration_smpt_2",
-			"detectableBy": "hgroup > h1#wb-cont",
+			"detectableBy": "hgroup#wb-cont > p:first-child + h1",
 			"layout": "The section page title is above the page title. The line is positioned below the page title.",
 			"semantic": "hgroup > p + h1",
 			"schema": "dct:title, sectionTitle",
@@ -387,6 +501,27 @@
 			"style": "The line has a width of 3.55em (71px) and a thickness of 0.18em (3.6px) with the color #af3c43. Optionally, include a byline, tagline, or subtitle. The section page title has a font-size of 26px and has a color of #555.",
 			"guidance": "https://design.canada.ca/styles/typography.html",
 			"context": "First semantic element inside the main"
+		},
+		{
+			"@id": "_:cs_mptb",
+			"name": "Main page title with byline",
+			"baseOnIteration": "_:iteration_mptb_1",
+			"detectableBy": "hgroup#wb-cont > h1 + p:last-child",
+			"layout": "The byline is below the page title. The line is positioned between the page title and the byline.",
+			"semantic": "hgroup > h1 + p",
+			"schema": "dct:title, institutionName, institutionUrl",
+			"include": {
+				"@type": "source-code",
+				"collapsed": true,
+				"description": "Include with logic in Liquid.",
+				"code": {
+					"@type": [ "@id", "rdf:HTML" ],
+					"@value": "includes/main-page-title.html"
+				}
+			},
+			"style": "The line has a width of 3.55em (71px) and a thickness of 0.18em (3.6px) with the color #af3c43. The byline is bolded.",
+			"guidance": "https://design.canada.ca/common-design-patterns/institutional-byline.html",
+			"context": "Page context: First semantic element inside the main. Site context: limited to news pages on Canada.ca."
 		}
 	],
 	"iteration": [
@@ -434,18 +569,25 @@
 			"@id": "_:iteration_smpt_1",
 			"name": "Stacked main page title - Iteration 1",
 			"date": "2024-08",
-			"detectableBy": "hgroup > h1#wb-cont",
+			"detectableBy": "hgroup#wb-cont > h1",
 			"successor": "_:iteration_smpt_2"
 		},
 		{
 			"@id": "_:iteration_smpt_2",
 			"name": "Stacked main page title - Iteration 2 (LTR support)",
 			"date": "2024-10",
-			"detectableBy": "hgroup > h1#wb-cont[dir='ltr'], [dir='ltr'] hgroup > h1#wb-cont",
+			"detectableBy": "hgroup#wb-cont > h1[dir='ltr'], [dir='ltr'] hgroup#wb-cont > h1",
 			"additions": [
 				"Added right to left support"
 			],
 			"predecessor": "_:iteration_smpt_1"
+		},
+		{
+			"@id": "_:iteration_mptb_1",
+			"name": "Main page title with byline - Iteration 1",
+			"date": "2024-12",
+			"detectableBy": "hgroup#wb-cont > h1 + p.gc-byline",
+			"successor": "_:iteration_mptb_1"
 		}
 	]
 }

--- a/sites/main-page-title/main-page-title-byline-en.html
+++ b/sites/main-page-title/main-page-title-byline-en.html
@@ -1,0 +1,28 @@
+---
+{
+	"altLangPage": "main-page-title-byline-fr.html",
+	"dateModified": "2024-12-11",
+	"description": "Example of the main page title with byline.",
+	"language": "en",
+	"title": "Main page title with byline",
+	"byline": {
+		"institution": "Service Canada",
+		"url": "https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html"
+	},
+	"breadcrumbs": [
+		{ "title": "Main page title - Documentation", "link": "sites/main-page-title/main-page-title-en.html" }
+	]
+}
+---
+
+<section class="alert alert-warning">
+	<h2 class="h3">Context of use</h2>
+	<p>This variation is limited to news pages. It is not permitted on any other page.</p>
+</section>
+
+<p>{{ page.description }}</p>
+
+<pre class="mrgn-tp-lg"><code>&lt;hgroup id="wb-cont">
+	&lt;h1>Main page title with byline&lt;/h1>
+	&lt;p class="gc-byline">From: &lt;a href="https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html">Service Canada&lt;/a>&lt;/p>
+&lt;/hgroup></code></pre>

--- a/sites/main-page-title/main-page-title-byline-fr.html
+++ b/sites/main-page-title/main-page-title-byline-fr.html
@@ -1,0 +1,28 @@
+---
+{
+	"altLangPage": "main-page-title-byline-en.html",
+	"dateModified": "2024-12-11",
+	"description": "Exemple du titre principal superposé avec institution responsable.",
+	"language": "fr",
+	"title": "Titre principal avec institution responsable",
+	"byline": {
+		"institution": "Service Canada",
+		"url": "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html"
+	},
+	"breadcrumbs": [
+		{ "title": "Titre principal - Documentation", "link": "sites/main-page-title/main-page-title-fr.html" }
+	]
+}
+---
+
+<section class="alert alert-warning">
+	<h2 class="h3">Contexte d'utilisation</h2>
+	<p>Cette variante est limitée aux pages de nouvelles. Elle n'est permise sur aucune autre page.</p>
+</section>
+
+<p>{{ page.description }}</p>
+
+<pre class="mrgn-tp-lg"><code>&lt;hgroup id="wb-cont">
+	&lt;h1>Titre principal superposé&lt;/h1>
+	&lt;p class="gc-byline">From: &lt;a href="https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html">Service Canada&lt;/a>&lt;/p>
+&lt;/hgroup></code></pre>

--- a/sites/theme.scss
+++ b/sites/theme.scss
@@ -171,6 +171,7 @@
 @import "../components/redacted";
 @import "../components/dshbrd/base";
 @import "../components/triangle-up";
+@import "../components/byline/base";
 @import "../components/gc-contributors/base";
 @import "../components/gc-follow-us/base";
 @import "../components/gc-minister/base";


### PR DESCRIPTION
- Adding byline documentation so that it can be deprecated
- Adding "Main page title with byline" variation to the Main page title (this variation is limited to news pages on Canada.ca)

Related to WET-494