### PR TITLE
SVG overflow at 320px screen width (WCAG 1.4.10) on theme-src.min.css pages

### DIFF
--- a/sites/servermessage/_screen.scss
+++ b/sites/servermessage/_screen.scss
@@ -10,7 +10,8 @@
 
 #gcwu-sig,
 #wmms {
-	height: 1.7em;
+	height: 2em;
+	max-width: 100%;
 }
 
 #wmms {


### PR DESCRIPTION
Issue discovered during automated accessibility testing using Playwright, targeting WCAG 1.4.10 (Reflow). On the test page 404 template, the SVG was overflowing the viewport at 320px width, violating reflow requirements for small screens.

The fix involved reducing the font size from `2em` to `1.7em`, which allowed the SVG to scale appropriately within the available space and eliminated the horizontal overflow.

Test page : https://wet-boew.github.io/GCWeb/templates/servermessage/404-en-fr.html

Before fix (overflowing SVG):
<img width="588" height="207" alt="image" src="https://github.com/user-attachments/assets/fa42aae6-1f7b-455f-9282-e60f8d5b3665" />

After fix (no overflow):
<img width="592" height="216" alt="image" src="https://github.com/user-attachments/assets/603ba2d8-288e-44b7-837d-6b0194dc703f" />
