### PR TITLE
Add GCDS loader and GCDS card example for co-existance tested version

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -220,6 +220,8 @@ module.exports = (grunt) ->
 			"copy:fonts"
 			"copy:wetboew"
 			"copy:depsJS_custom"
+			"copy:gcdsLoader"
+			"usebanner:gcdsLoader"
 		]
 	)
 
@@ -583,6 +585,7 @@ module.exports = (grunt) ->
 					"!{sites,common,components,templates,design-patterns,wet-boew}/**/assets"
 					"!{sites,common,components,templates,design-patterns,wet-boew}/**/demo"
 					"!{sites,common,components,templates,design-patterns,wet-boew}/**/demos"
+					"!sites/gcdsloader.js"
 				]
 				dest: "<%= themeDist %>/js/theme.js"
 			common:
@@ -666,6 +669,22 @@ module.exports = (grunt) ->
 						"<%= themeDist %>/css/*.*",
 						"<%= themeDist %>/méli-mélo/*.css"
 					]
+
+			gcdsLoader:
+				options:
+					position: "replace"
+					props:
+						ver: "<%= pkg.peerDependencies[ '@cdssnc/gcds-components' ] %>"
+						srijs: "<%= pkg[ 'io.github.wet-boew' ].gcdsSriJs %>"
+						sricss: "<%= pkg[ 'io.github.wet-boew' ].gcdsSriCss %>"
+					replace: (fileContents, newBanner, insertPositionMarker, src, options) ->
+						# Replace GCDS version and SRIs in the source file
+						return fileContents
+						.replace( "@gcdsComponentVersion@", options.props.ver )
+						.replace( "@gcdsSriJs@", options.props.srijs )
+						.replace( "@gcdsSriCss@", options.props.sricss )
+				src: "<%= themeDist %>/js/gcdsloader.js"
+
 			#
 			# Use the name in the package.json as packageName in the theme
 			# used to build the URL and to ease the reuse of this build script for derivative themes
@@ -839,6 +858,11 @@ module.exports = (grunt) ->
 				cwd: "<%= themeDist %>/deps-js"
 				src: "**/*.*"
 				dest: "dist/wet-boew/js/deps"
+			gcdsLoader:
+				expand: true
+				flatten: true
+				src: "sites/gcdsloader.js"
+				dest: "<%= themeDist %>/js"
 
 			wetboew_demos:
 				expand: true

