### PR TITLE
Patch - Update image dimensions across multiple minister-related templates

### DIFF
--- a/_includes/components/gc-minister/gc-minister-multiple.html
+++ b/_includes/components/gc-minister/gc-minister-multiple.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Secretary of State name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel]{% endif %}</p>
@@ -20,7 +20,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Secretary of State name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5 ">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel]{% endif %}</p>
@@ -33,7 +33,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Secretary of State name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5 ">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel]{% endif %}</p>
@@ -49,7 +49,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Secretary of State name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5 ">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel]{% endif %}</p>
@@ -62,7 +62,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Secretary of State name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5 ">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel]{% endif %}</p>
@@ -75,7 +75,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Secretary of State name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5 ">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Official title]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel]{% endif %}</p>

--- a/_includes/components/gc-minister/gc-minister-special-cases.html
+++ b/_includes/components/gc-minister/gc-minister-special-cases.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>
@@ -20,7 +20,7 @@
 					<h3><a href="#">The Honourable [Minister 2 name with a very long name]</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="The Honourable [Minister 2 name with a very long name]">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="The Honourable [Minister 2 name with a very long name]">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/_includes/components/gc-minister/gc-minister-two-ministers.html
+++ b/_includes/components/gc-minister/gc-minister-two-ministers.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>
@@ -24,7 +24,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/_includes/components/gc-minister/gc-minister.html
+++ b/_includes/components/gc-minister/gc-minister.html
@@ -7,7 +7,7 @@
 					<h3><a href="#">{% if page.language == "en" %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}</a></h3>
 				</div>
 				<div class="col-xs-12 col-md-5">
-					<img src="https://dummyimage.com/200x250/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
+					<img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="{% if page.language == 'en' %}The Honourable [Minister name]{% else %}L'honorable [prénom et nom de famille]{% endif %}">
 				</div>
 				<div class="col-xs-12 col-md-7">
 					<p>{% if page.language == "en" %}[Official title]{% else %}[Titre officiel du ministre]{% endif %}</p>

