### PR TITLE
fix horizontal scroll on medium screen

### DIFF
--- a/sites/gcweb-menu/_screen-md-min-to-screen-md-max.scss
+++ b/sites/gcweb-menu/_screen-md-min-to-screen-md-max.scss
@@ -11,6 +11,11 @@
 	 * (Grid of the submenu panel)
 	 */
 
+	// avoid horizontal scroll on medium breakpoint
+	[role=menu] [role=menu] {
+		width: 610px;
+	}
+
 	[role=menu] [role=menu] li {
 		width: 100%;
 	}

--- a/sites/gcweb-menu/gcweb-menu-docs-en.html
+++ b/sites/gcweb-menu/gcweb-menu-docs-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "gcweb-menu-docs-fr.html",
 	"secondlevel": false,
-	"dateModified": "2024-06-21",
+	"dateModified": "2025-05-13",
 	"share": "true"
 }
 ---
@@ -16,7 +16,7 @@
 	<dt>Type</dt>
 	<dd>Canada.ca site functionality</dd>
 	<dt>Last review</dt>
-	<dd>2024-06-21</dd>
+	<dd>2025-05-13</dd>
 </dl>
 
 <h2>Purpose</h2>
@@ -24,8 +24,8 @@
 
 <h2>Working example</h2>
 <ul>
-	<li><a href="../../templates/content-page/content-en.html">Content page including GCWeb Menu v3.0</a></li>
-	<li><a href="../../templates/home/home-en.html">Home page  including GCWeb Menu v3.0</a></li>
+	<li><a href="../../templates/content-page/content-en.html">Content page including GCWeb Menu v3.0.2</a></li>
+	<li><a href="../../templates/home/home-en.html">Home page  including GCWeb Menu v3.0.2</a></li>
 </ul>
 
 <h2>How to implement</h2>
@@ -35,7 +35,7 @@
 <h2>Evaluation and report</h2>
 <p>There is no evaluation and report available for this component.</p>
 
-<h2 id="v3">API (Version 3.0)</h2>
+<h2 id="v3">API (Version 3.0.2)</h2>
 <table class="table table-bordered">
 	<tr>
 		<th>CSS Class</th>
@@ -46,7 +46,7 @@
 	<tr>
 		<td>Version 1.0</td>
 		<td>Version 3.0</td>
-		<td>Version 1.0</td>
+		<td>Version 1.0.1</td>
 		<td>n.a.</td>
 	</tr>
 </table>
@@ -55,6 +55,9 @@
 <p><code>gcweb-menu</code></p>
 
 <h2>History</h2>
+
+<h3>Version 3.0.2</h3>
+<p>Update the width for the sub-menu at medium breakpoints.</p>
 
 <h3>Version 3.0.1</h3>
 <p>The aria-label was updated for accessibility.</p>

--- a/sites/gcweb-menu/gcweb-menu-docs-fr.html
+++ b/sites/gcweb-menu/gcweb-menu-docs-fr.html
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"altLangPage": "gcweb-menu-docs-en.html",
 	"secondlevel": false,
-	"dateModified": "2024-06-21",
+	"dateModified": "2025-05-13",
 	"share": "true"
 }
 ---
@@ -16,7 +16,7 @@
 	<dt>Type</dt>
 	<dd>Fonctionnalité du site Canada.ca</dd>
 	<dt>Dernière révision</dt>
-	<dd>2024-06-21</dd>
+	<dd>2025-05-13</dd>
 </dl>
 
 <h2>Objectif</h2>
@@ -24,8 +24,8 @@
 
 <h2>Example pratique</h2>
 <ul>
-	<li><a href="../../templates/content-page/content-fr.html">Page de contenu incluant le menu GCWeb version 3.0</a></li>
-	<li><a href="../../templates/home/home-en.html">Page d'accueil incluant le menu GCWeb version 3.0</a></li>
+	<li><a href="../../templates/content-page/content-fr.html">Page de contenu incluant le menu GCWeb version 3.0.2</a></li>
+	<li><a href="../../templates/home/home-en.html">Page d'accueil incluant le menu GCWeb version 3.0.2</a></li>
 </ul>
 
 <h2>Comment mettre en œuvre</h2>
@@ -34,7 +34,7 @@
 <h2>Évaluation et rapport</h2>
 <p>Il n'y a pas d'évaluation ni de rapport disponible pour ce composant.</p>
 
-<h2>API (version 3.0)</h2>
+<h2>API (version 3.0.2)</h2>
 <table class="table bordée de table">
 	<tr>
 		<th>Classe CSS</th>
@@ -45,7 +45,7 @@
 	<tr>
 		<td>Version 1.0</td>
 		<td>Version 3.0</td>
-		<td>Version 1.0</td>
+		<td>Version 1.0.1</td>
 		<td>n.d.</td>
 	</tr>
 </table>
@@ -54,6 +54,9 @@
 <p><code>gcweb-menu</code></p>
 
 <h2>Historique</h2>
+
+<h3>Version 3.0.2</h3>
+<p>Mise à jour la largeur du sous-menu au point d'arrêt moyen.</p>
 
 <h3>Version 3.0.1</h3>
 <p>Le aria-label a été mis à jour pour des raisons d'accessibilité.</p>


### PR DESCRIPTION
 Adjust the width of the 2nd level menu on medium breakpoints to avoid horizontal scroll on medium breakpoints