--- a/_data/components.json
+++ b/_data/components.json
@@ -2203,6 +2203,182 @@
 		"modified": "dct:modified"
 	},
 	"title": {
+		"en": "GCDS card",
+		"fr": "Carte GCDS"
+	},
+	"description": {
+		"en": "Co-existence pilot of the GCDSs card in GCWeb.",
+		"fr": "Pilote de co-existance des cartes GCDS dans GCWeb."
+	},
+	"modified": "2025-07-04",
+	"componentName": "gcds-card",
+	"status": "provisional",
+	"version": "1.0",
+	"pages": {
+		"examples": [
+			{
+				"title": "GCDS card",
+				"language": "en",
+				"path": "card-en.html"
+			},
+			{
+				"title": "Carte GCDS",
+				"language": "fr",
+				"path": "card-fr.html"
+			}
+		],
+		"docs": [
+			{
+				"title": "GCDS card",
+				"language": "en",
+				"path": "card-doc-en.html"
+			},
+			{
+				"title": "Carte GCDS",
+				"language": "fr",
+				"path": "card-doc-fr.html"
+			}
+		],
+		"test": [
+			{
+				"title": "GCDS Card with images",
+				"language": "en",
+				"path": "withimg-en.html"
+			},
+			{
+				"title": "Carte GCDS avec images",
+				"language": "fr",
+				"path": "withimg-fr.html"
+			},
+			{
+				"title": "GCDS Card as implemented in MWS",
+				"language": "en",
+				"path": "mws-en.html"
+			},
+			{
+				"title": "Carte GCDS tel que l'implémentation dans le système web géré",
+				"language": "fr",
+				"path": "mws-fr.html"
+			},
+			{
+				"title": "GCDS Card like as implemented in MWS (without workaround)",
+				"language": "en",
+				"path": "mws-no-workaround-en.html"
+			},
+			{
+				"title": "Carte GCDS similaire à l'implémentation dans le système web géré (sans contournement)",
+				"language": "fr",
+				"path": "mws-no-workaround-fr.html"
+			}
+		]
+	},
+	"a11yGuidance": "no accessibility guidance",
+	"variations": [
+		{
+			"name": {
+				"en": "GCDS Card - default",
+				"fr": "Carte GCDS - par défaut"
+			},
+			"status": "provisional",
+			"description": {
+				"en": "Co-existence pilot of the GCDS card in GCWeb.",
+				"fr": "Pilote de co-existance de la carte GCDS dans GCWeb."
+			},
+			"iteration": "_:implement_card",
+			"example": [
+				{
+					"en": { "href": "card-en.html", "text": "GCDS Card" },
+					"fr": { "href": "card-fr.html", "text": "Carte GCDS" }
+				}
+			],
+			"implementation": [
+				"_:implement_card"
+			],
+			"history": [
+				{
+					"en": "July 2025 - Initial implementation of the component co-existing with GCWeb.",
+					"fr": "Juillet 2025 - Implémentation initiale de la composante co-existant avec GCWeb."
+				}
+			]
+		}
+	],
+	"implementation": [
+		{
+			"@id": "_:implement_card",
+			"iteration": "_:iteration_card_1",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the component manually and want to participate to the Principal Publisher pilot.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement et qui veulent participer au pilote avec l'Éditeur Principal."
+			},
+			"instructions": {
+				"en": [
+					"Add the GCDS loader into your page, distributed here <code>&lt;script blocking=\"render\" src=\"dist/GCWeb/js/gcdsloader.min.js\">&lt;/script></code>",
+					"Add your <code>gcds-card</code> inside a <code>gcds-grid</code> and then you can configure according to GCDS documentation"
+				],
+				"fr": [
+					"Ajoutez le chargeur de GCDS dans votre page, ce dernier est distribué ici <code>&lt;script blocking=\"render\" src=\"dist/GCWeb/js/gcdsloader.min.js\">&lt;/script></code>",
+					"Ajoutez vos <code>gcds-card</code> à l'intérieur d'une <code>gcds-grid</code> et après vous pouvez faire votre configuration tel que la documenation de GCDS."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Code sample:",
+						"code": "<gcds-grid columns=\"1fr\" columns-tablet=\"1fr 1fr\" columns-desktop=\"1fr 1fr 1fr\">\n\n\t<gcds-card card-title=\"Lorem ipsum\" href=\"#\">\n\t\t<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Aenean id\" href=\"#\">\n\t\t<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Pellentesque dapibus\" href=\"#\" badge=\"badge\">\n\t\t<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Proin at ligula\" href=\"#\">\n\t\t<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>\n\t</gcds-card>\n\n</gcds-grid>"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple de code&nbsp;:",
+						"code": "<gcds-grid columns=\"1fr\" columns-tablet=\"1fr 1fr\" columns-desktop=\"1fr 1fr 1fr\">\n\n\t<gcds-card card-title=\"Lorem ipsum\" href=\"#\">\n\t\t<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Aenean id\" href=\"#\">\n\t\t<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Pellentesque dapibus\" href=\"#\" badge=\"badge\">\n\t\t<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Proin at ligula\" href=\"#\">\n\t\t<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>\n\t</gcds-card>\n\n</gcds-grid>"
+					}
+				]
+			}
+		}
+	],
+	"iteration": [
+		{
+			"@id": "_:iteration_card_1",
+			"name": "GCDS card - Iteration 1",
+			"date": "2025-07",
+			"detectableBy": ".wb-enable gcds-card",
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<gcds-grid columns=\"1fr\" columns-tablet=\"1fr 1fr\" columns-desktop=\"1fr 1fr 1fr\">\n\n\t<gcds-card card-title=\"Lorem ipsum\" href=\"#\">\n\t\t<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Aenean id\" href=\"#\">\n\t\t<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Pellentesque dapibus\" href=\"#\" badge=\"badge\">\n\t\t<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Proin at ligula\" href=\"#\">\n\t\t<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>\n\t</gcds-card>\n\n</gcds-grid>"
+				}
+			]
+		}
+	],
+	"changesets": [
+		{
+			"@id": "_:cs_card_1",
+			"name": "GCDS card",
+			"status": "provisional",
+			"detectableBy": ".wb-enable gcds-card",
+			"layout": "Not applicable",
+			"semantic": "Not applicable",
+			"notes": "Tested when used with the gcds-grid."
+		}
+	]
+}
+,{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
 		"en": "Well header responsive",
 		"fr": "Entête well responsive"
 	},

