### PR TITLE
GC-Subway: adding mobile-specific links to index page

### DIFF
--- a/_data/common.json
+++ b/_data/common.json
@@ -205,7 +205,7 @@
 	"pages": {
 		"docs": [
 			{
-				"title": "Color (Foreground/Background)",
+				"title": "Colour (Foreground/Background)",
 				"language": "en",
 				"path": "colour-en.html"
 			},

--- a/_data/components.json
+++ b/_data/components.json
@@ -564,7 +564,7 @@
 					"fr": "Mars 2024 - Stabilisation de la composante."
 				},
 				{
-					"en": "August 2023 - Adding possibility to customize the background color.",
+					"en": "August 2023 - Adding possibility to customize the background colour.",
 					"fr": "Août 2023 - Ajout de la possibilité de personnaliser la couleur de fond."
 				},
 				{
@@ -600,7 +600,7 @@
 			},
 			"notes": {
 				"en": [
-					"When customizing the background color, the component will automatically apply the correct color to the text: <code>#FFFFFF</code> for dark colours, <code>#333333</code> for light colours, <code>#000000</code> for colours in-between."
+					"When customizing the background colour, the component will automatically apply the correct colour to the text: <code>#FFFFFF</code> for dark colours, <code>#333333</code> for light colours, <code>#000000</code> for colours in-between."
 				],
 				"fr": [
 					"Lorsque la couleur de fond est personnalisée, la composante appliquera automatiquement la bonne couleur au texte : <code>#FFFFFF</code> pour les couleurs sombres, <code>#333333</code> pour les couleurs claires, <code>#000000</code> pour les couleurs intermédiaires."

--- a/_data/templates.json
+++ b/_data/templates.json
@@ -1127,11 +1127,11 @@
 	},
 	"title": {
 		"en": "Organizational profile",
-		"fr": "Profil organisationel"
+		"fr": "Profil organisationnel"
 	},
 	"description": {
 		"en": "Organizational profile templates",
-		"fr": "Gabarit à propos de page de profil organisationel"
+		"fr": "Gabarit à propos de page de profil organisationnel"
 	},
 	"modified": "2017-12-05",
 	"componentName": "organizational",

--- a/components/gc-subway/gc-subway.js
+++ b/components/gc-subway/gc-subway.js
@@ -66,9 +66,6 @@ var $document = wb.doc,
 
 				$elm.find( "a.active" ).attr( { tabindex: "0", "aria-current": "page" } );
 
-				//$subwayLinks = $( selector + " a, ." + mainClass + " .gc-subway-pagination a" ); Put back once correctly implemented
-				$subwayLinks = $( selector + " a, ." + mainClass + " .gc-subway-pagination a, main .pager a" );// Remove once correctly implemented
-
 				// Cloning .gc-subway-support
 				$support = $( "." + supportClass );
 				if ( $support ) {
@@ -76,30 +73,33 @@ var $document = wb.doc,
 					$support.addClass( "hidden-md hidden-lg" );
 				}
 
-				// Duplicating GC-Subway links for single-page application feel on mobile
-				$subwayLinks.each( function( i, el ) {
-					let $el = $( el ),
-						elHref = $el.attr( "href" ),
-
-						//cloneHref = elHref.includes( "#" ) ? elHref : elHref += "#wb-cont"; Put back once correctly implemented
-						cloneHref;
-
-					// Remove once correctly implemented
-					if ( elHref ) {
-						cloneHref = elHref.includes( "#" ) ? elHref : elHref += "#wb-cont";
-					}
-
-					$el.clone()
-						.addClass( "hidden-md hidden-lg" )
-						.attr( "href", cloneHref )
-						.insertAfter( el );
-
-					$el.addClass( "hidden-xs hidden-sm" );
-				} );
-
 				// Prevent on-load blinking on desktop
 				elm.classList.add( "no-blink" );
 			}
+
+			//$subwayLinks = $( selector + " a, ." + mainClass + " .gc-subway-pagination a" ); Put back once correctly implemented
+			$subwayLinks = $( selector + " a, ." + mainClass + " .gc-subway-pagination a, main .pager a" );// Remove once correctly implemented
+
+			// Duplicating GC-Subway links for single-page application feel on mobile
+			$subwayLinks.each( function( i, el ) {
+				let $el = $( el ),
+					elHref = $el.attr( "href" ),
+
+					//cloneHref = elHref.includes( "#" ) ? elHref : elHref += "#wb-cont"; Put back once correctly implemented
+					cloneHref;
+
+				// Remove once correctly implemented
+				if ( elHref ) {
+					cloneHref = elHref.includes( "#" ) ? elHref : elHref += "#wb-cont";
+				}
+
+				$el.clone()
+					.addClass( "hidden-md hidden-lg" )
+					.attr( "href", cloneHref )
+					.insertAfter( el );
+
+				$el.addClass( "hidden-xs hidden-sm" );
+			} );
 
 			// Identify that initialization has completed
 			wb.ready( $elm, componentName );


### PR DESCRIPTION
Duplicating links in index page just like in sections page so that in mobile view they anchor to the content.