### PR TITLE
In-page table of contents: Fix code sample inconsistency

### DIFF
--- a/components/gc-toc/toc-en.html
+++ b/components/gc-toc/toc-en.html
@@ -3,7 +3,7 @@
 	"title": "In-page table of contents",
 	"language": "en",
 	"altLangPage": "toc-fr.html",
-	"dateModified": "2023-06-16"
+	"dateModified": "2025-07-16"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -32,7 +32,7 @@
 </section>
 
 <h2 id="code">Code</h2>
-<pre><code>&lt;nav role="navigation" class="gc-toc"&gt;
+<pre><code>&lt;nav class="gc-toc"&gt;
 	&lt;h3&gt;On this page&lt;/h3&gt;
 	&lt;ul&gt;
 		&lt;li&gt;&lt;a href="#section1"&gt;First section heading&lt;/a&gt;&lt;/li&gt;

--- a/components/gc-toc/toc-fr.html
+++ b/components/gc-toc/toc-fr.html
@@ -3,7 +3,7 @@
 	"title": "Table des matières à l'intérieur de la page",
 	"language": "fr",
 	"altLangPage": "toc-en.html",
-	"dateModified": "2023-06-16"
+	"dateModified": "2025-07-16"
 }
 ---
 
@@ -32,7 +32,7 @@
 	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quam delectus iusto repellat assumenda nobis, modi accusamus, rerum praesentium ad dignissimos ipsam? Facilis repellat, quibusdam qui? Et dolore ipsa ut repellendus.</p>
 </section>
 <h2 id="code">code</h2>
-<pre><code>&lt;nav role="navigation" class="gc-toc"&gt;
+<pre><code>&lt;nav class="gc-toc"&gt;
 	&lt;h3&gt;Sur cette page&lt;/h3&gt;
 	&lt;ul&gt;
 		&lt;li&gt;&lt;a href="#section1"&gt;Première titre de section&lt;/a&gt;&lt;/li&gt;


### PR DESCRIPTION
This component's codes sample previously used a ``role="navigation"`` attribute on the pattern's ``nav`` element... but the demo page itself didn't. Not to mention that the attribute is irrelevant in that context (the ``nav`` element already has an implicit ARIA ``navigation`` role and hardcoding it triggers HTML validation warnings).

This resolves it by removing the offending attribute from the code samples.