--- a/components/gcds-card/_workaround.scss
+++ b/components/gcds-card/_workaround.scss
@@ -1,0 +1,14 @@
+/*
+ * GCDS card co-existence workaround
+ *
+*/
+
+//
+// Workaround needed for implementation in the MWS which wrap every component inside divs
+// TODO:
+//	-[ ] Evaluate the scope of use, like validating if a such fix are also required another CMS
+//	-[ ] Check alternative solution
+//
+.gcdscardcontainer.section > gcds-grid[equal-row-height] > div.gcdscard > gcds-card {
+	height: 100%;
+}

--- a/components/gcds-card/card-doc-en.html
+++ b/components/gcds-card/card-doc-en.html
@@ -1,0 +1,11 @@
+---
+{
+	"layout": "documentation",
+	"altLangPage": "card-doc-fr.html",
+	"dateModified": "2025-07-04",
+	"index_json": "index.json-ld",
+	"description": "GCDS Card - Documentation",
+	"language": "en",
+	"title": "GCDS Card"
+}
+---

--- a/components/gcds-card/card-doc-fr.html
+++ b/components/gcds-card/card-doc-fr.html
@@ -1,0 +1,11 @@
+---
+{
+	"layout": "documentation",
+	"altLangPage": "card-doc-en.html",
+	"dateModified": "2025-07-04",
+	"index_json": "index.json-ld",
+	"description": "Carte GCDS - Documentation",
+	"language": "fr",
+	"title": "Carte GCDS"
+}
+---

--- a/components/gcds-card/card-en.html
+++ b/components/gcds-card/card-en.html
@@ -1,0 +1,38 @@
+---
+dateModified: "2025-07-04"
+description: "Co-existence pilot of the GCDS card in GCWeb."
+language: "en"
+altLangPage: "card-fr.html"
+title: "GCDS Card"
+loadGCDS: true
+---
+
+<gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
+
+	<gcds-card card-title="Lorem ipsum" href="#">
+		<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+	</gcds-card>
+
+	<gcds-card card-title="Aenean id" href="#">
+		<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+	</gcds-card>
+
+	<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+		<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+	</gcds-card>
+
+	<gcds-card card-title="Proin at ligula" href="#">
+		<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+	</gcds-card>
+
+</gcds-grid>
+
+<h2>Additional working example</h2>
+
+<p>The following examples are for comparative implementation purposes and for tracking coexistence changes across versions.</p>
+
+<ul>
+	<li><a href="withimg-en.html">GCDS Card with images</a></li>
+	<li><a href="mws-en.html">GCDS Card as implemented in MWS</a></li>
+	<li><a href="mws-no-workaround-en.html">GCDS Card like as implemented in MWS (without workaround)</a></li>
+</ul>

--- a/components/gcds-card/card-fr.html
+++ b/components/gcds-card/card-fr.html
@@ -1,0 +1,38 @@
+---
+dateModified: "2025-07-04"
+description: "Pilote de co-existance de la carte GCDS dans GCWeb."
+language: "fr"
+altLangPage: "card-en.html"
+title: "Carte GCDS"
+loadGCDS: true
+---
+
+<gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
+
+	<gcds-card card-title="Lorem ipsum" href="#">
+		<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+	</gcds-card>
+
+	<gcds-card card-title="Aenean id" href="#">
+		<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+	</gcds-card>
+
+	<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+		<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+	</gcds-card>
+
+	<gcds-card card-title="Proin at ligula" href="#">
+		<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+	</gcds-card>
+
+</gcds-grid>
+
+<h2>Exemple pratique additionel</h2>
+
+<p>Les exemples suivant sont à des fins comparatives d’implémentation et de suivi des changements de coexistence à travers les versions.</p>
+
+<ul>
+	<li><a href="withimg-fr.html">Carte GCDS avec images</a></li>
+	<li><a href="mws-fr.html">Carte GCDS tel que l'implémentation dans le système web géré</a></li>
+	<li><a href="mws-no-workaround-fr.html">Carte GCDS similaire à l'implémentation dans le système web géré (sans contournement)</a></li>
+</ul>

