### PR TITLE
Theme: Break words in paragraphs and headings only

### DIFF
--- a/sites/baseline/_scaffolding.scss
+++ b/sites/baseline/_scaffolding.scss
@@ -21,14 +21,8 @@ main {
 	font-size: 20px;
 	line-height: 1.65em;
 
-	* {
+	h1, h2, h3, h4, h5, h6, p {
 		word-break: break-word;
-	}
-
-	table {
-		* {
-			word-break: initial;
-		}
 	}
 }
 

--- a/sites/baseline/_scaffolding.scss
+++ b/sites/baseline/_scaffolding.scss
@@ -7,6 +7,10 @@
  *
  */
 
+%gcweb-scaffolding-word-break-break-word {
+	word-break: break-word;
+}
+
 //
 // Apply baseline font styling
 // For the font smooth, read the justification here: https://wet-boew.github.io/themes-dist/GCWeb/gcweb-theme/index.html#antialiasing
@@ -22,7 +26,19 @@ main {
 	line-height: 1.65em;
 
 	h1, h2, h3, h4, h5, h6, p {
-		word-break: break-word;
+		@extend %gcweb-scaffolding-word-break-break-word;
+	}
+
+	table {
+		caption {
+			p {
+				@extend %gcweb-scaffolding-word-break-break-word;
+			}
+		}
+
+		p {
+			word-break: initial;
+		}
 	}
 }
 

--- a/sites/baseline/_scaffolding.scss
+++ b/sites/baseline/_scaffolding.scss
@@ -24,6 +24,12 @@ main {
 	* {
 		word-break: break-word;
 	}
+
+	table {
+		* {
+			word-break: initial;
+		}
+	}
 }
 
 //


### PR DESCRIPTION
#2450 added a CSS selector that set the ``word-break`` property to ``break-word`` anywhere within the ``main`` element.

But it had unexpected side effects in certain kinds of two-dimensional content, such as tables and input groups.

Specifically:
* It could cause wide tables (even ones situated within ``table-responsive`` containers) to divide their columns improperly - resulting in individual numbers in number groupings "splitting" across lines, columns that are too narrow to fit short words on the same line, non-breaking spaces getting ignored, etc...
* Buttons situated in input groups became "squished" - every letter within affected buttons appeared on its own line

This resolves it by reworking the selector to solely target paragraphs and headings. Paragraphs in table cells are exempted.

Fixes #2466.

CC @Garneauma @duboisp