### PR TITLE
Build(deps-dev): Bump stylelint-config-standard-scss from 15.0.1 to 16.0.0

### DIFF
--- a/_data/components.json
+++ b/_data/components.json
@@ -2001,10 +2001,10 @@
 		"en": "Features top tasks related to the page it is on.",
 		"fr": "Comprend des tâches principales liées à la page sur laquelle elles se trouvent."
 	},
-	"modified": "2025-05-08",
+	"modified": "2025-09-29",
 	"componentName": "gc-most-requested",
 	"status": "stable",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"pages": {
 		"docs": [
 			{
@@ -2028,6 +2028,16 @@
 				"title": "En demande",
 				"language": "fr",
 				"path": "gc-most-requested-fr.html"
+			},
+			{
+				"title": "Most requested - Two items",
+				"language": "en",
+				"path": "gc-most-requested-two-items-en.html"
+			},
+			{
+				"title": "En demande - Deux éléments",
+				"language": "fr",
+				"path": "gc-most-requested-two-items-fr.html"
 			},
 			{
 				"title": "Most requested - bad implementation",
@@ -2057,11 +2067,15 @@
 				"en": "https://design.canada.ca/common-design-patterns/most-requested.html",
 				"fr": "https://conception.canada.ca/configurations-conception-communes/en-demande.html"
 			},
-			"iteration": "_:iteration_mostrequested_2",
+			"iteration": "_:iteration_mostrequested_3",
 			"example": [
 				{
 					"en": { "href": "gc-most-requested-en.html", "text": "Most requested" },
 					"fr": { "href": "gc-most-requested-fr.html", "text": "En demande" }
+				},
+								{
+					"en": { "href": "gc-most-requested-two-items-en.html", "text": "Most requested - Two items" },
+					"fr": { "href": "gc-most-requested-two-items-fr.html", "text": "En demande - Deux éléments" }
 				},
 				{
 					"en": { "href": "gc-most-requested-bad-en.html", "text": "Most requested - bad implementation" },
@@ -2072,6 +2086,10 @@
 				"_:implement_mostrequested"
 			],
 			"history": [
+				{
+					"en": "September 2025 - Items are displayed horizontally when there are only two list items on medium screen breakpoint and larger.",
+					"fr": "Septembre 2025 - Les éléments sont affichés horizontalement quand il y a seulement deux éléments de liste à partir d'un breakpoint écran moyen et plus."
+				},
 				{
 					"en": "May 2025 - Items are now distributed vertically instead of horizontally.",
 					"fr": "Mai 2025 - Les items sont maintenant distribués verticalement plutôt que horizontalement."
@@ -2137,11 +2155,30 @@
 	],
 	"iteration": [
 		{
+			"@id": "_:iteration_mostrequested_3",
+			"name": "Most requested - Iteration 3",
+			"date": "2025-09",
+			"detectableBy": ".gc-most-requested:not(.provisional)",
+			"predecessor": "_:iteration_mostrequested_2",
+			"additions": [
+				"Changed display of list items from vertical to horizontal when there are only two list items on medium screen breakpoint and larger. This does not change the component's core behaviour, so this is a Minor change."
+			],
+			"assets": [
+				{
+					"@type": "source-code",
+					"@language": "en",
+					"description": "Code sample",
+					"code": "<section class=\"gc-most-requested\">\n\t<div class=\"container\">\n\t\t<h2>Most requested</h2>\n\t\t<ul>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 1]</a></li>\n\t\t\t<li><a href=\"#\">[Top task hyperlink 2]</a></li>\n\t\t</ul>\n\t</div>\n</section>"
+				}
+			]
+		},
+		{
 			"@id": "_:iteration_mostrequested_2",
 			"name": "Most requested - Iteration 2",
 			"date": "2024-11",
 			"detectableBy": ".gc-most-requested:not(.provisional)",
 			"predecessor": "_:iteration_mostrequested_1",
+			"successor": "_:iteration_mostrequested_3",
 			"additions": [
 				"Changed display of items from flex to column-count. This change is perceptible and a user will notice that change but it won't change the component essential behaviour. So this is a Minor change."
 			],

--- a/components/baseline/_alert.scss
+++ b/components/baseline/_alert.scss
@@ -1,13 +1,11 @@
 
 // Removes styling from the current WET4 Alert
 %alert-first-child-before-disable {
-	& {
-		> {
-			:first-child {
-				&::before {
-					color: inherit;
-					content: none;
-				}
+	> {
+		:first-child {
+			&::before {
+				color: inherit;
+				content: none;
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "postcss": "^8.5.6",
         "sass": "^1.93.2",
         "stylelint": "^16.24.0",
-        "stylelint-config-standard-scss": "^15.0.1",
+        "stylelint-config-standard-scss": "^16.0.0",
         "stylelint-order": "^7.0.0",
         "time-grunt": "^2.0.0"
       },
@@ -3999,8 +3999,7 @@
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
       "integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4929,8 +4928,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.6",
@@ -4985,7 +4983,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       },
@@ -5729,9 +5726,9 @@
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-16.0.0.tgz",
-      "integrity": "sha512-4RSmPjQegF34wNcK1e1O3Uz91HN8P1aFdFzio90wNK9mjgAI19u5vsU868cVZboKzCaa5XbpvtTzAAGQAxpcXA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-17.0.0.tgz",
+      "integrity": "sha512-WaMSdEiPfZTSFVoYmJbxorJfA610O0tlYuU2aEwY33UQhSPgFbClrVJYWvy3jGJx+XW37O+LyNLiZOEXhKhJmA==",
       "dev": true,
       "funding": [
         {
@@ -5743,31 +5740,29 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.16.0"
+        "stylelint": "^16.23.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-15.0.1.tgz",
-      "integrity": "sha512-V24bxkNkFGggqPVJlP9iXaBabwSGEG7QTz+PyxrRtjPkcF+/NsWtB3tKYvFYEmczRkWiIEfuFMhGpJFj9Fxe6Q==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-16.0.1.tgz",
+      "integrity": "sha512-wfpU6kmTUwPEHMACYdpt5wLM/aS44+sqE8yk82LkOkA7yVpAuTZDwd3m9762d0mRnNCn0JMUx4XfDVDmbb8hTA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "postcss-scss": "^4.0.9",
-        "stylelint-config-recommended": "^16.0.0",
-        "stylelint-scss": "^6.12.0"
+        "stylelint-config-recommended": "^17.0.0",
+        "stylelint-scss": "^6.12.1"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.16.0"
+        "stylelint": "^16.23.1"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -5776,9 +5771,9 @@
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "38.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-38.0.0.tgz",
-      "integrity": "sha512-uj3JIX+dpFseqd/DJx8Gy3PcRAJhlEZ2IrlFOc4LUxBX/PNMEQ198x7LCOE2Q5oT9Vw8nyc4CIL78xSqPr6iag==",
+      "version": "39.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-39.0.0.tgz",
+      "integrity": "sha512-JabShWORb8Bmc1A47ZyJstran60P3yUdI1zWMpGYPeFiC6xzHXJMkpKAd8EjIhq3HPUplIWWMDJ/xu0AiPd+kA==",
       "dev": true,
       "funding": [
         {
@@ -5790,33 +5785,31 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended": "^16.0.0"
+        "stylelint-config-recommended": "^17.0.0"
       },
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.18.0"
+        "stylelint": "^16.23.0"
       }
     },
     "node_modules/stylelint-config-standard-scss": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-15.0.1.tgz",
-      "integrity": "sha512-8pmmfutrMlPHukLp+Th9asmk21tBXMVGxskZCzkRVWt1d8Z0SrXjUUQ3vn9KcBj1bJRd5msk6yfEFM0UYHBRdg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-16.0.0.tgz",
+      "integrity": "sha512-/FHECLUu+med/e6OaPFpprG86ShC4SYT7Tzb2PTVdDjJsehhFBOioSlWqYFqJxmGPIwO3AMBxNo+kY3dxrbczA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended-scss": "^15.0.1",
-        "stylelint-config-standard": "^38.0.0"
+        "stylelint-config-recommended-scss": "^16.0.1",
+        "stylelint-config-standard": "^39.0.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.18.0"
+        "stylelint": "^16.23.1"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -5842,11 +5835,10 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.0.tgz",
-      "integrity": "sha512-U7CKhi1YNkM1pXUXl/GMUXi8xKdhl4Ayxdyceie1nZ1XNIdaUgMV6OArpooWcDzEggwgYD0HP/xIgVJo9a655w==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
+      "integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
@@ -5869,17 +5861,15 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
-      "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
-      "dev": true,
-      "license": "CC0-1.0"
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.24.0.tgz",
+      "integrity": "sha512-i97fklrJl03tL1tdRVw0ZfLLvuDsdb6wxL+TrJ+PKkCbLrp2PCu2+OYdCKychIUm19nSM/35S6qz7pJpnXttoA==",
+      "dev": true
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postcss": "^8.5.6",
     "sass": "^1.93.2",
     "stylelint": "^16.24.0",
-    "stylelint-config-standard-scss": "^15.0.1",
+    "stylelint-config-standard-scss": "^16.0.0",
     "stylelint-order": "^7.0.0",
     "time-grunt": "^2.0.0"
   }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -82,6 +82,7 @@ module.exports = {
 				"no-duplicate-selectors": null,
 				"no-irregular-whitespace": null,
 				"number-max-precision": null,
+				"property-no-deprecated": null,
 				"property-no-vendor-prefix": null,
 				"rule-empty-line-before": null,
 				"selector-attribute-quotes": null,
@@ -117,6 +118,7 @@ module.exports = {
 				"no-descending-specificity": null, // Extremely slow
 				"no-invalid-position-at-import-rule": null, // Fixable, need to run sass migrator
 				"number-max-precision": null,
+				"property-no-deprecated": null,
 				"scss/at-extend-no-missing-placeholder": null,
 				"scss/comment-no-empty": null,
 				"scss/dollar-variable-pattern": null, // Fixable


### PR DESCRIPTION
Bumps stylelint-config-standard-scss from 15.0.1 to 16.0.0. Includes a small fix in alerts to make the linting pass.

Supersedes #2649
