### PR TITLE
GCWeb Jekyll: adding possibility to include GCDS in global proprties

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,12 @@ global:
   applicationURL:
     en: "#"
     fr: "#"
+# Include GCDS component libraries, excluding its CSS utilities
+# - (default) unspecified: GCDS librarires are not going to be load
+# - true: Will use the latest GCDS libraries
+# - String: The value must represent a specific GCDS version number, when specified it will use that version number
+#  gcds: "0.33.0"
+
 #
 # Override include to use
 # includes:

--- a/_data/common.json
+++ b/_data/common.json
@@ -205,7 +205,7 @@
 	"pages": {
 		"docs": [
 			{
-				"title": "Colour (Foreground/Background)",
+				"title": "Color (Foreground/Background)",
 				"language": "en",
 				"path": "colour-en.html"
 			},

--- a/_data/components.json
+++ b/_data/components.json
@@ -564,7 +564,7 @@
 					"fr": "Mars 2024 - Stabilisation de la composante."
 				},
 				{
-					"en": "August 2023 - Adding possibility to customize the background colour.",
+					"en": "August 2023 - Adding possibility to customize the background color.",
 					"fr": "Août 2023 - Ajout de la possibilité de personnaliser la couleur de fond."
 				},
 				{
@@ -600,7 +600,7 @@
 			},
 			"notes": {
 				"en": [
-					"When customizing the background colour, the component will automatically apply the correct colour to the text: <code>#FFFFFF</code> for dark colours, <code>#333333</code> for light colours, <code>#000000</code> for colours in-between."
+					"When customizing the background color, the component will automatically apply the correct color to the text: <code>#FFFFFF</code> for dark colours, <code>#333333</code> for light colours, <code>#000000</code> for colours in-between."
 				],
 				"fr": [
 					"Lorsque la couleur de fond est personnalisée, la composante appliquera automatiquement la bonne couleur au texte : <code>#FFFFFF</code> pour les couleurs sombres, <code>#333333</code> pour les couleurs claires, <code>#000000</code> pour les couleurs intermédiaires."

--- a/_data/templates.json
+++ b/_data/templates.json
@@ -1127,11 +1127,11 @@
 	},
 	"title": {
 		"en": "Organizational profile",
-		"fr": "Profil organisationnel"
+		"fr": "Profil organisationel"
 	},
 	"description": {
 		"en": "Organizational profile templates",
-		"fr": "Gabarit à propos de page de profil organisationnel"
+		"fr": "Gabarit à propos de page de profil organisationel"
 	},
 	"modified": "2017-12-05",
 	"componentName": "organizational",

--- a/sites/resources-inc/head.html
+++ b/sites/resources-inc/head.html
@@ -1,6 +1,22 @@
+{%- if site.global.gcds and site.global.gcds != false -%}
+	{%- capture gcds-version -%}
+		{%- if site.global.gcds == true -%}
+			latest
+		{%- else -%}
+			{{ site.global.gcds }}
+		{%- endif -%}
+	{%- endcapture -%}
+
+<!-- GC Design System -->
+<link rel="stylesheet" href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.css">
+<script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.esm.js"></script>
+<script nomodule src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.js"></script>
+{% endif %}
+
 <link href="{{ setting-resourcesBasePathTheme }}/assets/favicon.ico" rel="icon" type="image/x-icon" />
 <link rel="stylesheet" href="{{ setting-resourcesBasePathTheme }}/css/theme{{ setting-minifiedSuffix }}.css" />
 <noscript><link rel="stylesheet" href="{{ setting-resourcesBasePathWetboew }}/css/noscript{{ setting-minifiedSuffix }}.css" /></noscript>
+
 {%- if page.css.first -%}
 	{%- for sheet in page.css -%}
 		{%- if sheet.first -%}


### PR DESCRIPTION
In `_config.yml`, Set: `gcds: true` in the `global` property to activate GCDS globally. 

Optionally, set `gcds: [version number]` to define a specific version of GCDS. For example: `gcds: "0.33.0"`.

Finally, you can set `gcds: false` to deactivate GCDS, or simply remove the property.