--- a/components/gcds-card/index.json-ld
+++ b/components/gcds-card/index.json-ld
@@ -1,0 +1,176 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "GCDS card",
+		"fr": "Carte GCDS"
+	},
+	"description": {
+		"en": "Co-existence pilot of the GCDSs card in GCWeb.",
+		"fr": "Pilote de co-existance des cartes GCDS dans GCWeb."
+	},
+	"modified": "2025-07-04",
+	"componentName": "gcds-card",
+	"status": "provisional",
+	"version": "1.0",
+	"pages": {
+		"examples": [
+			{
+				"title": "GCDS card",
+				"language": "en",
+				"path": "card-en.html"
+			},
+			{
+				"title": "Carte GCDS",
+				"language": "fr",
+				"path": "card-fr.html"
+			}
+		],
+		"docs": [
+			{
+				"title": "GCDS card",
+				"language": "en",
+				"path": "card-doc-en.html"
+			},
+			{
+				"title": "Carte GCDS",
+				"language": "fr",
+				"path": "card-doc-fr.html"
+			}
+		],
+		"test": [
+			{
+				"title": "GCDS Card with images",
+				"language": "en",
+				"path": "withimg-en.html"
+			},
+			{
+				"title": "Carte GCDS avec images",
+				"language": "fr",
+				"path": "withimg-fr.html"
+			},
+			{
+				"title": "GCDS Card as implemented in MWS",
+				"language": "en",
+				"path": "mws-en.html"
+			},
+			{
+				"title": "Carte GCDS tel que l'implémentation dans le système web géré",
+				"language": "fr",
+				"path": "mws-fr.html"
+			},
+			{
+				"title": "GCDS Card like as implemented in MWS (without workaround)",
+				"language": "en",
+				"path": "mws-no-workaround-en.html"
+			},
+			{
+				"title": "Carte GCDS similaire à l'implémentation dans le système web géré (sans contournement)",
+				"language": "fr",
+				"path": "mws-no-workaround-fr.html"
+			}
+		]
+	},
+	"a11yGuidance": "no accessibility guidance",
+	"variations": [
+		{
+			"name": {
+				"en": "GCDS Card - default",
+				"fr": "Carte GCDS - par défaut"
+			},
+			"status": "provisional",
+			"description": {
+				"en": "Co-existence pilot of the GCDS card in GCWeb.",
+				"fr": "Pilote de co-existance de la carte GCDS dans GCWeb."
+			},
+			"iteration": "_:implement_card",
+			"example": [
+				{
+					"en": { "href": "card-en.html", "text": "GCDS Card" },
+					"fr": { "href": "card-fr.html", "text": "Carte GCDS" }
+				}
+			],
+			"implementation": [
+				"_:implement_card"
+			],
+			"history": [
+				{
+					"en": "July 2025 - Initial implementation of the component co-existing with GCWeb.",
+					"fr": "Juillet 2025 - Implémentation initiale de la composante co-existant avec GCWeb."
+				}
+			]
+		}
+	],
+	"implementation": [
+		{
+			"@id": "_:implement_card",
+			"iteration": "_:iteration_card_1",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the component manually and want to participate to the Principal Publisher pilot.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le composant manuellement et qui veulent participer au pilote avec l'Éditeur Principal."
+			},
+			"instructions": {
+				"en": [
+					"Add the GCDS loader into your page, distributed here <code>&lt;script blocking=\"render\" src=\"dist/GCWeb/js/gcdsloader.min.js\">&lt;/script></code>",
+					"Add your <code>gcds-card</code> inside a <code>gcds-grid</code> and then you can configure according to GCDS documentation"
+				],
+				"fr": [
+					"Ajoutez le chargeur de GCDS dans votre page, ce dernier est distribué ici <code>&lt;script blocking=\"render\" src=\"dist/GCWeb/js/gcdsloader.min.js\">&lt;/script></code>",
+					"Ajoutez vos <code>gcds-card</code> à l'intérieur d'une <code>gcds-grid</code> et après vous pouvez faire votre configuration tel que la documenation de GCDS."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Code sample:",
+						"code": "<gcds-grid columns=\"1fr\" columns-tablet=\"1fr 1fr\" columns-desktop=\"1fr 1fr 1fr\">\n\n\t<gcds-card card-title=\"Lorem ipsum\" href=\"#\">\n\t\t<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Aenean id\" href=\"#\">\n\t\t<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Pellentesque dapibus\" href=\"#\" badge=\"badge\">\n\t\t<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Proin at ligula\" href=\"#\">\n\t\t<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>\n\t</gcds-card>\n\n</gcds-grid>"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Exemple de code&nbsp;:",
+						"code": "<gcds-grid columns=\"1fr\" columns-tablet=\"1fr 1fr\" columns-desktop=\"1fr 1fr 1fr\">\n\n\t<gcds-card card-title=\"Lorem ipsum\" href=\"#\">\n\t\t<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Aenean id\" href=\"#\">\n\t\t<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Pellentesque dapibus\" href=\"#\" badge=\"badge\">\n\t\t<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Proin at ligula\" href=\"#\">\n\t\t<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>\n\t</gcds-card>\n\n</gcds-grid>"
+					}
+				]
+			}
+		}
+	],
+	"iteration": [
+		{
+			"@id": "_:iteration_card_1",
+			"name": "GCDS card - Iteration 1",
+			"date": "2025-07",
+			"detectableBy": ".wb-enable gcds-card",
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<gcds-grid columns=\"1fr\" columns-tablet=\"1fr 1fr\" columns-desktop=\"1fr 1fr 1fr\">\n\n\t<gcds-card card-title=\"Lorem ipsum\" href=\"#\">\n\t\t<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Aenean id\" href=\"#\">\n\t\t<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Pellentesque dapibus\" href=\"#\" badge=\"badge\">\n\t\t<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>\n\t</gcds-card>\n\n\t<gcds-card card-title=\"Proin at ligula\" href=\"#\">\n\t\t<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>\n\t</gcds-card>\n\n</gcds-grid>"
+				}
+			]
+		}
+	],
+	"changesets": [
+		{
+			"@id": "_:cs_card_1",
+			"name": "GCDS card",
+			"status": "provisional",
+			"detectableBy": ".wb-enable gcds-card",
+			"layout": "Not applicable",
+			"semantic": "Not applicable",
+			"notes": "Tested when used with the gcds-grid."
+		}
+	]
+}

