### PR TITLE
Pft pii

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -631,7 +631,7 @@
 }
 ,{
 	"@context": {
-		"@version": 2.0,
+		"@version": 2.1,
 		"dct": "http://purl.org/dc/terms/",
 		"title": { "@id": "dct:title", "@container": "@language" },
 		"description": { "@id": "dct:description", "@container": "@language" },
@@ -645,10 +645,10 @@
 		"en": "Documentation on how to use the elements of the feedback area.",
 		"fr": "Documentation sur l'utilisation des éléments de la zone commentaires."
 	},
-	"modified": "2023-01-10",
+	"modified": "2024-07-19",
 	"componentName": "feedback",
 	"status": "stable",
-	"version": "2.0",
+	"version": "2.1",
 	"pages": {
 		"docs": [
 			{
@@ -751,7 +751,7 @@
 				"en": "https://design.canada.ca/feedback/index.html",
 				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"example": [
 				{
 					"en": { "href": "page-feedback-en.html", "text": "Page feedback tool" },
@@ -765,6 +765,10 @@
 				"_:implement_pft_mws_author"
 			],
 			"history": [
+				{
+					"en": "July 2024 - AJAX fragment: Added <code>pageData</code> to the French variant, changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\".",
+					"fr": "Juillet 2024 - Fragment AJAX&nbsp;: Ajout de <code>pageData</code> à la variante française, changement de <code>aria-live=\"polite\"</code> à <code>role=\"status\"</code> dans «&nbsp;Dites nous pourquoi ci-dessous&nbsp;:&nbsp;»."
+				},
 				{
 					"en": "August 2023 - Initial implementation of the variation.",
 					"fr": "Août 2023 - Implémentation initiale de la variante."
@@ -785,7 +789,7 @@
 				"en": "https://design.canada.ca/feedback/index.html",
 				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"example": [
 				{
 					"en": { "href": "page-feedback-contact-en.html", "text": "Page feedback tool with contact link" },
@@ -995,7 +999,7 @@
 		},
 		{
 			"@id": "_:implement_pft",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "Standard (wet-boew)",
 				"fr": "Standard (wet-boew)"
@@ -1065,7 +1069,7 @@
 		},
 		{
 			"@id": "_:implement_pft_gcweb",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "GCWeb Jekyll",
 				"fr": "GCWeb Jekyll"
@@ -1103,7 +1107,7 @@
 		},
 		{
 			"@id": "_:implement_pft_upgrade_rap",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "Upgrade from RAP",
 				"fr": "Mise à jour à partir de SUP"
@@ -1125,7 +1129,7 @@
 		},
 		{
 			"@id": "_:implement_pft_mws_author",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "MWS users",
 				"fr": "Utilisateur SWG"
@@ -1151,7 +1155,7 @@
 		},
 		{
 			"@id": "_:implement_pft_contact",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "Standard (WET-BOEW)",
 				"fr": "Standard (WET-BOEW)"
@@ -1221,7 +1225,7 @@
 		},
 		{
 			"@id": "_:implement_pft_contact_gcweb",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "GCWeb Jekyll",
 				"fr": "GCWeb Jekyll"
@@ -1265,7 +1269,7 @@
 			"@id": "_:cs_pft_container",
 			"name": "Page feedback tool with AJAX",
 			"status": "stable",
-			"baseOnIteration": "_:iteration_pft_1",
+			"baseOnIteration": "_:iteration_pft_2",
 			"detectableBy": ".pagedetails .wb-disable-allow[data-ajax-replace*=feedback]",
 			"layout": [
 				"At the top-left column in the page details component",
@@ -1313,7 +1317,7 @@
 			"@id": "_:cs_pft_ajax",
 			"name": "Page feedback tool AJAX file",
 			"status": "stable",
-			"baseOnIteration": "_:iteration_pft_1",
+			"baseOnIteration": "_:iteration_pft_2",
 			"dependOnChangeSet": "_:cs_pft_container",
 			"detectableBy": "<div class=\"gc-pft\">",
 			"layout": [
@@ -1610,10 +1614,15 @@
 	],
 	"iteration": [
 		{
-			"@id": "_:iteration_pft_1",
-			"name": "Page feedback tool - Iteration 1",
-			"date": "2023-08",
-			"detectableBy": ".gc-pft",
+			"@id": "_:iteration_pft_2",
+			"name": "Page feedback tool - Iteration 1.1",
+			"date": "2024-07",
+			"detectableBy": "#gc-pft:has(.gc-pft-no p[role=\"status\"]:nth-of-type(2))",
+			"fixes": [
+				"AJAX fragment: Added <code>pageData</code> to the French variant",
+				"AJAX fragment: Changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\"."
+			],
+			"predecessor": "_:iteration_pft_1",
 			"assets": [
 				{
 					"@type": "source-code",
@@ -1655,6 +1664,56 @@
 					"code": {
 						"@type": [ "rdf:HTML", "@id" ],
 						"@value": "assets/page-feedback-fr.html"
+					}
+				}
+			]
+		},
+		{
+			"@id": "_:iteration_pft_1",
+			"name": "Page feedback tool - Iteration 1",
+			"date": "2023-08",
+			"detectableBy": "#gc-pft",
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/deprecated/page-feedback-v1-en.html\" \ndata-feedback-section=\"[Text defining the theme of your page]\" \ndata-feedback-theme=\"[Text defining the section where your page resides]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample with contact link",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/deprecated/page-feedback-v1-en.html\" \ndata-feedback-section=\"[Text defining the theme of your page]\" \ndata-feedback-theme=\"[Text defining the section where your page resides]\"\ndata-feedback-link=\"[Contact link text]\"\ndata-feedback-url=\"[Contact link URL]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Ajaxed-in content",
+					"code": {
+						"@type": [ "rdf:HTML", "@id" ],
+						"@value": "assets/deprecated/page-feedback-v1-en.html"
+					}
+				},
+				{
+					"@type": "source-code",
+					"@language": "fr",
+					"description": "Exemple de code",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/page-feedback-fr.html\" \ndata-feedback-section=\"[Texte définissant le thème de votre page]\" \ndata-feedback-theme=\"[Texte définissant la section où réside votre page]\"\ndata-feedback-link=\"[Texte du lien de contact]\"\ndata-feedback-url=\"[URL du lien de contact]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "fr",
+					"description": "Exemple de code avec lien de contact",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/page-feedback-fr.html\" \ndata-feedback-section=\"[Texte définissant le thème de votre page]\" \ndata-feedback-theme=\"[Texte définissant la section où réside votre page]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "fr",
+					"description": "Contenu ajouté via Ajax",
+					"code": {
+						"@type": [ "rdf:HTML", "@id" ],
+						"@value": "assets/deprecated/page-feedback-v1-fr.html"
 					}
 				}
 			]

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -645,10 +645,10 @@
 		"en": "Documentation on how to use the elements of the feedback area.",
 		"fr": "Documentation sur l'utilisation des éléments de la zone commentaires."
 	},
-	"modified": "2024-07-19",
+	"modified": "2025-01-09",
 	"componentName": "feedback",
 	"status": "stable",
-	"version": "2.1",
+	"version": "2.0.1",
 	"pages": {
 		"docs": [
 			{
@@ -729,10 +729,20 @@
 	},
 	"dependencies": {
 		"en": [
-			{ "title": "Page details", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-en.html", "component": "page-details" }
+			{ "title": "Page details", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-en.html", "component": "page-details" },
+			{ "title": "Postback", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-postback/wb-postback-en.html", "component": "postback" },
+			{ "title": "PII Scrub", "url": "https://wet-boew.github.io/wet-boew/docs/ref/pii-postback/pii-scrub-en.html", "component": "pii-scrub" },
+			{ "title": "Data JSON", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-data-json/wb-data-json-en.html", "component": "wb-data-json" },
+			{ "title": "JSON Manager", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-jsonmanager/wb-jsonmanager-en.html", "component": "wb-json-manager" },
+			{ "title": "Do Action", "url": "https://wet-boew.github.io/GCWeb/components/wb-doaction/doaction-doc-en.html", "component": "doaction" }
 		],
 		"fr": [
-			{ "title": "Détails de la page", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-fr.html", "component": "page-details" }
+			{ "title": "Détails de la page", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-fr.html", "component": "page-details" },
+			{ "title": "Envoie de formulaire via Ajax", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-postback/wb-postback-fr.html", "component": "postback" },
+			{ "title": "Nettoyage d'IPI", "url": "https://wet-boew.github.io/wet-boew/docs/ref/pii-postback/pii-scrub-fr.html", "component": "pii-scrub" },
+			{ "title": "Data JSON", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-data-json/wb-data-json-fr.html", "component": "wb-data-json" },
+			{ "title": "Gestionnaire JSON", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.html", "component": "wb-json-manager" },
+			{ "title": "Do Action", "url": "https://wet-boew.github.io/GCWeb/components/wb-doaction/doaction-doc-fr.html", "component": "doaction" }
 		]
 	},
 	"a11yGuidance": "no accessibility guidance",
@@ -1024,10 +1034,12 @@
 			},
 			"notes": {
 				"en": [
+					"In order for your PFT to benefit from the personal information screening tool, you have to make sure your version of WET-BOEW is at 4.0.84 or higher.",
 					"To upgrade from the RAP to the PFT, follow the instructions of the \"Upgrade from RAP\" tab.",
 					"For more information about Data Ajax plugin, please visit <a href=\"https://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-en.html\">Data Ajax documentation page</a>."
 				],
 				"fr": [
+					"Pour que votre ORP puisse bénéficier de l'outil de filtrage des informations personnelles, vous devez vous assurer que votre version de WET-BOEW est supérieure ou égalse à 4.0.84.",
 					"Pour passer du SUP au ORP, suivez les instructions de l'onglet \"Mise à jour à partir de SUP\".",
 					"Pour plus d'informations sur le plugin Data Ajax, veuillez visiter la <a href=\"https://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-fr.html\">page de documentation Data Ajax</a>."
 				]
@@ -1615,12 +1627,13 @@
 	"iteration": [
 		{
 			"@id": "_:iteration_pft_2",
-			"name": "Page feedback tool - Iteration 1.1",
-			"date": "2024-07",
+			"name": "Page feedback tool - Iteration 2",
+			"date": "2025-01",
 			"detectableBy": "#gc-pft:has(.gc-pft-no p[role=\"status\"]:nth-of-type(2))",
 			"fixes": [
 				"AJAX fragment: Added <code>pageData</code> to the French variant",
-				"AJAX fragment: Changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\"."
+				"AJAX fragment: Changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\".",
+				"AJAX fragment: Added PII scrub of the comment field."
 			],
 			"predecessor": "_:iteration_pft_1",
 			"assets": [

--- a/_data/templates.json
+++ b/_data/templates.json
@@ -1486,6 +1486,18 @@
 				"language": "fr",
 				"path": "topic-doc-fr.html"
 			}
+		],
+		"reports": [
+			{
+				"title": "Accessibility assessment #1 - GC topic template",
+				"language": "en",
+				"path": "reports/a11y-1-en.html"
+			},
+			{
+				"title": "Évaluation d'accessibilité #1 - Gabarits de page de sujet GC",
+				"language": "fr",
+				"path": "reports/a11y-1-fr.html"
+			}
 		]
 	},
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "3.4.1",
-        "wet-boew": "github:wet-boew/wet-boew#v4.0.83"
+        "wet-boew": "github:garneauma/wet-boew#wb-data-scrub"
       },
       "devDependencies": {
         "@lodder/grunt-postcss": "^3.0.1",
@@ -13537,7 +13537,7 @@
     },
     "node_modules/wet-boew": {
       "version": "4.0.83",
-      "resolved": "git+ssh://git@github.com/wet-boew/wet-boew.git#996ffd12786dcfe881f6064996fd8bcfdaa8b921",
+      "resolved": "git+ssh://git@github.com/garneauma/wet-boew.git#ea65ca174216af92e8d9c10e55d1cfc3b544de34",
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap-sass": "3.4.1",
-    "wet-boew": "github:wet-boew/wet-boew#v4.0.83"
+    "wet-boew": "github:garneauma/wet-boew#wb-data-scrub"
   },
   "browserslist": [
     "last 2 versions",

--- a/sites/feedback/assets/deprecated/page-feedback-v1-en.html
+++ b/sites/feedback/assets/deprecated/page-feedback-v1-en.html
@@ -14,7 +14,7 @@
 }'>
 	<div class="col-sm-10 col-md-9 col-lg-8">
 		<section class="well mrgn-bttm-0">
-			<h3 class="wb-inv">Donnez votre rétroaction sur cette page</h3>
+			<h3 class="wb-inv">Give feedback about this page</h3>
 			<form action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post" class="wb-postback wb-disable-allow" data-wb-postback='{"success":".gc-pft-thnk"}'>
 				<div class="wb-disable-allow" data-wb-json='{
 					"url": "#[gc-pft]/pageData",
@@ -28,21 +28,21 @@
 					</template>
 				</div>
 				<fieldset class="gc-pft-btns chkbxrdio-grp row row-no-gutters d-sm-flex flex-sm-wrap align-items-sm-center">
-					<legend class="col-xs-12 col-sm-7 nojs-col-sm-12 col-md-9 col-lg-8 text-center text-sm-left nojs-text-left mrgn-tp-sm pr-sm-3"><span class="field-name">Avez-vous trouvé ce que vous cherchiez?</span></legend>
+					<legend class="col-xs-12 col-sm-7 nojs-col-sm-12 col-md-9 col-lg-8 text-center text-sm-left nojs-text-left mrgn-tp-sm pr-sm-3"><span class="field-name">Did you find what you were looking for?</span></legend>
 					<div class="col-xs-12 nojs-show">
-						<button name="helpful" value="Yes-Oui" class="btn btn-primary" aria-describedby="gc-pft-why">Oui</button>
+						<button name="helpful" value="Yes-Oui" class="btn btn-primary" aria-describedby="gc-pft-why">Yes</button>
 					</div>
 					<div class="col-xs-12 col-sm-5 col-md-3 col-lg-4 text-center text-sm-right nojs-hide">
-						<button name="helpful" value="Yes-Oui" class="btn btn-primary">Oui</button>
+						<button name="helpful" value="Yes-Oui" class="btn btn-primary">Yes</button>
 						<button class="btn btn-primary mrgn-lft-sm" data-wb-doaction='[
 							{"action":"removeClass","source":".gc-pft-no","class":"nojs-show"},
 							{"action":"addClass","source":".gc-pft-btns","class":"hide"}
-						]'>Non</button>
+						]'>No</button>
 					</div>
 				</fieldset>
 				<div class="gc-pft-no nojs-show">
-					<p id="gc-pft-why" class="nojs-show mrgn-tp-lg mrgn-bttm-md">Sinon, dites nous pourquoi ci-dessous&nbsp;:</p>
-					<p class="nojs-hide wb-inv" role="status">Dites nous pourquoi ci-dessous&nbsp;:</p>
+					<p id="gc-pft-why" class="nojs-show mrgn-tp-lg mrgn-bttm-md">If not, tell us why below:</p>
+					<p class="nojs-hide wb-inv" aria-live="polite">Tell us why below:</p>
 					<div class="wb-disable-allow"  data-wb-json='{
 						"url": "#[gc-pft]/contact",
 						"streamline": "true",
@@ -60,7 +60,7 @@
 					}'>
 						<template data-contact-template>
 							<details>
-								<summary>Besoin d’aide urgente pour résoudre un problème? Communiquez avec nous</summary>
+								<summary>Need urgent help with a problem? Contact us</summary>
 								<p class="mrgn-bttm-0 mrgn-tp-md fnt-nrml">
 									<a href="#"></a>
 								</p>
@@ -68,16 +68,16 @@
 						</template>
 					</div>
 					<div class="form-group">
-						<label for="gc-pft-prblm" class="mrgn-bttm-0"><span class="field-name">Veuillez fournir plus de détails</span></label>
-						<p id="gc-pft-prblm-note" class="mrgn-bttm-sm"><small>Vous ne recevrez pas de réponse. N'incluez pas de renseignements personnels (téléphone, courriel, NAS, renseignements financiers, médicaux ou professionnels).</small></p>
-						<p id="gc-pft-prblm-instruction" class="fnt-nrml small">Maximum de 300 caractères</p>
+						<label id="gc-pft-prblm-label" for="gc-pft-prblm" class="mrgn-bttm-0"><span class="field-name">Please provide more details</span></label>
+						<p id="gc-pft-prblm-note" class="mrgn-bttm-sm"><small>You will not receive a reply. Don't include personal information (telephone, email, SIN, financial, medical, or work details).</small></p>
+						<p id="gc-pft-prblm-instruction" class="fnt-nrml small">Maximum 300 characters</p>
 						<textarea id="gc-pft-prblm" aria-describedby="gc-pft-prblm-note gc-pft-prblm-instruction" name="details" class="form-control full-width" maxlength="300"></textarea>
 					</div>
-					<button name="helpful" value="No-Non" class="btn btn-primary">Soumettre</button>
+					<button name="helpful" value="No-Non" class="btn btn-primary">Submit</button>
 				</div>
 			</form>
 			<div class="gc-pft-thnk hide">
-				<p class="mrgn-tp-sm mrgn-bttm-0" role="status"><span class="glyphicon glyphicon-ok text-success mrgn-rght-sm" aria-hidden="true"></span> Merci de vos commentaires.</p>
+				<p class="mrgn-tp-sm mrgn-bttm-0" role="status"><span class="glyphicon glyphicon-ok text-success mrgn-rght-sm" aria-hidden="true"></span> Thank you for your feedback.</p>
 			</div>
 		</section>
 	</div>

--- a/sites/feedback/assets/deprecated/page-feedback-v1-fr.html
+++ b/sites/feedback/assets/deprecated/page-feedback-v1-fr.html
@@ -1,13 +1,13 @@
 <div id="gc-pft" class="row wb-disable-allow" data-wb-jsonmanager='{
 	"name": "gc-pft",
 	"extractor": [
-		{ "selector": "title", "path": "pageData/pageTitle" },
-		{ "selector": "html", "attr": "lang", "path": "pageData/language" },
-		{ "interface": "locationHref", "path": "pageData/submissionPage" },
-		{ "selector": "#wb-lng ul li:first-child a[lang]", "attr": "href", "path": "pageData/oppositelang" },
-		{ "selector": "[data-feedback-theme]", "attr": "data-feedback-theme", "path": "pageData/themeopt" },
-		{ "selector": "[data-feedback-section]", "attr": "data-feedback-section", "path": "pageData/sectionopt" },
-		{ "selector": "meta[name=\"dcterms.creator\"]", "attr": "content", "path": "pageData/institutionopt" },
+		{ "selector": "title", "path": "pageTitle" },
+		{ "selector": "html", "attr": "lang", "path": "language" },
+		{ "interface": "locationHref", "path": "submissionPage" },
+		{ "selector": "#wb-lng ul li:first-child a[lang]", "attr": "href", "path": "oppositelang" },
+		{ "selector": "[data-feedback-theme]", "attr": "data-feedback-theme", "path": "themeopt" },
+		{ "selector": "[data-feedback-section]", "attr": "data-feedback-section", "path": "sectionopt" },
+		{ "selector": "meta[name=\"dcterms.creator\"]", "attr": "content", "path": "institutionopt" },
 		{ "selector": "[data-feedback-link]", "attr": "data-feedback-link", "path": "contact/link" },
 		{ "selector": "[data-feedback-url]", "attr": "data-feedback-url", "path": "contact/url" }
 	]
@@ -17,7 +17,7 @@
 			<h3 class="wb-inv">Donnez votre rétroaction sur cette page</h3>
 			<form action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post" class="wb-postback wb-disable-allow" data-wb-postback='{"success":".gc-pft-thnk"}'>
 				<div class="wb-disable-allow" data-wb-json='{
-					"url": "#[gc-pft]/pageData",
+					"url": "#[gc-pft]",
 					"mapping": [
 						{ "selector": "input", "attr": "name", "value": "/@id" },
 						{ "selector": "input", "attr": "value", "value": "/@value" }
@@ -42,7 +42,7 @@
 				</fieldset>
 				<div class="gc-pft-no nojs-show">
 					<p id="gc-pft-why" class="nojs-show mrgn-tp-lg mrgn-bttm-md">Sinon, dites nous pourquoi ci-dessous&nbsp;:</p>
-					<p class="nojs-hide wb-inv" role="status">Dites nous pourquoi ci-dessous&nbsp;:</p>
+					<p class="nojs-hide wb-inv" aria-live="polite">Dites nous pourquoi ci-dessous&nbsp;:</p>
 					<div class="wb-disable-allow"  data-wb-json='{
 						"url": "#[gc-pft]/contact",
 						"streamline": "true",

--- a/sites/feedback/assets/page-feedback-en.html
+++ b/sites/feedback/assets/page-feedback-en.html
@@ -42,7 +42,7 @@
 				</fieldset>
 				<div class="gc-pft-no nojs-show">
 					<p id="gc-pft-why" class="nojs-show mrgn-tp-lg mrgn-bttm-md">If not, tell us why below:</p>
-					<p class="nojs-hide wb-inv" aria-live="polite">Tell us why below:</p>
+					<p class="nojs-hide wb-inv" role="status">Tell us why below:</p>
 					<div class="wb-disable-allow"  data-wb-json='{
 						"url": "#[gc-pft]/contact",
 						"streamline": "true",

--- a/sites/feedback/assets/page-feedback-en.html
+++ b/sites/feedback/assets/page-feedback-en.html
@@ -15,7 +15,35 @@
 	<div class="col-sm-10 col-md-9 col-lg-8">
 		<section class="well mrgn-bttm-0">
 			<h3 class="wb-inv">Give feedback about this page</h3>
-			<form action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post" class="wb-postback wb-disable-allow" data-wb-postback='{"success":".gc-pft-thnk"}'>
+			<form action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post" class="wb-postback wb-disable-allow wb-pii-scrub" data-wb-postback='{"success":".gc-pft-thnk"}' data-wb-pii-scrub='{"modalTemplate": "[data-pft-scrub-modal]", "scrubChar": "########"}'>
+				<template data-pft-scrub-modal>
+					<header class="modal-header">
+						<h2 class="modal-title">Personal information in your comment has been removed</h2>
+					</header>
+					<div class="modal-body">
+						<p>Comments are only used to improve our website. You will not receive a response.</p>
+						<p><strong>To protect your privacy, your comment will be submitted as:</strong></p>
+						<div data-scrub-modal-fields=""></div>
+						<details class="mrgn-tp-md">
+							<summary>What is considered personal information?</summary>
+							<p>Certain types of information <strong>can’t</strong> be included in this comment form, such as your:</p>
+							<ul>
+								<li>email address</li>
+								<li>telephone number</li>
+								<li>postal code</li>
+								<li>passport number</li>
+								<li>business number</li>
+								<li>social insurance number (SIN)</li>
+							</ul>
+						</details>
+					</div>
+					<div class="modal-footer">
+						<div class="row">
+							<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">Go back and edit comment</button></div>
+							<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit="">Submit comment</button></div>
+						</div>
+					</div>
+				</template>
 				<div class="wb-disable-allow" data-wb-json='{
 					"url": "#[gc-pft]/pageData",
 					"mapping": [
@@ -71,7 +99,7 @@
 						<label id="gc-pft-prblm-label" for="gc-pft-prblm" class="mrgn-bttm-0"><span class="field-name">Please provide more details</span></label>
 						<p id="gc-pft-prblm-note" class="mrgn-bttm-sm"><small>You will not receive a reply. Don't include personal information (telephone, email, SIN, financial, medical, or work details).</small></p>
 						<p id="gc-pft-prblm-instruction" class="fnt-nrml small">Maximum 300 characters</p>
-						<textarea id="gc-pft-prblm" aria-describedby="gc-pft-prblm-note gc-pft-prblm-instruction" name="details" class="form-control full-width" maxlength="300"></textarea>
+						<textarea id="gc-pft-prblm" aria-describedby="gc-pft-prblm-note gc-pft-prblm-instruction" name="details" class="form-control full-width" maxlength="300" data-scrub-field></textarea>
 					</div>
 					<button name="helpful" value="No-Non" class="btn btn-primary">Submit</button>
 				</div>

--- a/sites/feedback/assets/page-feedback-fr.html
+++ b/sites/feedback/assets/page-feedback-fr.html
@@ -15,7 +15,35 @@
 	<div class="col-sm-10 col-md-9 col-lg-8">
 		<section class="well mrgn-bttm-0">
 			<h3 class="wb-inv">Donnez votre rétroaction sur cette page</h3>
-			<form action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post" class="wb-postback wb-disable-allow" data-wb-postback='{"success":".gc-pft-thnk"}'>
+			<form action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post" class="wb-postback wb-disable-allow wb-pii-scrub" data-wb-postback='{"success":".gc-pft-thnk"}' data-wb-pii-scrub='{"modalTemplate": "[data-pft-scrub-modal]", "scrubChar": "########"}'>
+				<template data-pft-scrub-modal>
+					<header class="modal-header">
+						<h2 class="modal-title">Les renseignements personnels dans votre commentaire ont été supprimés</h2>
+					</header>
+					<div class="modal-body">
+						<p>Les commentaires ne servent qu’à améliorer notre site Web. Vous ne recevrez aucune réponse.</p>
+						<p><strong>Afin de veiller à la protection de vos renseignements personnels, votre commentaire sera soumis comme suit&nbsp;:</strong></p>
+						<div data-scrub-modal-fields=""></div>
+						<details class="mrgn-tp-md">
+							<summary>Qu'est-ce qui est considéré comme un renseignement personnel?</summary>
+							<p>Certains renseignements <strong>ne peuvent pas</strong> être inclus dans ce formulaire de commentaire, notamment :</p>
+							<ul>
+								<li>Adresse courriel</li>
+								<li>Numéro de téléphone</li>
+								<li>Code postal</li>
+								<li>Numéro de passeport</li>
+								<li>Numéro d’entreprise</li>
+								<li>Numéro d’assurance sociale (NAS)</li>
+							</ul>
+						</details>
+					</div>
+					<div class="modal-footer">
+						<div class="row">
+							<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">Revenir en arrière et modifier le commentaire</button></div>
+							<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit="">Soumettre le commentaire</button></div>
+						</div>
+					</div>
+				</template>
 				<div class="wb-disable-allow" data-wb-json='{
 					"url": "#[gc-pft]/pageData",
 					"mapping": [
@@ -71,7 +99,7 @@
 						<label for="gc-pft-prblm" class="mrgn-bttm-0"><span class="field-name">Veuillez fournir plus de détails</span></label>
 						<p id="gc-pft-prblm-note" class="mrgn-bttm-sm"><small>Vous ne recevrez pas de réponse. N'incluez pas de renseignements personnels (téléphone, courriel, NAS, renseignements financiers, médicaux ou professionnels).</small></p>
 						<p id="gc-pft-prblm-instruction" class="fnt-nrml small">Maximum de 300 caractères</p>
-						<textarea id="gc-pft-prblm" aria-describedby="gc-pft-prblm-note gc-pft-prblm-instruction" name="details" class="form-control full-width" maxlength="300"></textarea>
+						<textarea id="gc-pft-prblm" aria-describedby="gc-pft-prblm-note gc-pft-prblm-instruction" name="details" class="form-control full-width" maxlength="300" data-scrub-field></textarea>
 					</div>
 					<button name="helpful" value="No-Non" class="btn btn-primary">Soumettre</button>
 				</div>

--- a/sites/feedback/feedback-docs-en.html
+++ b/sites/feedback/feedback-docs-en.html
@@ -4,7 +4,7 @@
 	"title_section": "GCWeb (the Canada.ca theme in WET)",
 	"language": "en",
 	"altLangPage": "feedback-docs-fr.html",
-	"dateModified": "2023-11-08",
+	"dateModified": "2025-01-09",
 	"layout": "documentation",
 	"index_json": "index.json-ld",
 	"before_start_ajax_url": "dto-guidance-en.html #beforeYouBegin"

--- a/sites/feedback/feedback-docs-fr.html
+++ b/sites/feedback/feedback-docs-fr.html
@@ -4,7 +4,7 @@
 	"title_section": "GCWeb (le thème de Canada.ca dans la BOEW)",
 	"language": "fr",
 	"altLangPage": "feedback-docs-en.html",
-	"dateModified": "2023-11-08",
+	"dateModified": "2025-01-09",
 	"layout": "documentation",
 	"index_json": "index.json-ld",
 	"before_start_ajax_url": "dto-guidance-fr.html #beforeYouBegin"

--- a/sites/feedback/index.json-ld
+++ b/sites/feedback/index.json-ld
@@ -14,10 +14,10 @@
 		"en": "Documentation on how to use the elements of the feedback area.",
 		"fr": "Documentation sur l'utilisation des éléments de la zone commentaires."
 	},
-	"modified": "2024-07-19",
+	"modified": "2025-01-09",
 	"componentName": "feedback",
 	"status": "stable",
-	"version": "2.1",
+	"version": "2.0.1",
 	"pages": {
 		"docs": [
 			{
@@ -98,10 +98,20 @@
 	},
 	"dependencies": {
 		"en": [
-			{ "title": "Page details", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-en.html", "component": "page-details" }
+			{ "title": "Page details", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-en.html", "component": "page-details" },
+			{ "title": "Postback", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-postback/wb-postback-en.html", "component": "postback" },
+			{ "title": "PII Scrub", "url": "https://wet-boew.github.io/wet-boew/docs/ref/pii-postback/pii-scrub-en.html", "component": "pii-scrub" },
+			{ "title": "Data JSON", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-data-json/wb-data-json-en.html", "component": "wb-data-json" },
+			{ "title": "JSON Manager", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-jsonmanager/wb-jsonmanager-en.html", "component": "wb-json-manager" },
+			{ "title": "Do Action", "url": "https://wet-boew.github.io/GCWeb/components/wb-doaction/doaction-doc-en.html", "component": "doaction" }
 		],
 		"fr": [
-			{ "title": "Détails de la page", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-fr.html", "component": "page-details" }
+			{ "title": "Détails de la page", "url": "https://wet-boew.github.io/GCWeb/sites/page-details/page-details-docs-fr.html", "component": "page-details" },
+			{ "title": "Envoie de formulaire via Ajax", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-postback/wb-postback-fr.html", "component": "postback" },
+			{ "title": "Nettoyage d'IPI", "url": "https://wet-boew.github.io/wet-boew/docs/ref/pii-postback/pii-scrub-fr.html", "component": "pii-scrub" },
+			{ "title": "Data JSON", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-data-json/wb-data-json-fr.html", "component": "wb-data-json" },
+			{ "title": "Gestionnaire JSON", "url": "https://wet-boew.github.io/wet-boew/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.html", "component": "wb-json-manager" },
+			{ "title": "Do Action", "url": "https://wet-boew.github.io/GCWeb/components/wb-doaction/doaction-doc-fr.html", "component": "doaction" }
 		]
 	},
 	"a11yGuidance": "no accessibility guidance",
@@ -393,10 +403,12 @@
 			},
 			"notes": {
 				"en": [
+					"In order for your PFT to benefit from the personal information screening tool, you have to make sure your version of WET-BOEW is at 4.0.84 or higher.",
 					"To upgrade from the RAP to the PFT, follow the instructions of the \"Upgrade from RAP\" tab.",
 					"For more information about Data Ajax plugin, please visit <a href=\"https://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-en.html\">Data Ajax documentation page</a>."
 				],
 				"fr": [
+					"Pour que votre ORP puisse bénéficier de l'outil de filtrage des informations personnelles, vous devez vous assurer que votre version de WET-BOEW est supérieure ou égalse à 4.0.84.",
 					"Pour passer du SUP au ORP, suivez les instructions de l'onglet \"Mise à jour à partir de SUP\".",
 					"Pour plus d'informations sur le plugin Data Ajax, veuillez visiter la <a href=\"https://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-fr.html\">page de documentation Data Ajax</a>."
 				]
@@ -984,12 +996,13 @@
 	"iteration": [
 		{
 			"@id": "_:iteration_pft_2",
-			"name": "Page feedback tool - Iteration 1.1",
-			"date": "2024-07",
+			"name": "Page feedback tool - Iteration 2",
+			"date": "2025-01",
 			"detectableBy": "#gc-pft:has(.gc-pft-no p[role=\"status\"]:nth-of-type(2))",
 			"fixes": [
 				"AJAX fragment: Added <code>pageData</code> to the French variant",
-				"AJAX fragment: Changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\"."
+				"AJAX fragment: Changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\".",
+				"AJAX fragment: Added PII scrub of the comment field."
 			],
 			"predecessor": "_:iteration_pft_1",
 			"assets": [

--- a/sites/feedback/index.json-ld
+++ b/sites/feedback/index.json-ld
@@ -1,6 +1,6 @@
 {
 	"@context": {
-		"@version": 2.0,
+		"@version": 2.1,
 		"dct": "http://purl.org/dc/terms/",
 		"title": { "@id": "dct:title", "@container": "@language" },
 		"description": { "@id": "dct:description", "@container": "@language" },
@@ -14,10 +14,10 @@
 		"en": "Documentation on how to use the elements of the feedback area.",
 		"fr": "Documentation sur l'utilisation des éléments de la zone commentaires."
 	},
-	"modified": "2023-01-10",
+	"modified": "2024-07-19",
 	"componentName": "feedback",
 	"status": "stable",
-	"version": "2.0",
+	"version": "2.1",
 	"pages": {
 		"docs": [
 			{
@@ -120,7 +120,7 @@
 				"en": "https://design.canada.ca/feedback/index.html",
 				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"example": [
 				{
 					"en": { "href": "page-feedback-en.html", "text": "Page feedback tool" },
@@ -134,6 +134,10 @@
 				"_:implement_pft_mws_author"
 			],
 			"history": [
+				{
+					"en": "July 2024 - AJAX fragment: Added <code>pageData</code> to the French variant, changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\".",
+					"fr": "Juillet 2024 - Fragment AJAX&nbsp;: Ajout de <code>pageData</code> à la variante française, changement de <code>aria-live=\"polite\"</code> à <code>role=\"status\"</code> dans «&nbsp;Dites nous pourquoi ci-dessous&nbsp;:&nbsp;»."
+				},
 				{
 					"en": "August 2023 - Initial implementation of the variation.",
 					"fr": "Août 2023 - Implémentation initiale de la variante."
@@ -154,7 +158,7 @@
 				"en": "https://design.canada.ca/feedback/index.html",
 				"fr": "https://conception.canada.ca/retroaction/index.html"
 			},
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"example": [
 				{
 					"en": { "href": "page-feedback-contact-en.html", "text": "Page feedback tool with contact link" },
@@ -364,7 +368,7 @@
 		},
 		{
 			"@id": "_:implement_pft",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "Standard (wet-boew)",
 				"fr": "Standard (wet-boew)"
@@ -434,7 +438,7 @@
 		},
 		{
 			"@id": "_:implement_pft_gcweb",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "GCWeb Jekyll",
 				"fr": "GCWeb Jekyll"
@@ -472,7 +476,7 @@
 		},
 		{
 			"@id": "_:implement_pft_upgrade_rap",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "Upgrade from RAP",
 				"fr": "Mise à jour à partir de SUP"
@@ -494,7 +498,7 @@
 		},
 		{
 			"@id": "_:implement_pft_mws_author",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "MWS users",
 				"fr": "Utilisateur SWG"
@@ -520,7 +524,7 @@
 		},
 		{
 			"@id": "_:implement_pft_contact",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "Standard (WET-BOEW)",
 				"fr": "Standard (WET-BOEW)"
@@ -590,7 +594,7 @@
 		},
 		{
 			"@id": "_:implement_pft_contact_gcweb",
-			"iteration": "_:iteration_pft_1",
+			"iteration": "_:iteration_pft_2",
 			"name": {
 				"en": "GCWeb Jekyll",
 				"fr": "GCWeb Jekyll"
@@ -634,7 +638,7 @@
 			"@id": "_:cs_pft_container",
 			"name": "Page feedback tool with AJAX",
 			"status": "stable",
-			"baseOnIteration": "_:iteration_pft_1",
+			"baseOnIteration": "_:iteration_pft_2",
 			"detectableBy": ".pagedetails .wb-disable-allow[data-ajax-replace*=feedback]",
 			"layout": [
 				"At the top-left column in the page details component",
@@ -682,7 +686,7 @@
 			"@id": "_:cs_pft_ajax",
 			"name": "Page feedback tool AJAX file",
 			"status": "stable",
-			"baseOnIteration": "_:iteration_pft_1",
+			"baseOnIteration": "_:iteration_pft_2",
 			"dependOnChangeSet": "_:cs_pft_container",
 			"detectableBy": "<div class=\"gc-pft\">",
 			"layout": [
@@ -979,10 +983,15 @@
 	],
 	"iteration": [
 		{
-			"@id": "_:iteration_pft_1",
-			"name": "Page feedback tool - Iteration 1",
-			"date": "2023-08",
-			"detectableBy": ".gc-pft",
+			"@id": "_:iteration_pft_2",
+			"name": "Page feedback tool - Iteration 1.1",
+			"date": "2024-07",
+			"detectableBy": "#gc-pft:has(.gc-pft-no p[role=\"status\"]:nth-of-type(2))",
+			"fixes": [
+				"AJAX fragment: Added <code>pageData</code> to the French variant",
+				"AJAX fragment: Changed <code>aria-live=\"polite\"</code> to <code>role=\"status\"</code> in \"Tell us why below:\"."
+			],
+			"predecessor": "_:iteration_pft_1",
 			"assets": [
 				{
 					"@type": "source-code",
@@ -1024,6 +1033,56 @@
 					"code": {
 						"@type": [ "rdf:HTML", "@id" ],
 						"@value": "assets/page-feedback-fr.html"
+					}
+				}
+			]
+		},
+		{
+			"@id": "_:iteration_pft_1",
+			"name": "Page feedback tool - Iteration 1",
+			"date": "2023-08",
+			"detectableBy": "#gc-pft",
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/deprecated/page-feedback-v1-en.html\" \ndata-feedback-section=\"[Text defining the theme of your page]\" \ndata-feedback-theme=\"[Text defining the section where your page resides]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample with contact link",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/deprecated/page-feedback-v1-en.html\" \ndata-feedback-section=\"[Text defining the theme of your page]\" \ndata-feedback-theme=\"[Text defining the section where your page resides]\"\ndata-feedback-link=\"[Contact link text]\"\ndata-feedback-url=\"[Contact link URL]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Ajaxed-in content",
+					"code": {
+						"@type": [ "rdf:HTML", "@id" ],
+						"@value": "assets/deprecated/page-feedback-v1-en.html"
+					}
+				},
+				{
+					"@type": "source-code",
+					"@language": "fr",
+					"description": "Exemple de code",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/page-feedback-fr.html\" \ndata-feedback-section=\"[Texte définissant le thème de votre page]\" \ndata-feedback-theme=\"[Texte définissant la section où réside votre page]\"\ndata-feedback-link=\"[Texte du lien de contact]\"\ndata-feedback-url=\"[URL du lien de contact]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "fr",
+					"description": "Exemple de code avec lien de contact",
+					"code": "<div class=\"wb-disable-allow\" \ndata-ajax-replace=\"assets/page-feedback-fr.html\" \ndata-feedback-section=\"[Texte définissant le thème de votre page]\" \ndata-feedback-theme=\"[Texte définissant la section où réside votre page]\"></div>"
+				},
+				{
+					"@type": "source-code",
+					"@language": "fr",
+					"description": "Contenu ajouté via Ajax",
+					"code": {
+						"@type": [ "rdf:HTML", "@id" ],
+						"@value": "assets/deprecated/page-feedback-v1-fr.html"
 					}
 				}
 			]


### PR DESCRIPTION
This pull request does the following:

### 1 - Polish AJAX fragments (from @EricDunsworth) 
The AJAX fragments had two minor flaws:
- The English fragment contained pageData references that were missing from the French variant. That difference caused a hidden input named "contact" (with a JSON string as its value) to be injected into French feedback widgets. Although it didn't cause any other issues (data-feedback-link and data-feedback-url still worked fine in practice).
- The no button's invisible transition message in JS mode is technically a status message, but wasn't coded as such (was using aria-live="polite" as opposed to role="status").

This resolves the flaws by:
- Adding pageData references throughout the French fragment (same spots as English) to eliminate the hidden "contact" input.
- Replacing aria-live="polite" with role="status" in the no button's transition message:
  - role="status" is a more formal way of denoting status messages, implicitly sets aria-live="polite" + aria-atomic="true" and is already in use for the widget's thank you message.

### 2 - Adds PII Scrub to the PFT
The Page feedback tool now has personal information screening added to the comment field on submit.

Changes related to WET-509