### PR TITLE
Authentication: Fixing typo in French page breadcrumb

### DIFF
--- a/sites/authentication/activeusersession-fr.html
+++ b/sites/authentication/activeusersession-fr.html
@@ -2,7 +2,7 @@
 {
 	"altLangPage": "activeusersession-en.html",
 	"breadcrumb": {
-		"title": "Canada.ca", "link": "https://www.canada.ca/en.html"
+		"title": "Canada.ca", "link": "https://www.canada.ca/fr.html"
 	},
 	"dateModified": "2023-03-28",
 	"description": "Exemple d'une session utilisateur active.",


### PR DESCRIPTION
Related to: WET-598 & #2546 
Authentication: Fixing typo in the link for the French page breadcrumb