--- a/components/gcds-card/mws-en.html
+++ b/components/gcds-card/mws-en.html
@@ -1,0 +1,71 @@
+---
+dateModified: "2025-07-04"
+description: "Co-existence pilot of the GCDS card in GCWeb as implemented in the managed web service."
+language: "en"
+altLangPage: "mws-fr.html"
+title: "GCDS Card as implemented in MWS"
+loadGCDS: true
+---
+
+<p>This is an example test for comparative implementation purposes and for tracking coexistence changes across versions.</p>
+
+<div class="gcdscardcontainer section">
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr">
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>
+
+<h2>With equal row height</h2>
+<div class="gcdscardcontainer section">
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr" equal-row-height>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>

--- a/components/gcds-card/mws-fr.html
+++ b/components/gcds-card/mws-fr.html
@@ -1,0 +1,71 @@
+---
+dateModified: "2025-07-04"
+description: "Pilote de co-existance de la carte GCDS dans GCWeb tel qu'implémentation dans le système web géré."
+language: "fr"
+altLangPage: "mws-en.html"
+title: "Carte GCDS tel que l'implémentation dans le système web géré"
+loadGCDS: true
+---
+
+<p>Ceci est un exemple d’essai à des fins comparatives d’implémentation et de suivi des changements de coexistence à travers les versions.</p>
+
+<div class="gcdscardcontainer section">
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr">
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>
+
+<h2>Avec l'égalisateur de hauteur de ligne</h2>
+<div class="gcdscardcontainer section">
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr" equal-row-height>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div class="gcdscard section">
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>

