### PR TITLE
build: Use GitHub's Actions for Page deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,10 +40,9 @@ jobs:
 
       # Necessary in order to build Jekyll
       - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.3'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,31 +2,26 @@ name: Build for Github Pages
 
 on:
   push:
-    branches: dev
+    branches:
+      - dev
 
 jobs:
-  build-test:
+  build:
     runs-on: ubuntu-latest
-
-    environment: dev
-
-    strategy:
-      matrix:
-        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use NodeJS ${{ matrix.node-version }}
+      - name: Use NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Install dependencies
-        run: |
-          npm i -g bower grunt-cli
-          npm ci
+      - name: Install Grunt
+        run: npm i -g bower grunt-cli --force
+
+      - name: Install npm dependencies
+        run: npm ci --ignore-scripts
 
       # Related to GCWeb#1737 about wet-boew#cc340a6 commit
       - name: Copy the missing _sprite_share.scss file
@@ -42,19 +37,23 @@ jobs:
         run: |
           cp -R ~jekyll-dist/_includes/* _includes/
           cp -R ~jekyll-dist/_layouts/* _layouts/
-          sed -i '/^dist\/$/s/^/#/' .gitignore
 
-      - name: Commit all changes
-        run: |
-          git config --global user.name "${{ github.repository_owner}}"
-          git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
-          git add .
-          git commit -m "${{ github.run_id }}: Deploy to gh-pages" --allow-empty
-
-      - name: Push to gh-pages
-        uses: ad-m/github-push-action@v0.8.0
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages
-          force: true
-          github_token: ${{ secrets.my_token }}
+          path: ./
 
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Grunt
-        run: npm i -g bower grunt-cli --force
+        run: npm i -g grunt-cli --force
 
       - name: Install npm dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,12 +38,34 @@ jobs:
           cp -R ~jekyll-dist/_includes/* _includes/
           cp -R ~jekyll-dist/_layouts/* _layouts/
 
+      # Necessary in order to build Jekyll
+      - name: Setup Ruby
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+
+      # Necessary for Github pages (when not publishing to gh-pages)
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      # Generate all the Jekyll files and push to ./_site
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      # Zip the ./_site/ folder as an artifact
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./
+          path: ./_site/
 
+  # Publish the artifact to Github Pages
   deploy:
     permissions:
       pages: write

--- a/docs/developing-en.md
+++ b/docs/developing-en.md
@@ -126,42 +126,19 @@ Note: A manual update is required if you have specified a version for your jekyl
 
 ## Develop using Github Pages
 
-### 1. Create Personal Access Token (PAT)
-
-Once your Github Pages are set up, you'll have to generate a personal access token in order for the Github Actions workflow to work. Here are the steps:
-
-1. Go to this URL: [https://github.com/settings/tokens](https://github.com/settings/tokens)
-2. Select "Generate new token".
-3. Select "Generate new token (classic)".
-    * **Note**: "GCWeb dev for Github Pages"
-    * **Expiration**: Set it to a year from creation.
-4. Select the `repo` checkbox.
-5. Select "Generate new token".
-6. Copy the token.
-
-### 2. Create your environment
-
-You'll now have to add the token you created to the dev environment:
-
-1. In your GCWeb fork, go to the Settings tab.
-2. In the Settings page, go to the "Enviromnents" tab.
-3. **Name**: dev
-4. Select "Configure environment".
-5. Under "Environment secrets", select "Add environment secret":
-    * **Name**: MY_TOKEN
-    * **Value**: [Paste the token you copied in step 1.7]
-
-### 3. Setup Github Pages
+### 1. Setup Github Pages
 
 To be able to view GCWeb through Github, you'll have to setup your repo to use Github pages. Here's how to do so:
 
 1. In your GCWeb fork, go to the Settings tab.
 2. In the Settings page, go to the Pages tab.
     * **Source**: deploy from a branch
-    * **Branch**: gh-pages /(root) (if you don't have the `gh-pages` branch already, you'll have to create it)
-3. You are now set up to start developing.
+    * **Branch**: gh-pages | /(root) (if you don't have the `gh-pages` branch already, you'll have to create it)
+3. Still in the Settings pages, go to the Environments tab.
+4. Select "github-pages" environment.
+5. Under "Deployment branches and tags", if it is not already there, add the branch `dev`.
 
-### 4. Develop using the Github Pages workflow
+### 2. Develop using the Github Pages workflow
 
 You are now set up to start developing. Here's the process to do so:
 

--- a/docs/developing-fr.md
+++ b/docs/developing-fr.md
@@ -8,7 +8,8 @@
 }
 ---
 
-<div lang="en">
+<div lang="en" markdown="1">
+
 [Needs translation]
 
 Install NodeJS
@@ -129,42 +130,19 @@ Note: A manual update is required if you have specified a version for your jekyl
 
 ## Develop using Github Pages
 
-### 1. Create Personal Access Token (PAT)
-
-Once your Github Pages are set up, you'll have to generate a personal access token in order for the Github Actions workflow to work. Here are the steps:
-
-1. Go to this URL: [https://github.com/settings/tokens](https://github.com/settings/tokens)
-2. Select "Generate new token".
-3. Select "Generate new token (classic)".
-    * **Note**: "GCWeb dev for Github Pages"
-    * **Expiration**: Set it to a year from creation.
-4. Select the `repo` checkbox.
-5. Select "Generate new token".
-6. Copy the token.
-
-### 2. Create your environment
-
-You'll now have to add the token you created to the dev environment:
-
-1. In your GCWeb fork, go to the Settings tab.
-2. In the Settings page, go to the "Enviromnents" tab.
-3. **Name**: dev
-4. Select "Configure environment".
-5. Under "Environment secrets", select "Add environment secret":
-    * **Name**: MY_TOKEN
-    * **Value**: [Paste the token you copied in step 1.7]
-
-### 3. Setup Github Pages
+### 1. Setup Github Pages
 
 To be able to view GCWeb through Github, you'll have to setup your repo to use Github pages. Here's how to do so:
 
 1. In your GCWeb fork, go to the Settings tab.
 2. In the Settings page, go to the Pages tab.
     * **Source**: deploy from a branch
-    * **Branch**: gh-pages /(root) (if you don't have the `gh-pages` branch already, you'll have to create it)
-3. You are now set up to start developing.
+    * **Branch**: gh-pages | /(root) (if you don't have the `gh-pages` branch already, you'll have to create it)
+3. Still in the Settings pages, go to the Environments tab.
+4. Select "github-pages" environment.
+5. Under "Deployment branches and tags", if it is not already there, add the branch `dev`.
 
-### 4. Develop using the Github Pages workflow
+### 2. Develop using the Github Pages workflow
 
 You are now set up to start developing. Here's the process to do so:
 


### PR DESCRIPTION
Feel free to close this, I was just seeing if I could get the GitHub Actions to work for deployment.
The path probably still isn't right for to scope down the pages.
You can see what it looked like when I pushed this against my own default branch before rolling back and changing the branch back to `dev` https://github.com/nschonni/GCWeb/actions/runs/14767194643