### PR TITLE
Add 2025-06-math-grid to the mile-iles compilation 

### DIFF
--- a/_data/méli-mélo.json
+++ b/_data/méli-mélo.json
@@ -5,7 +5,7 @@
 			"nom": "2025-04-nahanni",
 			"libs": [
         "2024-10-datatable-utilities",
-				"2024-02-charts",
+		"2024-02-charts",
         "2024-04-stepsquiz",
         "2021-05-conjunction",
         "2021-05-steps",
@@ -15,9 +15,10 @@
 		{
 			"nom": "2025-12-mille-iles",
 			"libs": [
+				"2025-06-math-grid",
 				"2024-10-datatable-utilities",
-        "2021-05-conjunction",
-        "2021-05-steps",
+        		"2021-05-conjunction",
+        		"2021-05-steps",
 				"deprecated"
 			]
 		},
@@ -33,6 +34,10 @@
 		}
 	],
 	"subProjects": [
+		{
+			"nom": "2025-06-math-grid",
+			"mainpage": "index.html"
+		},
 		{
 			"nom": "@sample",
 			"mainpage": "index-fr.html",

--- a/docs/méta-détails/2025-06-math-grid-en.html
+++ b/docs/méta-détails/2025-06-math-grid-en.html
@@ -1,0 +1,11 @@
+---
+title: 2025-06-math-grid- Méli-mélo details
+componentName: 2025-06-math-grid
+layout: méli-mélo-en
+altLangPage: détails-fr.html
+lang: en
+breadcrumbs: [
+	{ "title": "Méli-mélo", "link": "méli-mélo/méli-mélo-en.html" }
+]
+permalink: /méli-mélo/2025-06-math-grid/détails-en.html
+---

--- a/docs/méta-détails/2025-06-math-grid-fr.html
+++ b/docs/méta-détails/2025-06-math-grid-fr.html
@@ -1,0 +1,11 @@
+---
+title: 2025-06-math-grid- Détails du méli-mélo
+componentName: 2025-06-math-grid
+layout: méli-mélo-fr
+altLangPage: détails-en.html
+lang: fr
+breadcrumbs: [
+	{ "title": "Méli-mélo", "link": "méli-mélo/méli-mélo-fr.html" }
+]
+permalink: /méli-mélo/2025-06-math-grid/détails-fr.html
+---


### PR DESCRIPTION
This PR is for:

- add the `2025-06-math-grid`` experimentation to the mille-iles compilation in méli-mélo.json.

- create the according files of `2025-06-math-grid`` in docs/méta-détails