--- a/components/gcds-card/mws-no-workaround-en.html
+++ b/components/gcds-card/mws-no-workaround-en.html
@@ -1,0 +1,71 @@
+---
+dateModified: "2025-07-04"
+description: "Co-existence pilot of the GCDS card in GCWeb like how it's implemented in the managed web service."
+language: "en"
+altLangPage: "mws-no-workaround-fr.html"
+title: "GCDS Card like as implemented in MWS (without workaround)"
+loadGCDS: true
+---
+
+<p>This is an example test for comparative implementation purposes and for tracking coexistence changes across versions.</p>
+
+<div>
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr">
+
+		<div>
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>
+
+<h2>With equal row height</h2>
+<div>
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr" equal-row-height>
+
+		<div>
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>

--- a/components/gcds-card/mws-no-workaround-fr.html
+++ b/components/gcds-card/mws-no-workaround-fr.html
@@ -1,0 +1,71 @@
+---
+dateModified: "2025-07-04"
+description: "Pilote de co-existance de la carte GCDS dans GCWeb tel qu'implémenté dans le système web géré."
+language: "fr"
+altLangPage: "mws-no-workaround-en.html"
+title: "Carte GCDS similaire à l'implémentation dans le système web géré (sans contournement)"
+loadGCDS: true
+---
+
+<p>Ceci est un exemple d’essai à des fins comparatives d’implémentation et de suivi des changements de coexistence à travers les versions.</p>
+
+<div>
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr">
+
+		<div>
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>
+
+<h2>Avec l'égalisateur de hauteur de ligne</h2>
+<div>
+	<gcds-grid columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" columns="1fr" equal-row-height>
+
+		<div>
+			<gcds-card card-title="Lorem ipsum" href="#">
+				<gcds-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Aenean id" href="#">
+				<gcds-text>Aenean id sem tellus. Sed sodales mauris non sagittis auctor. Etiam tempus a metus in porta.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Pellentesque dapibus" href="#" badge="badge">
+				<gcds-text>Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque.</gcds-text>
+			</gcds-card>
+		</div>
+
+		<div>
+			<gcds-card card-title="Proin at ligula" href="#">
+				<gcds-text>Proin at ligula tincidunt neque convallis varius.</gcds-text>
+			</gcds-card>
+		</div>
+
+	</gcds-grid>
+</div>

--- a/components/gcds-card/withimg-en.html
+++ b/components/gcds-card/withimg-en.html
@@ -1,0 +1,39 @@
+---
+dateModified: "2025-07-04"
+description: "Co-existence pilot of the GCDS card in GCWeb with images."
+language: "en"
+altLangPage: "withimg-fr.html"
+title: "GCDS Card with images"
+loadGCDS: true
+---
+
+<p>This is an example test for comparative implementation purposes and for tracking coexistence changes across versions. In particular, this example shows a width inconsistency that is only visible in small viewports</p>
+
+<gcds-grid place-items="center" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
+
+	<gcds-card card-title="Lorem ipsum" description="Lorem ipsum dolor sit amet, consectetur adipiscing elit." href="#" img-src="https://dummyimage.com/360x200/000000/FFFFFF.png">
+	</gcds-card>
+
+	<gcds-card card-title="Aenean id" description="Aenean id sem tellus." href="#" img-src="https://dummyimage.com/100x50/000000/FFFFFF.png">
+	</gcds-card>
+
+	<gcds-card card-title="Pellentesque dapibus" description="Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque." href="#" badge="badge" img-src="https://dummyimage.com/306x203/000000/FFFFFF.png">
+	</gcds-card>
+
+	<gcds-card card-title="Proin at ligula" description="Proin at ligula tincidunt neque convallis varius." href="#" img-src="https://dummyimage.com/365x205/000000/FFFFFF.png">
+	</gcds-card>
+
+</gcds-grid>
+
+<h2>Technical notes</h2>
+<p>To reproduce the concern:</p>
+<ul>
+	<li>This happen when the attribute <code>place-items="center"</code> are set on the GCDS grid</li>
+	<li>Images width need to lower than the width available in the view port</li>
+	<li>The description text take less width space than the width available in the view port</li>
+</ul>
+<p>Workaround, at least one of the following:</p>
+<ul>
+	<li>Use images that have a minimum width of 400 pixels</li>
+	<li>Ensure the description text will take at least 2 lines, like with a least 70 characters</li>
+</ul>

