### PR TITLE
News: Add closing alt quotes to docs' deprecated code sample

### DIFF
--- a/templates/news/news-doc-en.html
+++ b/templates/news/news-doc-en.html
@@ -3,7 +3,7 @@ title: Documentation about News template
 description: Documentation and working examples for the News template.
 language: en
 altLangPage: news-doc-fr.html
-dateModified: 2025-05-26
+dateModified: 2025-10-14
 share: true
 ---
 
@@ -79,20 +79,20 @@ share: true
 		&lt;div class="wb-tabs carousel-s2 show-thumbs playing slow"&gt;
 			&lt;ul role="tablist"&gt;
 				&lt;li class="active"&gt;
-					&lt;a href="#tab1"&gt;&lt;img src="./img/promos/1170x347-1.png" alt="&gt;&lt;span class="wb-inv"&gt;Tab 1: Banff National Park&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#tab1"&gt;&lt;img src="./img/promos/1170x347-1.png" alt=""&gt;&lt;span class="wb-inv"&gt;Tab 1: Banff National Park&lt;/span&gt;&lt;/a&gt;
 				&lt;/li&gt;
 				&lt;li&gt;
-					&lt;a href="#tab2"&gt;&lt;img src="./img/promos/1170x347-2.png" alt="&gt;&lt;span class="wb-inv"&gt;Tab 2: Algonquin Provincial Park&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#tab2"&gt;&lt;img src="./img/promos/1170x347-2.png" alt=""&gt;&lt;span class="wb-inv"&gt;Tab 2: Algonquin Provincial Park&lt;/span&gt;&lt;/a&gt;
 				&lt;/li&gt;
 				&lt;li&gt;
-					&lt;a href="#tab3"&gt;&lt;img src="./img/promos/1170x347-3.png" alt="&gt;&lt;span class="wb-inv"&gt;Tab 3: Rideau Canal&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#tab3"&gt;&lt;img src="./img/promos/1170x347-3.png" alt=""&gt;&lt;span class="wb-inv"&gt;Tab 3: Rideau Canal&lt;/span&gt;&lt;/a&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 			&lt;div class="tabpanels"&gt;
 				&lt;div role="tabpanel" id="tab1" class="in fade"&gt;
 					&lt;a href="#" class="learnmore"&gt;
 						&lt;figure&gt;
-							&lt;img src="./img/promos/1170x347-1.png" alt="&gt;
+							&lt;img src="./img/promos/1170x347-1.png" alt=""&gt;
 							&lt;figcaption&gt;
 								&lt;p&gt;Banff National Park &lt;/p&gt;
 							&lt;/figcaption&gt;
@@ -102,7 +102,7 @@ share: true
 				&lt;div role="tabpanel" id="tab2" class="out fade"&gt;
 					&lt;a href="#" class="learnmore"&gt;
 						&lt;figure&gt;
-							&lt;img src="./img/promos/1170x347-2.png" alt="&gt;
+							&lt;img src="./img/promos/1170x347-2.png" alt=""&gt;
 							&lt;figcaption&gt;
 								&lt;p&gt;Algonquin Provincial Park &lt;/p&gt;
 							&lt;/figcaption&gt;
@@ -112,7 +112,7 @@ share: true
 				&lt;div role="tabpanel" id="tab3" class="out fade"&gt;
 					&lt;a href="#" class="learnmore"&gt;
 						&lt;figure&gt;
-							&lt;img src="./img/promos/1170x347-3.png" alt="&gt;
+							&lt;img src="./img/promos/1170x347-3.png" alt=""&gt;
 							&lt;figcaption&gt;
 								&lt;p&gt;Rideau Canal &lt;/p&gt;
 							&lt;/figcaption&gt;

--- a/templates/news/news-doc-fr.html
+++ b/templates/news/news-doc-fr.html
@@ -3,7 +3,7 @@ title: Documentation au sujet de la page de nouvelles
 description: Documentation et exemple pratique des pages de nouvelles.
 language: fr
 altLangPage: news-doc-en.html
-dateModified: 2025-05-26
+dateModified: 2025-10-14
 share: true
 ---
 
@@ -79,20 +79,20 @@ share: true
 		&lt;div class="wb-tabs carousel-s2 show-thumbs playing slow"&gt;
 			&lt;ul role="tablist"&gt;
 				&lt;li class="active"&gt;
-					&lt;a href="#tab1"&gt;&lt;img src="./img/promos/1170x347-1.png" alt="&gt;&lt;span class="wb-inv"&gt;Tab 1: Banff National Park&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#tab1"&gt;&lt;img src="./img/promos/1170x347-1.png" alt=""&gt;&lt;span class="wb-inv"&gt;Tab 1: Banff National Park&lt;/span&gt;&lt;/a&gt;
 				&lt;/li&gt;
 				&lt;li&gt;
-					&lt;a href="#tab2"&gt;&lt;img src="./img/promos/1170x347-2.png" alt="&gt;&lt;span class="wb-inv"&gt;Tab 2: Algonquin Provincial Park&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#tab2"&gt;&lt;img src="./img/promos/1170x347-2.png" alt=""&gt;&lt;span class="wb-inv"&gt;Tab 2: Algonquin Provincial Park&lt;/span&gt;&lt;/a&gt;
 				&lt;/li&gt;
 				&lt;li&gt;
-					&lt;a href="#tab3"&gt;&lt;img src="./img/promos/1170x347-3.png" alt="&gt;&lt;span class="wb-inv"&gt;Tab 3: Rideau Canal&lt;/span&gt;&lt;/a&gt;
+					&lt;a href="#tab3"&gt;&lt;img src="./img/promos/1170x347-3.png" alt=""&gt;&lt;span class="wb-inv"&gt;Tab 3: Rideau Canal&lt;/span&gt;&lt;/a&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 			&lt;div class="tabpanels"&gt;
 				&lt;div role="tabpanel" id="tab1" class="in fade"&gt;
 					&lt;a href="#" class="learnmore"&gt;
 						&lt;figure&gt;
-							&lt;img src="./img/promos/1170x347-1.png" alt="&gt;
+							&lt;img src="./img/promos/1170x347-1.png" alt=""&gt;
 							&lt;figcaption&gt;
 								&lt;p&gt;Banff National Park &lt;/p&gt;
 							&lt;/figcaption&gt;
@@ -102,7 +102,7 @@ share: true
 				&lt;div role="tabpanel" id="tab2" class="out fade"&gt;
 					&lt;a href="#" class="learnmore"&gt;
 						&lt;figure&gt;
-							&lt;img src="./img/promos/1170x347-2.png" alt="&gt;
+							&lt;img src="./img/promos/1170x347-2.png" alt=""&gt;
 							&lt;figcaption&gt;
 								&lt;p&gt;Algonquin Provincial Park &lt;/p&gt;
 							&lt;/figcaption&gt;
@@ -112,7 +112,7 @@ share: true
 				&lt;div role="tabpanel" id="tab3" class="out fade"&gt;
 					&lt;a href="#" class="learnmore"&gt;
 						&lt;figure&gt;
-							&lt;img src="./img/promos/1170x347-3.png" alt="&gt;
+							&lt;img src="./img/promos/1170x347-3.png" alt=""&gt;
 							&lt;figcaption&gt;
 								&lt;p&gt;Rideau Canal &lt;/p&gt;
 							&lt;/figcaption&gt;


### PR DESCRIPTION
The deprecated code sample failed HTML validation due to the lack of closing quotes in its ``alt`` attributes... and could mess-up MWS page templates if copied/pasted into it.