### PR TITLE
GCWeb Jekyll - Ability to import script of type module w/ front-matter

### DIFF
--- a/sites/resources-inc/footer.html
+++ b/sites/resources-inc/footer.html
@@ -5,7 +5,9 @@
 {%- if page.script.first -%}
 	{%- for js in page.script -%}
 		{%- if js.first -%}
-			<script src="{{ js.src }}" integrity="{{ js.integrity }}" crossorigin="anonymous"></script>
+			{% assign jsType = js.type %}
+			{% assign jsIntegrity = js.integrity %}
+			<script src="{{ js.src }}"{% if jsType %} type="{{ jsType }}"{% endif %}{% if jsIntegrity %} integrity="{{ jsIntegrity }}" crossorigin="anonymous"{% endif %}></script>
 		{%- elsif js -%}
 			<script src="{{ js }}"></script>
 		{%- endif -%}


### PR DESCRIPTION
This PR is related to [GCWeb Jekyll](https://github.com/wet-boew/gcweb-jekyll) options and does not affect the distribution files, and it does not require a release to take effect. as the CD updates GCWeb Jekyll upon merging.

It allows for importing on a page scripts of various types, such as `module`.

This will enable running test pages with the GCWeb Jekyll theme for [GC Search UI](https://github.com/ServiceCanada/search-ui).

I have added working examples throug a [PR in the GCWeb Jekyll website sample](https://github.com/wet-boew/gcweb-jekyll-website/pull/1). When merged, example of success is that this page shows "Hello world from module" in the grey well: https://wet-boew.github.io/gcweb-jekyll-website/advanced/add-script-module.html

Related to **SR-454**