--- a/components/gcds-card/withimg-fr.html
+++ b/components/gcds-card/withimg-fr.html
@@ -1,0 +1,39 @@
+---
+dateModified: "2025-07-04"
+description: "Pilote de co-existance de la carte GCDS dans GCWeb avec images."
+language: "fr"
+altLangPage: "withimg-en.html"
+title: "Carte GCDS avec images"
+loadGCDS: true
+---
+
+<p>Ceci est un exemple d’essai à des fins comparatives d’implémentation et de suivi des changements de coexistence à travers les versions. En particulier, cet exemple montre une incohérence de largeur visible uniquement dans les petites fenêtres d’affichage et corresponds à un cas utilisateur réelle.</p>
+
+<gcds-grid place-items="center" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
+
+	<gcds-card card-title="Lorem ipsum" description="Lorem ipsum dolor sit amet, consectetur adipiscing elit." href="#" img-src="https://dummyimage.com/360x200/000000/FFFFFF.png">
+	</gcds-card>
+
+	<gcds-card card-title="Aenean id" description="Aenean id sem tellus." href="#" img-src="https://dummyimage.com/100x50/000000/FFFFFF.png">
+	</gcds-card>
+
+	<gcds-card card-title="Pellentesque dapibus" description="Pellentesque dapibus erat sit amet lectus scelerisque, sed gravida metus pellentesque." href="#" badge="badge" img-src="https://dummyimage.com/306x203/000000/FFFFFF.png">
+	</gcds-card>
+
+	<gcds-card card-title="Proin at ligula" description="Proin at ligula tincidunt neque convallis varius." href="#" img-src="https://dummyimage.com/365x205/000000/FFFFFF.png">
+	</gcds-card>
+
+</gcds-grid>
+
+<h2>Notes techniques</h2>
+<p>Pour reproduire le problème :</p>
+<ul>
+	<li>Le problème survient lorsque l’attribut <code>place-items="center"</code> est appliqué à la grille GCDS</li>
+	<li>La largeur des images doit être inférieure à la largeur disponible dans la fenêtre d’affichage</li>
+	<li>Le texte descriptif occupe moins d’espace en largeur que la fenêtre d’affichage disponible</li>
+</ul>
+<p>Contournement, au moins une des options suivantes :</p>
+<ul>
+	<li>Utiliser des images ayant une largeur minimale de 400 pixels</li>
+	<li>S’assurer que le texte descriptif occupe au moins 2 lignes, par exemple en contenant au moins 70 caractères</li>
+</ul>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,19 @@
     "bootstrap-sass": "3.4.3",
     "wet-boew": "github:wet-boew/wet-boew#v4.0.88.1"
   },
