### PR TITLE
Page details: Bump WET-BOEW to 4.0.86.1 and fix typo indentation variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11891,8 +11891,8 @@
       }
     },
     "node_modules/wet-boew": {
-      "version": "4.0.85",
-      "resolved": "git+ssh://git@github.com/wet-boew/wet-boew.git#eedd3f4c26152d4f6f315a96693f477c4ca9478e",
+      "version": "4.0.86.1",
+      "resolved": "git+ssh://git@github.com/wet-boew/wet-boew.git#1c2d44622d1d231e6c56c4879b8618393a787976",
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap-sass": "3.4.1",
-    "wet-boew": "github:wet-boew/wet-boew#v4.0.85"
+    "wet-boew": "github:wet-boew/wet-boew#v4.0.86.1"
   },
   "browserslist": [
     "last 2 versions",

--- a/sites/page-details/_base.scss
+++ b/sites/page-details/_base.scss
@@ -70,8 +70,8 @@ main {
 
 		.well {
 			margin: {
-				left: -$details-identation;
-				right: -$details-identation;
+				left: -$details-indentation;
+				right: -$details-indentation;
 			}
 		}
 	}


### PR DESCRIPTION
Caused by https://github.com/wet-boew/wet-boew/pull/9881