### PR TITLE
Fixed broken vitality details link

### DIFF
--- a/docs/méta-détails/th-vitality-en.html
+++ b/docs/méta-détails/th-vitality-en.html
@@ -1,0 +1,11 @@
+---
+title: th-vitality - Méli-mélo details
+componentName: th-vitality
+layout: thématique-en
+altLangPage: détails-fr.html
+lang: en
+breadcrumbs: [
+	{ "title": "Thematic", "link": "thématique/gc-thématique-en.html" }
+]
+permalink: /méli-mélo/th-vitality/détails-en.html
+---

--- a/docs/méta-détails/th-vitality-fr.html
+++ b/docs/méta-détails/th-vitality-fr.html
@@ -1,0 +1,11 @@
+---
+title: th-vitality - Détails du méli-mélo
+componentName: th-vitality
+layout: thématique-fr
+altLangPage: détails-en.html
+lang: fr
+breadcrumbs: [
+	{ "title": "Thématique", "link": "thématique/gc-thématique-fr.html" }
+]
+permalink: /méli-mélo/th-vitality/détails-fr.html
+---


### PR DESCRIPTION
Added the necessary documentation to fix broken vitality thematic link on the [GC promotional thematic page](https://wet-boew.github.io/GCWeb/th%C3%A9matique/gc-th%C3%A9matique-en.html).