### PR TITLE
Carousel overrides (xxs): Fix selectors, flexbox refinements

### DIFF
--- a/components/tabs/_screen-xxs-max.scss
+++ b/components/tabs/_screen-xxs-max.scss
@@ -6,15 +6,20 @@
 	.wb-tabs.carousel-s2 {
 		[role="tablist"] {
 			li {
-				.plypause {
+				&.plypause {
+					margin-top: 7px;
+
 					a {
 						font-size: 1em;
+						padding-bottom: 7.5px;
+						padding-top: 7.5px;
 						vertical-align: middle;
 					}
 				}
 
-				.tab-count {
+				&.tab-count {
 					height: 0;
+					margin-right: 0;
 					visibility: hidden;
 					width: 0;
 


### PR DESCRIPTION
Specifically:
* Related to the deprecated layout code sample in the news template's documentation (``templates/news/news-doc-en.html`` and ``templates/news/news-doc-fr.html``):
  * Also used by the old campaign page template (https://web.archive.org/web/20210417054958/https://wet-boew.github.io/themes-dist/GCWeb/campaign-en.html)
* Add ``&`` prefixes to ``.plypause`` and ``.tab-count``'s selector rules:
  * Those selectors previously used ``&``, but were accidentally removed in #675 (in ``src/sass/parts/_carousel-xxSmallView.scss``)... which broke them from that point onward
* Add additional properties to align with wet-boew/wet-boew#10055's changes

**Screenshots (Firefox, 320px screen width):**
* **Without wet-boew/wet-boew#10055's changes:**
  * **Before:**
    <img width="320" height="240" alt="gcweb-tabs-xxs-before" src="https://github.com/user-attachments/assets/f159aa35-f2b8-4221-a440-3edafec14f40" />
  * **After:**
    <img width="320" height="240" alt="gcweb-tabs-xxs-after" src="https://github.com/user-attachments/assets/2edb59fd-3c92-4a0c-be72-c3e12ee39165" />
* **With wet-boew/wet-boew#10055's changes:**
  * **Before:**
    <img width="320" height="240" alt="gcweb-tabs-xxs-before-pr-10055" src="https://github.com/user-attachments/assets/8eb08b5a-81d9-4bb4-98fd-3e8ecad0a1c6" />
  * **After (this is how it'll look once everything is said and done):**
    <img width="320" height="240" alt="gcweb-tabs-xxs-after-pr-10055" src="https://github.com/user-attachments/assets/de613aa8-806d-4602-9147-9f114f85dbea" />