+  "peerDependencies": {
+    "@cdssnc/gcds-components": "0.36.0"
+  },
+  "io.github.wet-boew": {
+    "gcdsSriJs": "sha384-dyE8IpLmFMtdU/ftC4nFeuLMvr2vMI8s1UY2OXl9pbzizebJeCfWp9iLhiVXdXtA",
+    "gcdsSriCss": "sha384-0CRuUE9X0B5RfCdDx1BDT6Ru1MajB7Ngy0CmoORlBF+ey/W8T75AKwLehkl+QaGR",
+    "gcdsPiloting": [ "gcds-card", "gcds-grid > gcds-card" ]
+  },
+  "peerDependenciesMeta": {
+    "@cdssnc/gcds-components": {
+      "optional": true
+    }
+  },
   "browserslist": [
     "last 2 versions",
     "Firefox ESR",

--- a/sites/gcdsloader.js
+++ b/sites/gcdsloader.js
@@ -1,0 +1,66 @@
+/**
+ * @title GCDS loader
+ * @overview Script to load GCDS which was tested for co-existance in GCWeb
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @duboisp
+ */
+( function( wnd, doc, escape ) {
+"use strict";
+
+
+//
+// Configuration updated during the build process with info in package.json
+//
+const gcdsVersion = "@gcdsComponentVersion@", // pkg.peerDependencies[ "@cdssnc/gcds-components" ]
+	gcdsSriJs = "@gcdsSriJs@", // pkg[ "io.github.wet-boew" ].gcdsSriJs
+	gcdsSriCss = "@gcdsSriCss@"; // pkg[ "io.github.wet-boew" ].gcdsSriCss
+
+
+//
+// General configuration used to detect and load GCSD
+//
+const gcdsBasePath = "https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@",
+	gcdsSuffixJs = "/dist/gcds/gcds.esm.js",
+	gcdsSuffixCss = "/dist/gcds/gcds.css",
+	txtScript = "script",
+	txtLink = "link",
+	blockingState = "render";
+
+
+//
+// Check if GCDS lib are already defined in the header
+//
+let traceFound = doc.querySelector( txtLink + "[href$=" + escape( gcdsSuffixCss ) + "]," + txtScript + "[src$=" + escape( gcdsSuffixJs ) + "]" );
+
+
+//
+// Import the GCDS libs
+//
+if ( !traceFound && gcdsSriJs && gcdsSriCss ) {
+	let scrGcds = doc.createElement( txtScript );
+	scrGcds.blocking = blockingState;
+	scrGcds.type = "module";
+	scrGcds.integrity = gcdsSriJs;
+	scrGcds.src = gcdsBasePath + gcdsVersion + gcdsSuffixJs;
+	doc.head.appendChild( scrGcds );
+
+	let lnkGcds = doc.createElement( txtLink );
+	lnkGcds.blocking = blockingState;
+	lnkGcds.rel = "stylesheet";
+	lnkGcds.crossOrigin = "anonymous";
+	lnkGcds.integrity = gcdsSriCss;
+	lnkGcds.href = gcdsBasePath + gcdsVersion + gcdsSuffixCss;
+	doc.head.appendChild( lnkGcds );
+
+
+	//
+	// Set GCDS version globally once loaded
+	//
+	wnd.addEventListener( "appload", ( event ) => {
+		if ( event.detail.namespace === "gcds" ) {
+			wnd.wbgcds = gcdsVersion;
+		}
+	} );
+}
+
+} )( window, document, CSS.escape );

--- a/sites/resources-inc/head.html
+++ b/sites/resources-inc/head.html
@@ -10,7 +10,9 @@
 <!-- GC Design System -->
 <link rel="stylesheet" href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.css">
 <script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.esm.js"></script>
-<script nomodule src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.js"></script>
+{% endif %}
+{%- if page.loadGCDS -%}
+<script blocking="render" src="{{ setting-resourcesBasePathTheme }}/js/gcdsloader{{ setting-minifiedSuffix }}.js"></script>
 {% endif %}
 
 <link href="{{ setting-resourcesBasePathTheme }}/assets/favicon.ico" rel="icon" type="image/x-icon" />

--- a/sites/theme.scss
+++ b/sites/theme.scss
@@ -81,6 +81,9 @@
 @import "main-page-title/base";
 @import "contributors/base";
 
+/*! GCDS Components complementary style */
+@import "../components/gcds-card/workaround";
+
 /*! Components (CSS type only) */
 @import "bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
 @import "wet-boew/src/base/transitions/base";


### PR DESCRIPTION
This introduce the initial addition of the GCDS libraries which will co-exist along with GCWeb.

GCWeb are going to be updated with more example as our co-existence component testing are going to progress.

Changes:
* Add GCDS-card working example
* Add a GCDS loader in our distribution package that are loading the tested compatible version of GCDS
* Include a workaround for a know issue with GCDS in the managed web services.
