### PR TITLE
Adding .colcount-no-break to lists documentation

### DIFF
--- a/_data/templates.json
+++ b/_data/templates.json
@@ -99,10 +99,10 @@
 		"en": "All services page template.",
 		"fr": "Gabarit de page pour tous les services."
 	},
-	"modified": "2025-07-24",
+	"modified": "2025-08-29",
 	"componentName": "all-services",
 	"status": "stable",
-	"version": "1.2",
+	"version": "1.3",
 	"pages": {
 		"examples": [
 			{
@@ -141,7 +141,7 @@
 				"en": "All services page template.",
 				"fr": "Gabarit de page pour tous les services."
 			},
-			"iteration": "_:iteration_allservices_3",
+			"iteration": "_:iteration_allservices_4",
 			"example": [
 				{
 					"en": { "href": "all-services-en.html", "text": "All services" },
@@ -152,6 +152,10 @@
 				"_:implement_allservices"
 			],
 			"history": [
+				{
+					"en": "August 2025 - Use the class \".colcount-no-break\" to prevent list items from splitting across multiple columns.",
+					"fr": "Août 2025 - Utilisation de la classe « .colcount-no-break » pour empêcher les éléments de liste de se diviser en plusieurs colonnes."
+				},
 				{
 					"en": "July 2025 - Remove expand and collapse All buttons.",
 					"fr": "Juillet 2025 - Suppression des boutons « Développer » et « Réduire »."
@@ -166,7 +170,7 @@
 	"implementation": [
 		{
 			"@id": "_:implement_allservices",
-			"iteration": "_:iteration_allservices_3",
+			"iteration": "_:iteration_allservices_4",
 			"name": {
 				"en": "Standard",
 				"fr": "Standard"
@@ -192,13 +196,21 @@
 	],
 	"iteration": [
 		{
+			"@id": "_:iteration_allservices_4",
+			"name": "All services page - Iteration 4",
+			"date": "2025-08",
+			"additions": [ "Use the class \".colcount-no-break\" to prevent list items from splitting across multiple columns." ],
+			"detectableBy": "Three navigation bands each whose list container has the class \".colcount-no-break\" followed by a Services and Information component containing a list of all themes and topics.",
+			"predecessor": "_:iteration_allservices_3"
+		},
+		{
 			"@id": "_:iteration_allservices_3",
 			"name": "All services page - Iteration 3",
 			"date": "2025-07",
 			"additions": [ "Removing expand/collapse all buttons." ],
 			"detectableBy": "Three navigation bands followed by a Services and Information component containing a list of all themes and topics.",
 			"predecessor": "_:iteration_allservices_2",
-			"successor": "_:iteration_allservices_3"
+			"successor": "_:iteration_allservices_4"
 		},
 		{
 			"@id": "_:iteration_allservices_2",

--- a/common/list/lists-en.html
+++ b/common/list/lists-en.html
@@ -3,7 +3,7 @@
 	"title": "Lists",
 	"language": "en",
 	"altLangPage": "lists-fr.html",
-	"dateModified": "2023-03-05"
+	"dateModified": "2025-08-29"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -312,6 +312,87 @@
 ...
 &lt;li&gt;Item 8&lt;/li&gt;
 &lt;/ul&gt;</code></pre>
+
+<h3><code>.colcount-no-break</code></h3><div></div>
+<p>Prevents list items from splitting across multiple list columns.</p>
+<h4>Unordered list</h4>
+<h5>Working example</h5>
+<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+<li>Item 1<br>Line 2<br>Line 3</li>
+<li>Item 2<br>Line 2<br>Line 3</li>
+<li>Item 3</li>
+<li>Item 4<br>Line 2<br>Line 3</li>
+<li>Item 5<br>Line 2<br>Line 3</li>
+<li>Item 6<br>Line 2</li>
+<li>Item 7<br>Line 2</li>
+<li>Item 8</li>
+</ul>
+<h5>code</h5>
+<pre><code><span class="tag">&lt;ul</span><span class="pln"> </span><span class="atn">class</span><span class="pun">=</span><span class="atv">"colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"</span><span class="tag">&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 1</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 4</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 5</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 6</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 7</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 8</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+</span><span class="tag">&lt;/ul&gt;</span></code></pre>
+<h4>Description list</h4>
+<h5>Working example</h5>
+<dl class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+<div>
+<dt>Term 1</dt>
+<dd>Description</dd>
+</div>
+<div>
+<dt>Term 2</dt>
+<dd>Description<br>Line 2<br>Line 3</dd>
+</div>
+<div>
+<dt>Term 3</dt>
+<dd>Description<br>Line 2<br>Line 3</dd>
+</div>
+<div>
+<dt>Term 4</dt>
+<dd>Description<br>Line 2</dd>
+</div>
+<div>
+<dt>Term 5</dt>
+<dd>Description<br>Line 2</dd>
+</div>
+<div>
+<dt>Term 6</dt>
+<dd>Description</dd>
+</div>
+</dl>
+<h5>code</h5>
+<pre><code><span class="tag">&lt;dl</span><span class="pln"> </span><span class="atn">class</span><span class="pun">=</span><span class="atv">"colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"</span><span class="tag">&gt;</span><span class="pln">
+	</span><span class="tag">&lt;div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dt&gt;</span><span class="pln">Term 1</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+	</span><span class="tag">&lt;div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dt&gt;</span><span class="pln">Term 2</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 3</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+	</span><span class="tag">&lt;div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dt&gt;</span><span class="pln">Term 3</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 3</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+	</span><span class="tag">&lt;div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dt&gt;</span><span class="pln">Term 4</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+	</span><span class="tag">&lt;div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dt&gt;</span><span class="pln">Term 5</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Line 2</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+	</span><span class="tag">&lt;div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dt&gt;</span><span class="pln">Term 6</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+		</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+</span><span class="tag">&lt;/dl&gt;</span></code></pre>
 
 <h2>Responsive list <code>.list-responsive</code></h2>
 <ul class="wb-eqht list-unstyled mrgn-tp-md mrgn-bttm-sm lst-spcd-2 list-responsive">

--- a/common/list/lists-fr.html
+++ b/common/list/lists-fr.html
@@ -3,18 +3,17 @@
 	"title": "Listes",
 	"language": "fr",
 	"altLangPage": "lists-en.html",
-	"dateModified": "2023-03-05"
+	"dateModified": "2025-08-29"
 }
 ---
 <div class="wb-prettify all-pre"></div>
 
-<p>Cette page nécessite une traduction.</p>
-<div lang="en">
-	<h2> Unordered lists</h2>
+<div lang="fr">
+	<h2>Listes non ordonnées</h2>
 	<ul>
-		<li>List item 1</li>
-		<li>List item 2</li>
-		<li>List item 3</li>
+		<li>Item 1</li>
+		<li>Item 2</li>
+		<li>Item 3</li>
 	</ul>
 	<h3>Code</h3>
 	<pre><code><strong>&lt;ul&gt;</strong>
@@ -22,84 +21,84 @@
 		&lt;/ul&gt;
 	</code></pre>
 
-	<h2>Ordered lists </h2>
+	<h2>Listes ordonnées</h2>
 	<ol>
-		<li>List item 1</li>
-		<li>List item 2</li>
-		<li>List item 3</li>
+		<li>Item 1</li>
+		<li>Item 2</li>
+		<li>Item 3</li>
 	</ol>
 	<h3>Code</h3>
 	<pre><code><strong>&lt;ol&gt;</strong>
 	&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2>Definition lists </h2>
+	<h2>Listes de définitions</h2>
 	<dl>
-		<dt>Term 1</dt>
-		<dd>Definition of term 1</dd>
-		<dt>Term 2</dt>
-		<dd>Definition of term 2</dd>
+		<dt>Terme 1</dt>
+		<dd>Définition du terme 1</dd>
+		<dt>Terme 2</dt>
+		<dd>Définition du terme 2</dd>
 	</dl>
-	<pre><code>// Data list
+	<pre><code>// Liste de données
 	&lt;dl&gt;
 
-	// Data term:
+	// Terme de données:
 	<strong>&lt;dt&gt;</strong>...&lt;/dt&gt;
 
-	// Data definition:
+	// Définition de données
 	<strong>&lt;dd&gt;</strong>...&lt;/dd&gt;
 	&lt;/dl&gt;</code></pre>
 
-	<h2>Unstyled lists </h2>
-	<p>Unstyled list:</p>
+	<h2>Listes non stylées</h2>
+	<p>Liste non stylée:</p>
 	<ul class="list-unstyled">
-		<li>List item 1</li>
-		<li>List item 2
+		<li>Item 1</li>
+		<li>Item 2
 		<ul>
-			<li>List item 2a</li>
-			<li>List item 2b</li>
+			<li>Item 2a</li>
+			<li>Item 2b</li>
 		</ul>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ul>
-	<p>Unstyled nested list:</p>
+	<p>Listes imbriquées non stylées:</p>
 	<ul>
-		<li>List item 1</li>
-		<li>List item 2
+		<li>Item 1</li>
+		<li>Item 2
 		<ul class="lst-none">
-			<li>List item 2a</li>
-			<li>List item 2b</li>
+			<li>Item 2a</li>
+			<li>Item 2b</li>
 		</ul>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ul>
 	<h3>Code</h3>
-	<pre><code>//Unstyled list:
+	<pre><code>//Liste non stylée:
 	&lt;ul <strong>class=&quot;list-unstyled&quot;</strong>&gt;
 		&lt;li&gt;...&lt;/li&gt;
 	&lt;/ul&gt;
 
-	//Unstyled nested list:
+	//Liste imbriquée non stylée:
 	&lt;ul&gt;
-		&lt;li&gt;List item 1
+		&lt;li&gt;Item 1
 			&lt;ul <strong>class=&quot;lst-none&quot;</strong>&gt;
-				&lt;li&gt;List item 1a&lt;/li&gt;
-				&lt;li&gt;List item 1b&lt;/li&gt;
+				&lt;li&gt;Item 1a&lt;/li&gt;
+				&lt;li&gt;Item 1b&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h2> Numbered lists </h2>
+	<h2>Listes numérotées</h2>
 	<ol>
-		<li>List item 1</li>
+		<li>Item 1</li>
 		<li>
-			List item 2
+			Item 2
 			<ol class="lst-num">
-				<li>List item 2a</li>
-				<li>List item 2b</li>
+				<li>Item 2a</li>
+				<li>Item 2b</li>
 			</ol>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ol>
 	<h3>Code</h3>
 	<pre><code>&lt;ol&gt;
@@ -111,17 +110,17 @@
 	&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2>Alpha lists − Lower alpha </h2>
+	<h2>Listes alphabétiques − minuscules</h2>
 	<ol>
-		<li>List item 1</li>
+		<li>Item 1</li>
 		<li>
-			List item 2
+			Item 2
 			<ol class="lst-lwr-alph">
-				<li>List item 2a</li>
-				<li>List item 2b</li>
+				<li>Item 2a</li>
+				<li>Item 2b</li>
 			</ol>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ol>
 	<h3>Code</h3>
 	<pre><code>&lt;ol&gt;
@@ -133,34 +132,34 @@
 	&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2> Alpha lists − Upper alpha</h2>
+	<h2>Listes alphabétiques − majuscules</h2>
 	<ol class="lst-upr-alph">
-		<li>List item 1</li>
+		<li>Item 1</li>
 		<li>
-			List item 2
+			Item 2
 			<ol>
-				<li>List item 2a</li>
-				<li>List item 2b</li>
+				<li>Item 2a</li>
+				<li>Item 2b</li>
 			</ol>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ol>
 	<h3>Code</h3>
 	<pre><code>&lt;ol <strong>class=&quot;lst-upr-alph&quot;</strong>&gt;
 	&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2>Roman numeral − Lower Roman </h2>
+	<h2>Chiffres romains − minuscules</h2>
 	<ol>
-		<li>List item 1</li>
+		<li>Item 1</li>
 		<li>
-			List item 2
+			Item 2
 			<ol class="lst-lwr-rmn">
-				<li>List item 2a</li>
-				<li>List item 2b</li>
+				<li>Item 2a</li>
+				<li>Item 2b</li>
 			</ol>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ol>
 	<h3>Code</h3>
 	<pre><code>&lt;ol&gt;
@@ -172,80 +171,80 @@
 	&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2> Roman numeral − Upper Roman </h2>
+	<h2>Chiffres romains − majuscules </h2>
 	<ol class="lst-upr-rmn">
-		<li>List item 1</li>
+		<li>Item 1</li>
 		<li>
-			List item 2
+			Item 2
 			<ol>
-				<li>List item 2a</li>
-				<li>List item 2b</li>
+				<li>Item 2a</li>
+				<li>Item 2b</li>
 			</ol>
 		</li>
-		<li>List item 3</li>
+		<li>Item 3</li>
 	</ol>
 	<h3>Code</h3>
 	<pre><code>&lt;ol<strong> class=&quot;lst-upr-rmn&quot;</strong>&gt;
 		&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2> List inline </h2>
+	<h2>Liste en ligne</h2>
 	<ul class="list-inline">
-		<li>List item 1</li>
-		<li>List item 2</li>
-		<li>List item 3</li>
+		<li>Item 1</li>
+		<li>Item 2</li>
+		<li>Item 3</li>
 	</ul>
 	<h3>Code</h3>
 	<pre><code>&lt;ol <strong>class=&quot;list-inline&quot;</strong>&gt;
 		&lt;li&gt;...&lt;/li&gt;
 	&lt;/ol&gt;</code></pre>
 
-	<h2> Spacing lists - spaces added</h2>
+	<h2>Listes avec espacement ajouté</h2>
 	<ul class="lst-spcd">
-		<li>List item 1</li>
-		<li>List item 2</li>
-		<li>List item 3</li>
+		<li>Item 1</li>
+		<li>Item 2</li>
+		<li>Item 3</li>
 	</ul>
 	<h3>Code</h3>
-	<pre><code>// Spaced list:
+	<pre><code>// Liste éspacée:
 	&lt;ul <strong>class=&quot;lst-spcd&quot;</strong>&gt;
-	&lt;li&gt;List item 1&lt;/li&gt;
-	&lt;li&gt;List item 2&lt;/li&gt;
-	&lt;li&gt;List item 3&lt;/li&gt;
+	&lt;li&gt;Item 1&lt;/li&gt;
+	&lt;li&gt;Item 2&lt;/li&gt;
+	&lt;li&gt;Item 3&lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h2> Definition lists − horizontal layout </h2>
+	<h2>Listes de définitions – disposition horizontale</h2>
 	<dl class="dl-horizontal">
-		<dt>Term 1</dt>
-		<dd>Definition of term 1</dd>
-		<dt>Term 2</dt>
-		<dd>Definition of term 2</dd>
+		<dt>Terme 1</dt>
+		<dd>Définition du terme 1</dd>
+		<dt>Terme 2</dt>
+		<dd>Définition du terme 2</dd>
 	</dl>
-	<p> With no border</p>
+	<p>Sans bordure</p>
 	<dl class="dl-horizontal brdr-0">
-		<dt>Term 1</dt>
-		<dd>Definition of term 1</dd>
-		<dt>Term 2</dt>
-		<dd>Definition of term 2</dd>
+		<dt>Terme 1</dt>
+		<dd>Définition du terme 1</dd>
+		<dt>Terme 2</dt>
+		<dd>Définition du terme 2</dd>
 	</dl>
 	<h3>Code</h3>
 	<pre><code>&lt;dl <strong>class=&quot;dl-horizontal&quot;</strong>&gt;
 	&lt;dt&gt;...&lt;/dt&gt;
 	&lt;dd&gt;...&lt;/dd&gt;
 	&lt;/dl&gt;
-	//With no border
+	//Sans bordure
 	&lt;dl <strong>class=&quot;dl-horizontal brdr-0&quot;</strong>&gt;
 	&lt;dt&gt;...&lt;/dt&gt;
 	&lt;dd&gt;...&lt;/dd&gt;
 	&lt;/dl&gt;</code></pre>
 
-	<h2> List columns </h2>
+	<h2>Listes en colonnes</h2>
 	<ul>
 		<li><code>.colcount-xxs-2</code>, <code>.colcount-xs-2</code>, <code>.colcount-sm-2</code>, <code>.colcount-md-2</code>, <code>.colcount-lg-2</code>, <code>.colcount-xl-2</code></li>
 		<li><code>.colcount-xxs-3</code>, <code>.colcount-xs-3</code>, <code>.colcount-sm-3</code>, <code>.colcount-md-3</code>, <code>.colcount-lg-3</code>, <code>.colcount-xl-3</code></li>
 		<li><code>.colcount-xxs-4</code>, <code>.colcount-xs-4</code>, <code>.colcount-sm-4</code>, <code>.colcount-md-4</code>, <code>.colcount-lg-4</code>, <code>.colcount-xl-4</code></li>
 	</ul>
-	<h3> Appearance − Two columns</h3>
+	<h3>Disposition – deux colonnes</h3>
 	<ul class="colcount-sm-2">
 		<li>Item 1</li>
 		<li>Item 2</li>
@@ -263,7 +262,7 @@
 	&lt;li&gt;Item 8&lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h3> Appearance − Three columns</h3>
+	<h3>Disposition – trois colonnes</h3>
 	<ul class="colcount-sm-3">
 		<li>Item 1</li>
 		<li>Item 2</li>
@@ -274,14 +273,14 @@
 		<li>Item 7</li>
 		<li>Item 8</li>
 	</ul>
-	<h4> code </h4>
+	<h4>code</h4>
 	<pre><code>&lt;ul <strong>class=&quot;colcount-sm-3&quot;</strong>&gt;
 	&lt;li&gt;Item 1&lt;/li&gt;
 	...
 	&lt;li&gt;Item 8&lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h3> Appearance − Four columns</h3>
+	<h3>Disposition – quatre colonnes</h3>
 	<ul class="colcount-sm-4">
 		<li>Item 1</li>
 		<li>Item 2</li>
@@ -298,7 +297,7 @@
 	&lt;li&gt;Item 8&lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h3> Appearance − Multi-class</h3>
+	<h3>Disposition − Multi-classes</h3>
 	<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4">
 		<li>Item 1</li>
 		<li>Item 2</li>
@@ -315,77 +314,158 @@
 	&lt;li&gt;Item 8&lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h2>Responsive list <code>.list-responsive</code></h2>
+	<h3><code>.colcount-no-break</code></h3>
+	<p>Empêche les éléments de liste de se séparer à travers plusieurs colonnes de liste.</p>
+	<h4>Liste sans ordre</h4>
+	<h5>Exemple pratique</h5>
+	<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+	<li>Item 1<br>Ligne 2<br>Ligne 3</li>
+	<li>Item 2<br>Ligne 2<br>Ligne 3</li>
+	<li>Item 3</li>
+	<li>Item 4<br>Ligne 2<br>Ligne 3</li>
+	<li>Item 5<br>Ligne 2<br>Ligne 3</li>
+	<li>Item 6<br>Ligne 2</li>
+	<li>Item 7<br>Ligne 2</li>
+	<li>Item 8</li>
+	</ul>
+	<h5>code</h5>
+	<pre><code><span class="tag">&lt;ul</span><span class="pln"> </span><span class="atn">class</span><span class="pun">=</span><span class="atv">"colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"</span><span class="tag">&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 1</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 4</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 5</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 3</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 6</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 7</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+		</span><span class="tag">&lt;li&gt;</span><span class="pln">Item 8</span><span class="tag">&lt;/li&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/ul&gt;</span></code></pre>
+	<h4>Liste de descriptions</h4>
+	<h5>Exemple pratique</h5>
+	<dl class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+	<div>
+	<dt>Terme 1</dt>
+	<dd>Description</dd>
+	</div>
+	<div>
+	<dt>Terme 2</dt>
+	<dd>Description<br>Ligne 2<br>Ligne 3</dd>
+	</div>
+	<div>
+	<dt>Terme 3</dt>
+	<dd>Description<br>Ligne 2<br>Ligne 3</dd>
+	</div>
+	<div>
+	<dt>Terme 4</dt>
+	<dd>Description<br>Ligne 2</dd>
+	</div>
+	<div>
+	<dt>Terme 5</dt>
+	<dd>Description<br>Ligne 2</dd>
+	</div>
+	<div>
+	<dt>Terme 6</dt>
+	<dd>Description</dd>
+	</div>
+	</dl>
+	<h5>code</h5>
+	<pre><code><span class="tag">&lt;dl</span><span class="pln"> </span><span class="atn">class</span><span class="pun">=</span><span class="atv">"colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"</span><span class="tag">&gt;</span><span class="pln">
+		</span><span class="tag">&lt;div&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dt&gt;</span><span class="pln">Terme 1</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+		</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;div&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dt&gt;</span><span class="pln">Terme 2</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 3</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+		</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;div&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dt&gt;</span><span class="pln">Terme 3</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 3</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+		</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;div&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dt&gt;</span><span class="pln">Terme 4</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+		</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;div&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dt&gt;</span><span class="pln">Terme 5</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;br&gt;</span><span class="pln">Ligne 2</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+		</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+		</span><span class="tag">&lt;div&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dt&gt;</span><span class="pln">Terme 6</span><span class="tag">&lt;/dt&gt;</span><span class="pln">
+			</span><span class="tag">&lt;dd&gt;</span><span class="pln">Description</span><span class="tag">&lt;/dd&gt;</span><span class="pln">
+		</span><span class="tag">&lt;/div&gt;</span><span class="pln">
+	</span><span class="tag">&lt;/dl&gt;</span></code></pre>
+
+	<h2>Liste responsive<code>.list-responsive</code></h2>
 	<ul class="wb-eqht list-unstyled mrgn-tp-md mrgn-bttm-sm lst-spcd-2 list-responsive">
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
 	</ul>
 	<h3>code</h3>
 	<pre><code>&lt;ul class="<strong>list-responsive</strong>"&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
 	&lt;/ul&gt;
 	</code></pre>
 
-	<h2>List - Additional styles - GCWeb theme V5</h2>
-	<h3>List double spaced <code>.lst-spcd-2</code></h3>
+	<h2>Liste - Styles additionnels - GCWeb thème V5</h2>
+	<h3>Liste double interligne <code>.lst-spcd-2</code></h3>
 	<ul class="lst-spcd-2">
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
 	</ul>
 	<h4>code</h4>
 	<pre><code>&lt;ul class="lst-spcd-2"&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
 	&lt;/ul&gt;</code></pre>
 
-	<h3>Lists in columns <code>.list-col-[breakpoint]-[columns]</code></h3>
+	<h3>Listes en colonnes <code>.list-col-[breakpoint]-[colonnes]</code></h3>
 	<ul class="list-col-xs-1 list-col-sm-2 list-col-md-3 list-col-lg-4">
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
-		<li>Item</li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
+		<li>Item </li>
 	</ul>
 	<h4>code</h4>
 	<pre><code>&lt;ul class="<strong>list-col-xs-1 list-col-sm-2 list-col-md-3 list-col-lg-4</strong>"&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
-	&lt;li&gt;Item&lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
+	&lt;li&gt;Item &lt;/li&gt;
 	&lt;/ul&gt;
 	</code></pre>
 </div>
 
 <h2 id="dl-inline">Liste descriptive en ligne</h2>
-<p>List descriptive en ligne utilisée pour afficher des termes et descriptions courts.</p>
+<p>Liste descriptive en ligne utilisée pour afficher des termes et descriptions courts.</p>
 
 <dl class="dl-inline">
 	<dt>Terme&nbsp;:</dt>

--- a/components/list/list-fr.html
+++ b/components/list/list-fr.html
@@ -49,7 +49,7 @@
 	<li>Item</li>
 	<li>Item</li>
 </ul>
-<h3>Source code</h3>
+<h3>Code source</h3>
 <pre><code>
 &lt;ul class="<strong>list-col-xs-1 list-col-sm-2 list-col-md-3 list-col-lg-4</strong>"&gt;
 	&lt;li&gt;Item&lt;/li&gt;

--- a/templates/all-services/all-services-doc-en.html
+++ b/templates/all-services/all-services-doc-en.html
@@ -3,7 +3,7 @@ title: All services
 description: Documentation for the all services page template.
 language: en
 altLangPage: all-services-doc-fr.html
-dateModified: 2025-07-04
+dateModified: 2025-08-29
 layout: documentation
 index_json: index.json-ld
 ---

--- a/templates/all-services/all-services-doc-fr.html
+++ b/templates/all-services/all-services-doc-fr.html
@@ -3,7 +3,7 @@ title: Tous les services
 description: Documentation du gabarit de page de tous les services.
 language: fr
 altLangPage: all-services-doc-en.html
-dateModified: 2025-07-04
+dateModified: 2025-08-29
 layout: documentation
 index_json: index.json-ld
 ---

--- a/templates/all-services/all-services-en.html
+++ b/templates/all-services/all-services-en.html
@@ -3,7 +3,7 @@
 "title": "Government of Canada services",
 "language": "en",
 "altLangPage": "all-services-fr.html",
-"dateModified": "2025-07-24",
+"dateModified": "2025-08-29",
 "layout": "no-container",
 "css": ["https://use.fontawesome.com/releases/v5.8.1/css/all.css"]
 }
@@ -19,16 +19,15 @@
 <section class="bg-light mt-3 pb-3">
 	<div class="container">
 		<h2 class="h3 mb-4">Top searches</h2>
-		<ul class="list-unstyled colcount-md-3 compact bold-content lst-spcd-2 fnt-hdng">
+		<ul class="list-unstyled colcount-md-3 colcount-no-break compact bold-content lst-spcd-2 fnt-hdng">
 			<li><a href="https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html">Canadian Dental Care Plan</a></li>
 			<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports.html">Passports</a></li>
-			<li><a href="https://www.canada.ca/en/revenue-agency/services/forms-publications/forms/rc518.html">RC 518 Declaration of Tax Residence for Individuals</a></li>
-			<li><a href="https://www.canada.ca/en/employment-social-development/services/sin.html">Social insurance number (SIN)</a></li>
-			<li><a href="https://www.canada.ca/en/services/benefits/publicpensions.html">Public pensions (CPP, OAS, GIS)</a></li>
-			<li><a href="https://www.canada.ca/en/employment-social-development/services/my-account/find-pac.html">Personal Access Code (PAC) for My Service Canada Account</a></li>
-			<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/eta.html">Electronic travel authorization (eTA)</a></li>
-			<li><a href="https://www.canada.ca/en/employment-social-development/programs/ei/ei-list/ei-roe.html">Record of employment (ROE)</a></li>
-			<li><a href="https://www.canada.ca/en/health-canada/services/health-cards.html">Provincial and territorial health cards</a></li>
+			<li><a href="https://www.canada.ca/en/services/benefits/ei.html">Employment Insurance and leave</a></li>
+			<li><a href="https://www.canada.ca/en/employment-social-development/services/sin.html">Social insurance number (<abbr>SIN</abbr>)</a></li>
+			<li><a href="https://www.canada.ca/en/services/benefits/publicpensions.html">Public pensions (<abbr title="Canada Pension Plan">CPP</abbr>, <abbr title="Old Age Security Pension">OAS</abbr>, <abbr title="Guaranteed Income Supplement">GIS</abbr>)</a></li>
+			<li><a href="https://www.canada.ca/en/employment-social-development/services/my-account/find-pac.html">Personal Access Code (<abbr>PAC</abbr>) for My Service Canada Account</a></li>
+			<li><a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/eta.html">Electronic travel authorization (<abbr>eTA</abbr>)</a></li>
+			<li><a href="https://www.canada.ca/en/employment-social-development/programs/ei/ei-list/ei-roe.html">Record of employment (<abbr>ROE</abbr>)</a></li>
 		</ul>
 	</div>
 </section>
@@ -36,7 +35,7 @@
 <section class="pb-3">
 	<div class="container">
 		<h2 class="h3 mb-4">Most requested services</h2>
-		<ul class="list-unstyled colcount-md-3 compact bold-content lst-spcd-2 fnt-hdng">
+		<ul class="list-unstyled colcount-md-3 colcount-no-break compact bold-content lst-spcd-2 fnt-hdng">
 			<li><a href="https://www.canada.ca/en/government/sign-in-online-account.html">Sign in to an account</a></li>
 			<li><a href="https://www.canada.ca/en/government/change-address.html">Change your address</a></li>
 			<li><a href="https://www.canada.ca/en/public-services-procurement/services/payments-to-from-government/direct-deposit.html">Set up or change your direct deposit</a></li>
@@ -50,7 +49,7 @@
 <section class="bg-light pb-3">
 	<div class="container">
 		<h2 class="h3 mb-4">Manage life events</h2>
-		<ul class="list-unstyled colcount-md-3 compact bold-content lst-spcd-2 fnt-hdng">
+		<ul class="list-unstyled colcount-md-3 colcount-no-break compact bold-content lst-spcd-2 fnt-hdng">
 			<li><a href="https://www.canada.ca/en/services/life-events/child.html">Welcoming a child</a></li>
 			<li><a href="https://www.canada.ca/en/services/retirement.html">Learn and plan for your retirement</a></li>
 			<li><a href="https://www.canada.ca/en/services/death.html">What to do when someone dies</a></li>

--- a/templates/all-services/all-services-fr.html
+++ b/templates/all-services/all-services-fr.html
@@ -3,7 +3,7 @@
 "title": "Government of Canada services",
 "language": "fr",
 "altLangPage": "all-services-en.html",
-"dateModified": "2025-07-24",
+"dateModified": "2025-08-29",
 "layout": "no-container",
 "css": ["https://use.fontawesome.com/releases/v5.8.1/css/all.css"]
 }
@@ -19,16 +19,15 @@
 <section class="bg-light mt-3 pb-3">
 	<div class="container">
 		<h2 class="h3 mb-4">Recherches les plus populaires</h2>
-		<ul class="list-unstyled colcount-md-3 compact bold-content lst-spcd-2 fnt-hdng">
+		<ul class="list-unstyled colcount-md-3 colcount-no-break compact bold-content lst-spcd-2 fnt-hdng">
 			<li><a href="https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html">Régime canadien de soins dentaires</a></li>
 			<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens.html">Passeports</a></li>
-			<li><a href="https://www.canada.ca/fr/agence-revenu/services/formulaires-publications/formulaires/rc518.html">RRC518 Déclaration de résidence aux fins de l'impôt pour les particuliers</a></li>
-			<li><a href="https://www.canada.ca/fr/emploi-developpement-social/services/numero-assurance-sociale.html">Numéro d'assurance sociale (NAS)</a></li>
-			<li><a href="https://www.canada.ca/fr/services/prestations/pensionspubliques.html">Pensions publiques (RPC, SV, SRG)</a></li>
-			<li><a href="https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier/trouvez-code.htm">Code d’accès personnel (CAP) pour Mon dossier Service Canada</a></li>
-			<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/visiter-canada/ave.html">Autorisation de voyage électronique (AVE)</a></li>
-			<li><a href="https://www.canada.ca/fr/emploi-developpement-social/programmes/assurance-emploi/ae-liste/assurance-emploi-re.html">Relevé d’emploi (RE)</a></li>
-			<li><a href="https://www.canada.ca/fr/sante-canada/services/cartes-sante.html">Cartes santé provinciales et territoriales</a></li>
+			<li><a href="https://www.canada.ca/fr/services/prestations/ae.html">Assurance-emploi et congés</a></li>
+			<li><a href="https://www.canada.ca/fr/emploi-developpement-social/services/numero-assurance-sociale.html">Numéro d'assurance sociale (<abbr>NAS</abbr>)</a></li>
+			<li><a href="https://www.canada.ca/fr/services/prestations/pensionspubliques.html">Pensions publiques (<abbr title="Régime de pensions du Canada">RPC</abbr>, <abbr title="Sécurité de la vieillesse">SV</abbr>, <abbr title="Supplément de revenu garanti">SRG</abbr>)</a></li>
+			<li><a href="https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier/trouvez-code.html">Code d’accès personnel (<abbr>CAP</abbr>) pour Mon dossier Service Canada</a></li>
+			<li><a href="https://www.canada.ca/fr/immigration-refugies-citoyennete/services/visiter-canada/ave.html">Autorisation de voyage électronique (<abbr>AVE</abbr>)</a></li>
+			<li><a href="https://www.canada.ca/fr/emploi-developpement-social/programmes/assurance-emploi/ae-liste/assurance-emploi-re.html">Relevé d’emploi (<abbr>RE</abbr>)</a></li>
 		</ul>
 	</div>
 </section>
@@ -36,7 +35,7 @@
 <section class="pb-3">
 	<div class="container">
 		<h2 class="h3 mb-4">Services les plus demandés</h2>
-		<ul class="list-unstyled colcount-md-3 compact bold-content lst-spcd-2 fnt-hdng">
+		<ul class="list-unstyled colcount-md-3 colcount-no-break compact bold-content lst-spcd-2 fnt-hdng">
 			<li><a href="https://www.canada.ca/fr/gouvernement/ouvrir-session-dossier-compte-en-ligne.html">Se connecter à un compte</a></li>
 			<li><a href="https://www.canada.ca/fr/gouvernement/changement-adresse.html">Changement d'adresse</a></li>
 			<li><a href="https://www.tpsgc-pwgsc.gc.ca/recgen/txt/depot-deposit-fra.html">S'inscrire ou modifier vos informations de dépôt direct</a></li>
@@ -50,7 +49,7 @@
 <section class="bg-light pb-3">
 	<div class="container">
 		<h2 class="h3 mb-4">Gérer les événements de la vie</h2>
-		<ul class="list-unstyled colcount-md-3 compact bold-content lst-spcd-2 fnt-hdng">
+		<ul class="list-unstyled colcount-md-3 colcount-no-break compact bold-content lst-spcd-2 fnt-hdng">
 			<li><a href="https://www.canada.ca/fr/services/evenements-vie/enfant.html">Accueillir un enfant</a></li>
 			<li><a href="https://www.canada.ca/fr/services/retraite.html">Apprendre et planifier pour votre retraite</a></li>
 			<li><a href="https://www.canada.ca/fr/services/evenements-vie/deces.html">Que faire lors d'un décès</a></li>

--- a/templates/all-services/index.json-ld
+++ b/templates/all-services/index.json-ld
@@ -14,10 +14,10 @@
 		"en": "All services page template.",
 		"fr": "Gabarit de page pour tous les services."
 	},
-	"modified": "2025-07-24",
+	"modified": "2025-08-29",
 	"componentName": "all-services",
 	"status": "stable",
-	"version": "1.2",
+	"version": "1.3",
 	"pages": {
 		"examples": [
 			{
@@ -56,7 +56,7 @@
 				"en": "All services page template.",
 				"fr": "Gabarit de page pour tous les services."
 			},
-			"iteration": "_:iteration_allservices_3",
+			"iteration": "_:iteration_allservices_4",
 			"example": [
 				{
 					"en": { "href": "all-services-en.html", "text": "All services" },
@@ -67,6 +67,10 @@
 				"_:implement_allservices"
 			],
 			"history": [
+				{
+					"en": "August 2025 - Use the class \".colcount-no-break\" to prevent list items from splitting across multiple columns.",
+					"fr": "Août 2025 - Utilisation de la classe « .colcount-no-break » pour empêcher les éléments de liste de se diviser en plusieurs colonnes."
+				},
 				{
 					"en": "July 2025 - Remove expand and collapse All buttons.",
 					"fr": "Juillet 2025 - Suppression des boutons « Développer » et « Réduire »."
@@ -81,7 +85,7 @@
 	"implementation": [
 		{
 			"@id": "_:implement_allservices",
-			"iteration": "_:iteration_allservices_3",
+			"iteration": "_:iteration_allservices_4",
 			"name": {
 				"en": "Standard",
 				"fr": "Standard"
@@ -107,13 +111,21 @@
 	],
 	"iteration": [
 		{
+			"@id": "_:iteration_allservices_4",
+			"name": "All services page - Iteration 4",
+			"date": "2025-08",
+			"additions": [ "Use the class \".colcount-no-break\" to prevent list items from splitting across multiple columns." ],
+			"detectableBy": "Three navigation bands each whose list container has the class \".colcount-no-break\" followed by a Services and Information component containing a list of all themes and topics.",
+			"predecessor": "_:iteration_allservices_3"
+		},
+		{
 			"@id": "_:iteration_allservices_3",
 			"name": "All services page - Iteration 3",
 			"date": "2025-07",
 			"additions": [ "Removing expand/collapse all buttons." ],
 			"detectableBy": "Three navigation bands followed by a Services and Information component containing a list of all themes and topics.",
 			"predecessor": "_:iteration_allservices_2",
-			"successor": "_:iteration_allservices_3"
+			"successor": "_:iteration_allservices_4"
 		},
 		{
 			"@id": "_:iteration_allservices_2",


### PR DESCRIPTION
After working on the ticket [WET-563](https://jtickets.atlassian.net/browse/WET-563), it was noticed that the **.colcount-no-break** class is not present in the documentation for the list component in GCWeb, this PR is to fix that.