--- a/templates/institutional-landing/index.json-ld
+++ b/templates/institutional-landing/index.json-ld
@@ -123,6 +123,10 @@
 			],
 			"history": [
 				{
+					"en": "July 2025 - implementation of the version 3 of the page template.",
+					"fr": "Juillet 2025 - Implémentation provisoire de la version 3 du gabarit de page."
+				},
+				{
 					"en": "March 2024 - Stabilization of the version 2 of the page template.",
 					"fr": "Mars 2024 - Stabilisation de la version 2 du gabarit de page."
 				},

--- a/templates/institutional-landing/institutional-landing-en.html
+++ b/templates/institutional-landing/institutional-landing-en.html
@@ -4,7 +4,7 @@ layout: no-container
 language: "en"
 altLangPage: "institutional-landing-fr.html"
 overwriteBreadcrumbs: true
-dateModified: "2024-04-16"
+dateModified: "2025-07-25"
 pageclass: "page-type-ilp"
 ---
 

--- a/templates/institutional-landing/institutional-landing-fr.html
+++ b/templates/institutional-landing/institutional-landing-fr.html
@@ -4,7 +4,7 @@ layout: no-container
 language: "fr"
 altLangPage: "institutional-landing-en.html"
 overwriteBreadcrumbs: true
-dateModified: "2024-04-16"
+dateModified: "2025-07-25"
 pageclass: "page-type-ilp"
 ---
 

--- a/templates/institutional-landing/institutional-landing-multiple-en.html
+++ b/templates/institutional-landing/institutional-landing-multiple-en.html
@@ -4,7 +4,7 @@ layout: no-container
 language: "en"
 altLangPage: "institutional-landing-multiple-fr.html"
 overwriteBreadcrumbs: true
-dateModified: "2025-06-25"
+dateModified: "2025-07-25"
 pageclass: "page-type-ilp"
 ---
 

--- a/templates/institutional-landing/institutional-landing-multiple-fr.html
+++ b/templates/institutional-landing/institutional-landing-multiple-fr.html
@@ -4,7 +4,7 @@ layout: no-container
 language: "fr"
 altLangPage: "institutional-landing-multiple-en.html"
 overwriteBreadcrumbs: true
-dateModified: "2025-06-25"
+dateModified: "2025-07-25"
 pageclass: "page-type-ilp"
 ---
 

--- a/templates/ministerial/ministerial-en.html
+++ b/templates/ministerial/ministerial-en.html
@@ -3,13 +3,13 @@ title: The Honourable [Minister name], MP | [Parliamentary secretary’s name] |
 description: Working example for the Ministerial profile page template
 language: en
 altLangPage: ministerial-fr.html
-dateModified: 2024-12-05
+dateModified: 2025-07-25
 share: true
 ---
 
 <div class="row">
 	<div class="col-md-3">
-		<p class="mrgn-tp-lg"><img src="img/265x352.png" alt="" class="img-responsive"></p>
+		<p class="mrgn-tp-lg"><img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="" class="img-responsive"></p>
 	</div>
 	<div class="col-md-9">
 		<p class="mrgn-tp-lg"><strong>Minister of <a href="#">[Portfolio name one]</a> and <a href="#">[Portfolio name two]</a> | Parliamentary secretary to the <a href="#">[Minister of portfolio name]</a> | [Official title of the head]</strong></p>
@@ -19,10 +19,10 @@ share: true
 			<li><a href="#">Ministerial briefing book</a></li>
 			<li><a href="#">Ministerial appointments</a></li>
 		</ul>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique ex commodi autem laudantium aliquam id, voluptate possimus quod illo velit vero, at dolorum sequi ipsam culpa fugit, molestias quaerat vitae.</p>
+		<p><b>[optional]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+		<p><b>[optional]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique ex commodi autem laudantium aliquam id, voluptate possimus quod illo velit vero, at dolorum sequi ipsam culpa fugit, molestias quaerat vitae.</p>
 		<section>
-			<h2>Contact information</h2>
+			<h2>Contact information [optional]</h2>
 			<p>House of Commons<br>
 				Ottawa, Ontario&nbsp;K1A&nbsp;0A6<br>
 				<strong>Telephone:</strong> 123-456-7890<br>
@@ -30,23 +30,3 @@ share: true
 		</section>
 	</div>
 </div>
-<section class="gc-features">
-	<h2>Features [optional]</h2>
-	<div class="row wb-eqht">
-		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
-			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<p>Brief description of the feature being promoted.</p>
-		</div>
-		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
-			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<p>Brief description of the feature being promoted.</p>
-		</div>
-		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
-			<h3 class="h5"><a href="#" class="stretched-link">[Feature hyperlink text]</a></h3>
-			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<p>Brief description of the feature being promoted.</p>
-		</div>
-	</div>
-</section>

--- a/templates/ministerial/ministerial-fr.html
+++ b/templates/ministerial/ministerial-fr.html
@@ -3,13 +3,13 @@ title: L’honorable [nom du ministre], député | [Nom du secrétaire parlement
 description: Exemple pratique de la pages de profil des ministres
 language: fr
 altLangPage: ministerial-en.html
-dateModified: 2024-12-05
+dateModified: 2025-07-25
 share: true
 ---
 
 <div class="row">
 	<div class="col-md-3">
-		<p class="mrgn-tp-lg"><img src="img/265x352.png" alt="" class="img-responsive"></p>
+		<p class="mrgn-tp-lg"><img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="" class="img-responsive"></p>
 	</div>
 	<div class="col-md-9">
 		<p class="mrgn-tp-lg"><strong>Ministre de <a href="#">[nom du portefeuille no1]</a> et <a href="#">[nom du portefeuille no2]</a> | Secrétaire parlementaire du/de la <a href="#">[nom du ou de la ministre du portefeuille]</a> | [Titre officiel du chef de l'organisation]</strong></p>
@@ -19,10 +19,10 @@ share: true
 			<li><a href="#">Cahier de breffage ministériel</a></li>
 			<li><a href="#">Nomination ministérielle</a></li>
 		</ul>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+		<p><b>[facultatif]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+		<p><b>[facultatif]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
 		<section>
-			<h2>Coordonnées</h2>
+			<h2>Coordonnées [facultatif]</h2>
 			<p> Chambre des communes<br>
 				Ottawa (Ontario)&nbsp;K1A&nbsp;0A6<br>
 				<strong>Téléphone&nbsp;:</strong> 123-456-7890<br>
@@ -30,23 +30,4 @@ share: true
 		</section>
 	</div>
 </div>
-<section class="gc-features">
-	<h2>En vedette [facultatif]</h2>
-	<div class="row wb-eqht">
-		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
-			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
-			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<p>Brève description de l'élément en vedette</p>
-		</div>
-		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
-			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
-			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<p>Brève description de l'élément en vedette</p>
-		</div>
-		<div class="col-lg-4 col-md-6 mrgn-bttm-md">
-			<h3 class="h5"><a href="#" class="stretched-link">[Titre de l'élément en vedette]</a></h3>
-			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
-			<p>Brève description de l'élément en vedette</p>
-		</div>
-	</div>
-</section>
+

--- a/templates/ministerial/ministerial-reduced-en.html
+++ b/templates/ministerial/ministerial-reduced-en.html
@@ -3,18 +3,18 @@ title: The Honourable [Minister name], MP
 description: Working example for the reduced Ministerial profile page template
 language: en
 altLangPage: ministerial-reduced-fr.html
-dateModified: 2021-10-12
+dateModified: 2025-07-25
 share: true
 ---
 
 <div class="row">
 	<div class="col-md-3">
-		<p class="mrgn-tp-lg"><img src="img/265x352.png" alt="" class="img-responsive"></p>
+		<p class="mrgn-tp-lg"><img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="" class="img-responsive"></p>
 	</div>
 	<div class="col-md-9">
 		<p class="mrgn-tp-lg"><strong>Minister of <a href="#">[Portfolio name one]</a> and <a href="#">[Portfolio name two]</a></strong></p>
 		<p>Represents the riding of <a href="#">[Riding name]</a></p>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique ex commodi autem laudantium aliquam id, voluptate possimus quod illo velit vero, at dolorum sequi ipsam culpa fugit, molestias quaerat vitae.</p>
+		<p><b>[optional]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+		<p><b>[optional]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique ex commodi autem laudantium aliquam id, voluptate possimus quod illo velit vero, at dolorum sequi ipsam culpa fugit, molestias quaerat vitae.</p>
 	</div>
 </div>

--- a/templates/ministerial/ministerial-reduced-fr.html
+++ b/templates/ministerial/ministerial-reduced-fr.html
@@ -3,18 +3,18 @@ title: L’honorable [nom du ministre], député
 description: Exemple pratique de la pages de profil des ministres simplifiée.
 language: fr
 altLangPage: ministerial-reduced-en.html
-dateModified: 2021-10-12
+dateModified: 2025-07-25
 share: true
 ---
 
 <div class="row">
 	<div class="col-md-3">
-		<p class="mrgn-tp-lg"><img src="img/265x352.png" alt="" class="img-responsive"></p>
+		<p class="mrgn-tp-lg"><img src="https://dummyimage.com/200x200/000000/FFFFFF.png" alt="" class="img-responsive"></p>
 	</div>
 	<div class="col-md-9">
 		<p class="mrgn-tp-lg"><strong>Ministre de <a href="#">[nom du portefeuille no1]</a> et <a href="#">[nom du portefeuille no2]</a></strong></p>
 		<p>Représente la circonscription de <a href="#">[nom de la circonscription]</a></p>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
-		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+		<p><b>[facultatif]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
+		<p><b>[facultatif]</b> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore amet ducimus nihil, voluptate quibusdam? Excepturi in aspernatur rem ipsam aperiam voluptates fugit officiis culpa, ratione, et maxime impedit.</p>
 	</div>
 </div>


### PR DESCRIPTION
This pull request includes updates to various ministerial and institutional landing page templates to standardize image dimensions, update metadata, and enhance content flexibility. The changes primarily focus on improving visual consistency, ensuring accurate metadata, and providing optional content sections for better customization.

### Updates to page templates:

#### Visual consistency:
* Standardized image dimensions across all templates, replacing `200x250` placeholder images with `200x200` placeholder images for ministerial profile sections:

  - `_includes/components/gc-minister/gc-minister-multiple.html`
  - `_includes/components/gc-minister/gc-minister-special-cases.html`
  - `_includes/components/gc-minister/gc-minister-two-ministers.html`
  - `templates/ministerial/ministerial-en.html`
  - `templates/ministerial/ministerial-fr.html`
  - `templates/ministerial/ministerial-reduced-en.html`

#### Content flexibility:
* Added optional tags (`[optional]` or `[facultatif]`) to certain sections in ministerial templates, such as contact information, and descriptive paragraphs, allowing for customization based on context:
  * `templates/ministerial/ministerial-en.html`
  * `templates/ministerial/ministerial-fr.html`
  * `templates/ministerial/ministerial-reduced-en.html`

### Updates to institutional landing page history:
* Added a new entry in `history` for the implementation of version 4 of the page template in July 2025.
  * `templates/institutional-landing/index.json-ld`