### PR TITLE
Addition of a GCDS page layout to GCWeb

### DIFF
--- a/_data/templates.json
+++ b/_data/templates.json
@@ -448,6 +448,222 @@
 		"modified": "dct:modified"
 	},
 	"title": {
+		"en": "GCDS Layout",
+		"fr": "Disposition GCDS"
+	},
+	"description": {
+		"en": "Page layout using the GCDS header and footer components.",
+		"fr": "Disposition de la page utilisant les composants d'en-tête et de pied de page GCDS."
+	},
+	"modified": "2025-11-17",
+	"componentName": "gcds-layout",
+	"status": "stable",
+	"version": "1.0",
+	"pages": {
+		"examples": [
+			{
+				"title": "GCDS Layout - Core",
+				"language": "en",
+				"path": "gcds-layout-core-en.html"
+			},
+			{
+				"title": "Disposition GCDS - Essentiel",
+				"language": "fr",
+				"path": "gcds-layout-core-fr.html"
+			},
+			{
+				"title": "GCDS Layout - Complete",
+				"language": "en",
+				"path": "gcds-layout-complete-en.html"
+			},
+			{
+				"title": "Disposition GCDS - Complet",
+				"language": "fr",
+				"path": "gcds-layout-complete-fr.html"
+			}
+		],
+		"docs": [
+			{
+				"title": "GCDS Layout",
+				"language": "en",
+				"path": "gcds-layout-doc-en.html"
+			},
+			{
+				"title": "Disposition GCDS",
+				"language": "fr",
+				"path": "gcds-layout-doc-fr.html"
+			}
+		]
+	},
+	"a11yGuidance": "No accessibility guidance.",
+	"variations": [
+		{
+			"name": {
+				"en": "GCDS Layout",
+				"fr": "Disposition GCDS"
+			},
+			"status": "stable",
+			"description": {
+				"en": "Page template leveraging the GCDS header and footer components.",
+				"fr": "Gabarit de page utilisant les composants d'en-tête et de pied de page GCDS."
+			},
+			"iteration": "_:iteration_gcdslayout_1",
+			"example": [
+				{
+					"en": { "href": "gcds-layout-core-en.html", "text": "GCDS Layout - Core" },
+					"fr": { "href": "gcds-layout-core-fr.html", "text": "Disposition GCDS - Essentiel" }
+				},
+				{
+					"en": { "href": "gcds-layout-complete-en.html", "text": "GCDS Layout - Complete" },
+					"fr": { "href": "gcds-layout-complete-fr.html", "text": "Disposition GCDS - Complet" }
+				}
+			],
+			"implementation": [
+				"_:implement_gcdslayout",
+				"_:implement_gcdslayout_dev"
+			],
+			"history": [
+				{
+					"en": "November 2025 - Initial implementation of the page template.",
+					"fr": "Novembre 2025 - Implémentation initiale du gabarit de page."
+				}
+			]
+		}
+	],
+	"implementation": [
+		{
+			"@id": "_:implement_gcdslayout",
+			"iteration": "_:iteration_gcdslayout_1",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the template manually and wanting to use the new GCDS components.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le gabarit manuellement et souhaitent utiliser les nouveaux composants GCDS."
+
+			},
+			"instructions": {
+				"en": [
+					"Refer to the <a href=\"https://design-system.alpha.canada.ca\" target=\"_blank\">GCDS documentation</a> and examples for more information on implementing the components used in this page template."
+				],
+				"fr": [
+					"Référez-vous à <a href=\"https://systeme-design.alpha.canada.ca/fr/\" target=\"_blank\">la documentation GCDS</a> et aux exemples pour plus d'informations sur l'implémentation des composants utilisés dans ce gabarit."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "GCDS Layout - Core",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\"></gcds-header>\n\n...\n\n<gcds-footer display=\"compact\"></gcds-footer>"
+					},
+					{
+						"@type": "source-code",
+						"description": "GCDS Layout - Complete",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\">\n\t<gcds-search slot=\"search\"></gcds-search>\n\t<gcds-topic-menu slot=\"menu\"></gcds-topic-menu>\n\t<gcds-breadcrumbs slot=\"breadcrumb\" class=\"mt-2\">\n\t\t<gcds-breadcrumbs-item href=\"#\">GCWeb</gcds-breadcrumbs-item>\n\t</gcds-breadcrumbs>\n</gcds-header>\n\n...\n\n<gcds-footer\n\tdisplay=\"full\"\n\tcontextual-heading=\"Contextual navigation\"\n\tcontextual-links='{\"Context link 1\": \"#\", \"Context link 2\": \"#\", \"Context link 3\": \"#\"}'\n\tsub-links='{\"Custom sublink 1\": \"#\", \"Custom sublink 2\": \"#\", \"Custom sublink 3\": \"#\", \"Terms and conditions\": \"#\", \"Privacy\": \"#\"}'>\n</gcds-footer>"					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Disposition GCDS - Essentiel",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\"></gcds-header>\n\n...\n\n<gcds-footer display=\"compact\"></gcds-footer>"
+
+					},
+					{
+						"@type": "source-code",
+						"description": "Disposition GCDS - Complet",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\">\n\t<gcds-search slot=\"search\"></gcds-search>\n\t<gcds-topic-menu slot=\"menu\"></gcds-topic-menu>\n\t<gcds-breadcrumbs slot=\"breadcrumb\" class=\"mt-2\">\n\t\t<gcds-breadcrumbs-item href=\"#\">GCWeb</gcds-breadcrumbs-item>\n\t</gcds-breadcrumbs>\n</gcds-header>\n\n...\n\n<gcds-footer\n\tdisplay=\"full\"\n\tcontextual-heading=\"Navigation contextuelle\"\n\tcontextual-links='{\"Lien contextuel 1\": \"#\", \"Lien contextuel 2\": \"#\", \"Lien contextuel 3\": \"#\"}'\n\tsub-links='{\"Sous-lien personnalisé 1\": \"#\", \"Sous-lien personnalisé 2\": \"#\", \"Sous-lien personnalisé 3\": \"#\", \"Avis\": \"#\", \"Confidentialité\": \"#\"}'>\n</gcds-footer>"
+					}
+				]
+			}
+		},
+		{
+			"@id": "_:implement_gcdslayout_dev",
+			"iteration": "_:iteration_gcdslayout_1",
+			"name": {
+				"en": "GCWeb Jekyll",
+				"fr": "GCWeb Jekyll"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers trying to implement this layout within a GCWeb Jekyll site. To apply the optional components of the header and/or footer on any given page, you will need to do the following in the page's front matter:",
+				"fr": "Cette implémentation est destinée aux développeurs essayant d'implémenter ce composant dans un site GCWeb Jekyll. Pour appliquer les composants optionnels de l’en-tête et/ou du pied de page sur une page donnée, vous devrez procéder comme suit dans le front-matter de la page :"
+			},
+			"instructions": {
+				"en": [
+					"To implement the GCDS layout, simply set the <code>layout</code> property to <code>gcds</code>.",
+					"If the page being migrated to GCDS layout used the <code>no-container</code> layout previously, set the <code>noContainer</code> property to <code>true</code> to maintain the same layout.",
+					"To add custom sublinks to the footer, add a <code>customSublinks</code> object with the desired link texts and urls.",
+					"To see more examples of optional properties that can be used with the GCDS layout, refer to the source code of the individual components (i.e. <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/header/includes/gcds-header.html\" target=\"_blank\">gcds-header</a> and <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/footers/includes/gcds-footer.html\" target=\"_blank\">gcds-footer</a>)."
+				],
+				"fr": [
+					"Pour appliquer la disposition GCDS, définissez simplement la variable <code>layout</code> à <code>gcds</code>.",
+					"Si la page en cours de migration vers la disposition GCDS utilisait précédemment la mise en page <code>no-container</code>, définissez la variable <code>noContainer</code> à <code>true</code> pour conserver la même mise en page.",
+					"Pour ajouter des sous-liens personnalisés au pied de page, ajoutez un objet <code>customSublinks</code> avec les textes et les URL des liens souhaités.",
+					"Pour voir plus d'exemples de propriétés optionnelles qui peuvent être utilisées avec la disposition GCDS, consultez le code source des composants individuels (i.e. <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/header/includes/gcds-header.html\" target=\"_blank\">gcds-header</a> et <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/footers/includes/gcds-footer.html\" target=\"_blank\">gcds-footer</a>)."
+				]
+
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Using \"noContainer\" with the GCDS Layout",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"noContainer\": true\n\t...\n}\n---"
+
+
+					},
+					{
+						"@type": "source-code",
+						"description": "Using custom sublinks with the GCDS Layout",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"customSublinks\": {\n\t\t\"links\": [\n\t\t\t{\"url\": \"#\", \"text\": \"Custom sublink 1\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Custom sublink 2\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Custom sublink 3\"}\n\t\t]\n\t},\n\t...\n}\n---"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Utilisation de « noContainer » avec la disposition GCDS",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"noContainer\": true\n\t...\n}\n---"
+
+					},
+					{
+						"@type": "source-code",
+						"description": "Utlisation de sous-liens personnalisés avec la disposition GCDS",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"customSublinks\": {\n\t\t\"links\": [\n\t\t\t{\"url\": \"#\", \"text\": \"Sous-lien personnalisé 1\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Sous-lien personnalisé 2\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Sous-lien personnalisé 3\"}\n\t\t]\n\t},\n\t...\n}\n---"
+					}
+				]
+			}
+		}
+	],
+	"iteration": [
+		{
+			"@id": "_:iteration_gcdslayout_1",
+			"name": "GCDS Layout - Iteration 1",
+			"date": "2025-11",
+			"detectableBy": "<gcds-header> and <gcds-footer> components"
+		}
+	],
+	"changesets": [
+		{
+			"@id": "_:cs_gcdslayout",
+			"name": "GCDS Layout",
+			"status": "stable",
+			"detectableBy": "<gcds-header> and <gcds-footer> components",
+			"layout": "Not applicable",
+			"semantic": "Not applicable",
+			"notes": "Not applicable"
+		}
+	]
+}
+,{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
 		"en": "Home",
 		"fr": "Accueil"
 	},

--- a/_data/wet-boew.json
+++ b/_data/wet-boew.json
@@ -1351,7 +1351,7 @@
 	},
 	"modified": "2024-07-10",
 	"componentName": "paginate",
-	"status": "provisional",
+	"status": "stable",
 	"pages": {
 		"examples": [
 			{

--- a/common/scaffolding/_base.scss
+++ b/common/scaffolding/_base.scss
@@ -46,6 +46,12 @@ h6, .h6 {
 	line-height: 1.45;
 }
 
+/* Remove top margin from main page title when gcds-header is present
+   This will need to be revisted when we integrate the GCDS header fully */
+
+body:has(gcds-header) h1#wb-cont {
+	margin-top: 0;
+}
 
 /* Forms */
 

--- a/index-en.md
+++ b/index-en.md
@@ -223,7 +223,7 @@ css:
           <div class="modal-body">
             <div class="mx-3">
               <p>{{ template.description[ page.language ] | default: '[Short description of the template]' }}</p>
-              <a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>View source code</a>
+              <a href="https://github.com/wet-boew/GCWeb/tree/master/templates/{{ template.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>View source code</a>
                 {% for pgGroup in list-pages %}
                 {% assign grpkey = pgGroup[0] %}
               <h3 class="h6">{{ page_group[ grpkey ] | default: "Unknown group" }}</h3>
@@ -415,7 +415,7 @@ css:
         <div class="modal-body">
           <div class="mx-3">
           <p>{{ item.description[ page.language ] | default: '[Short description of the Canada.ca core component]' }}</p>
-          <a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>View source code</a>
+          <a href="https://github.com/wet-boew/GCWeb/tree/master/sites/{{ item.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>View source code</a>
             {% for pgGroup in list-pages %}
             {% assign grpkey = pgGroup[0] %}
             <h3 class="h6">{{ page_group[ grpkey ] | default: "Unknown group" }}</h3>
@@ -516,7 +516,7 @@ css:
           <div class="modal-body">
             <div class="mx-3">
               <p>{{ item.description[ page.language ] | default: '[Short description of the common component]' }}</p>
-              <a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>View source code</a>
+              <a href="https://github.com/wet-boew/GCWeb/tree/master/common/{{ item.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>View source code</a>
               {% for pgGroup in list-pages %}
               {% assign grpkey = pgGroup[0] %}
               <h3 class="h6">{{ page_group[ grpkey ] | default: "Unknown group" }}</h3>

--- a/index-fr.md
+++ b/index-fr.md
@@ -230,7 +230,7 @@ css:
 <div class="modal-body">
 <div class="mx-3">
 <p>{{ template.description[ page.language ] | default: '[Courte description du gabarit]' }}</p>
-<a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
+<a href="https://github.com/wet-boew/GCWeb/tree/master/templates/{{ template.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
 {% for pgGroup in list-pages %}
 {% assign grpkey = pgGroup[0] %}
 <h3 class="h6">{{ page_group[ grpkey ] | default: "Groupe inconnu" }}</h3>
@@ -324,7 +324,7 @@ css:
 <div class="modal-body">
 <div class="mx-3">
 <p>{{ designPattern.description[ page.language ] | default: '[Courte description des configurations de conception]' }}</p>
-<a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
+<a href="https://github.com/wet-boew/GCWeb/tree/master/design-patterns/{{ designPattern.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
 {% for pgGroup in list-pages %}
 {% assign grpkey = pgGroup[0] %}
 <h3 class="h6">{{ page_group[ grpkey ] | default: "Groupe inconnu" }}</h3>
@@ -432,7 +432,7 @@ css:
 <div class="modal-body">
 <div class="mx-3">
 <p>{{ item.description[ page.language ] | default: "[Courte description de la fonctionnalité globale]" }}</p>
-<a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
+<a href="https://github.com/wet-boew/GCWeb/tree/master/sites/{{ item.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
 {% for pgGroup in list-pages %}
 {% assign grpkey = pgGroup[0] %}
 <h3 class="h6">{{ page_group[ grpkey ] | default: "Groupe inconnu" }}</h3>
@@ -537,7 +537,7 @@ css:
         <div class="modal-body">
           <div class="mx-3">
             <p>{{ item.description[ page.language ] | default: "[Courte description de la fonctionnalité commune]" }}</p>
-            <a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
+            <a href="https://github.com/wet-boew/GCWeb/tree/master/common/{{ item.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
             {% for pgGroup in list-pages %}
               {% assign grpkey = pgGroup[0] %}
             <h3 class="h6">{{ page_group[ grpkey ] | default: "Groupe inconnu" }}</h3>
@@ -641,7 +641,7 @@ css:
         <div class="modal-body">
           <div class="mx-3">
             <p>{{ wetboew.description[ page.language ] | default: "[Courte description de wetboew]" }}</p>
-            <a href="https://github.com/wet-boew/GCWeb/tree/master/components/{{ component.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
+            <a href="https://github.com/wet-boew/GCWeb/tree/master/wet-boew/{{ wetboew.componentName }}" hreflang="en"><span class="fas fa-code small mrgn-rght-sm" aria-hidden="true"></span>Voir le code source</a>
             {% for pgGroup in list-pages %}
               {% assign grpkey = pgGroup[0] %}
             <h3 class="h6">{{ page_group[ grpkey ] | default: "Groupe inconnu" }}</h3>

--- a/sites/breadcrumbs/includes/gcds-breadcrumbs.html
+++ b/sites/breadcrumbs/includes/gcds-breadcrumbs.html
@@ -1,0 +1,20 @@
+<gcds-breadcrumbs slot="breadcrumb" class="mt-2">
+	{%- unless page.overwriteBreadcrumbs -%}
+		{%- if site.global.breadcrumbs -%}
+			{% for breadcrumb in site.global.breadcrumbs[i18nText-lang] %}
+				<gcds-breadcrumbs-item
+					href="{% unless breadcrumb.link contains 'http' or breadcrumb.link contains '../' %}{{ setting-siteBasePath }}{% endunless %}{{ breadcrumb.link }}">
+					{{ breadcrumb.title }}
+				</gcds-breadcrumbs-item>
+			{%- endfor -%}
+		{% endif %}
+	{%- endunless -%}
+	{%- if page.breadcrumbs -%}
+		{% for breadcrumb in page.breadcrumbs %}
+			<gcds-breadcrumbs-item
+			href="{% unless breadcrumb.link contains 'http' or breadcrumb.link contains '../' %}{{ setting-siteBasePath }}{% endunless %}{{ breadcrumb.link }}">
+			{{ breadcrumb.title }}
+			</gcds-breadcrumbs-item>
+		{%- endfor -%}
+	{% endif %}
+</gcds-breadcrumbs>

--- a/sites/footers/includes/gcds-footer.html
+++ b/sites/footers/includes/gcds-footer.html
@@ -1,0 +1,61 @@
+{% capture contextLinks %}
+	{% if page.contextualFooter and page.contextualFooter.links %}
+	{
+		{% for link in page.contextualFooter.links %}
+		"{{ link.text }}": "{{ link.url }}"{% if forloop.last == false %},{% endif %}
+		{% endfor %}
+	}
+	{% endif %}
+{% endcapture %}
+
+{%- capture termsUrl -%}
+	{%- if page.termsUrl -%}
+		{{ page.termsUrl }}
+	{%- elsif site.global.termsUrl[i18nText-lang] -%}
+		{{ site.global.termsUrl[i18nText-lang] }}
+	{%- else -%}
+		{{ i18nText-termsUrl }}
+	{%- endif -%}
+{%- endcapture -%}
+
+{%- capture privacyUrl -%}
+	{%- if page.privacyUrl -%}
+		{{ page.privacyUrl }}
+	{%- elsif site.global.privacyUrl[i18nText-lang] -%}
+		{{ site.global.privacyUrl[i18nText-lang] }}
+	{%- else -%}
+		{{ i18nText-privacyUrl }}
+	{%- endif -%}
+{%- endcapture -%}
+
+{% capture customSublinks %}
+	{% if page.customSublinks and page.customSublinks.links %}
+	{
+		{% for link in page.customSublinks.links %}
+			"{{ link.text }}": "{{ link.url }}",
+		{% endfor %}
+		{% if i18nText-lang == "en" %}
+			"Terms and conditions": "{{ termsUrl }}",
+			"Privacy": "{{ privacyUrl }}"
+		{% else %}
+			"Avis": "{{ termsUrl }}",
+			"Confidentialité": "{{ privacyUrl }}"
+		{% endif %}
+	}
+	{% endif %}
+{% endcapture %}
+
+<gcds-footer id="footer"
+{% unless page.noFooterMain %}
+	display="full"
+{% endunless %}
+{% unless page.noFooterContextual or layout.noFooterContextual %}
+	{% if contextualFooterTitle != "" and page.contextualFooter.links %}
+		contextual-heading="{{ page.contextualFooter.title }}"
+		contextual-links='{{ contextLinks }}'
+	{% endif %}
+{% endunless %}
+{% if page.customSublinks and page.customSublinks.links %}
+	sub-links='{{ customSublinks }}'
+{% endif %}>
+</gcds-footer>

--- a/sites/header/includes/gcds-header.html
+++ b/sites/header/includes/gcds-header.html
@@ -1,0 +1,13 @@
+<gcds-header lang-href="{{ page.altLangPage }}" skip-to-href="#wb-cont">
+	{% unless page.nositesearch %}
+	<gcds-search slot="search"></gcds-search>
+	{% endunless %}
+	{% unless page.nomenu %}
+	{% if page.sitemenuPath or site.global.sitemenuPath and site.global.sitemenuPath.first %}
+	<gcds-topic-menu slot="menu"></gcds-topic-menu>
+	{% endif %}
+	{% endunless %}
+	{% unless page.breadcrumbs == false %}
+		{% include breadcrumbs/gcds-breadcrumbs.html %}
+	{% endunless %}
+</gcds-header>

--- a/sites/layouts/gcds.html
+++ b/sites/layouts/gcds.html
@@ -1,0 +1,44 @@
+{%- include variable-core.liquid -%}
+{%- capture page-title -%}
+{%- if page.title -%}
+{{ page.title }}
+{%- else -%}
+Page untitled
+{%- endif -%}
+{%- endcapture -%}
+
+<!DOCTYPE html>
+<html class="no-js" lang="{{ i18nText-lang | default: 'en' }}" dir="{{ i18nText-langDir | default: 'ltr' }}">
+
+<head>
+	<meta charset="utf-8">
+	{% include license.html %}
+	<title>{{ page-title }} - {{ i18nText-siteTitle }}</title>
+	<meta content="width=device-width, initial-scale=1" name="viewport">
+	{% include metadata.html %}
+	{% include resources-inc/head.html %}
+</head>
+
+<body {% if page.pageclass %}class="{{ page.pageclass }}"{% endif %} vocab="http://schema.org/" typeof="WebPage">
+	{% include header/gcds-header.html %}
+	<main {% unless page.noContainer %}class="container"{% endunless %}
+		property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+
+	<!-- Check if the page has a hard coded h1 title -->
+	{% assign normalizedContent = content | downcase %}
+	{% assign hasH1Title = false %}
+	{% if normalizedContent contains 'id="wb-cont"' %}
+		{% assign hasH1Title = true %}
+	{% endif %}
+	<!-- Unless the page has a hard coded h1 title, include the main page title. -->
+	{% unless hasH1Title %}
+		{% include main-page-title/main-page-title.html %}
+	{% endunless %}
+	{{ content }}
+	{% include page-details/footer.html addContainer=page.noContainer %}
+
+	</main>
+	{% include footers/gcds-footer.html %}
+	{% include resources-inc/footer.html %}
+</body>
+</html>

--- a/sites/resources-inc/head.html
+++ b/sites/resources-inc/head.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.css">
 <script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@{{ gcds-version }}/dist/gcds/gcds.esm.js"></script>
 {% endif %}
-{%- if page.loadGCDS -%}
+{%- if page.loadGCDS or page.layout == "gcds" -%}
 <script blocking="render" src="{{ setting-resourcesBasePathTheme }}/js/gcdsloader{{ setting-minifiedSuffix }}.js"></script>
 {% endif %}
 

--- a/templates/gcds-layout/gcds-layout-complete-en.html
+++ b/templates/gcds-layout/gcds-layout-complete-en.html
@@ -1,0 +1,67 @@
+---
+{
+	"title": "GCDS Layout - Complete",
+	"language": "en",
+	"category": "templates",
+	"altLangPage": "gcds-layout-complete-fr.html",
+	"dateModified": "2025-11-17",
+	"layout": "gcds",
+	"contextualFooter": {
+		"title": "Contextual navigation",
+		"links": [
+			{"url": "#", "text": "Context link 1"},
+			{"url": "#", "text": "Context link 2"},
+			{"url": "#", "text": "Context link 3"}
+		]
+	},
+	"customSublinks": {
+		"links": [
+			{"url": "#", "text": "Custom sublink 1"},
+			{"url": "#", "text": "Custom sublink 2"},
+			{"url": "#", "text": "Custom sublink 3"}
+		]
+	}
+}
+---
+
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
+{% include web-contents/placeholdercontent-en.html %}
+<h2 id="cnt-wdth-lmtd">Section with limited width content</h2>
+<p>
+	Add the CSS class name <code>.cnt-wdth-lmtd</code> to a sectioning element
+	<code>&lt;section class="cnt-wdth-lmtd"&gt;...&lt;section&gt;</code> inside
+	the main content of your page. More guidance are provided in the Content and
+	IA specification.
+</p>
+<section class="cnt-wdth-lmtd">
+	<h3>Section example with limited width content</h3>
+	<p>
+		Different example text. Different example text. Different example text.
+		Different example text. Different example text. Different example text.
+		Different example text. Different example text. This is a very long word
+		pneumonoultramicroscopicsilicovolcanoconiosis.
+	</p>
+</section>
+<h2 id="call-to-action">Call to action button</h2>
+<p>
+	Add the CSS class name <code>.btn-call-to-action</code> to a your button or
+	link that define the main call for action for a page. For example the
+	initiation button/link in a service initiation pages. More guidance are
+	provided in the Content and IA specification.
+</p>
+<div class="row">
+	<div class="col-sm-6">
+		<h3>Link</h3>
+		<p class="mrgn-bttm-0">
+			<a class="btn btn-call-to-action" href="#">[Call to action]</a>
+		</p>
+		<pre><code>&lt;p&gt;&lt;a class="btn <strong>btn-call-to-action</strong>" href="#"&gt;[Call to action]&lt;/a&gt;&lt;/p&gt;</code></pre>
+	</div>
+	<div class="col-sm-6">
+		<h3>Button</h3>
+		<button class="btn btn-call-to-action" type="button">
+			[Call to action]
+		</button>
+		<pre><code>&lt;button class="btn <strong>btn-call-to-action</strong>" type="button"&gt;[Call to action]&lt;/button&gt;</code></pre>
+	</div>
+</div>

--- a/templates/gcds-layout/gcds-layout-complete-fr.html
+++ b/templates/gcds-layout/gcds-layout-complete-fr.html
@@ -1,0 +1,70 @@
+---
+{
+	"title": "Disposition GCDS - Complet",
+	"language": "fr",
+	"category": "templates",
+	"altLangPage": "gcds-layout-complete-en.html",
+	"dateModified": "2025-11-17",
+	"layout": "gcds",
+	"contextualFooter": {
+		"title": "Navigation contextuelle",
+		"links": [
+			{"url": "#", "text": "Lien contextuel 1"},
+			{"url": "#", "text": "Lien contextuel 2"},
+			{"url": "#", "text": "Lien contextuel 3"}
+		]
+	},
+	"customSublinks": {
+		"links": [
+			{"url": "#", "text": "Sous-lien personnalisé 1"},
+			{"url": "#", "text": "Sous-lien personnalisé 2"},
+			{"url": "#", "text": "Sous-lien personnalisé 3"}
+		]
+	}
+}
+---
+
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
+{% include web-contents/placeholdercontent-fr.html %}
+<h2 id="cnt-wdth-lmtd">Section avec une largeur de contenu limitée</h2>
+<p>
+	Ajouter la classe CSS <code>.cnt-wdth-lmtd</code> à l'élément de section
+	<code>&lt;section class="cnt-wdth-lmtd"&gt;...&lt;section&gt;</code> à
+	l'intérieur du contenu principal de votre page. De plus amples
+	renseignements sont disponibles dans la spécification du contenu et de
+	l'architecture de l'information pour Canada.ca.
+</p>
+<section class="cnt-wdth-lmtd">
+	<h3>Exemple de section avec une largeur de contenu limitée</h3>
+	<p>
+		Exemple de texte différent. Exemple de texte différent. Exemple de texte
+		différent. Exemple de texte différent. Exemple de texte différent.
+		Exemple de texte différent. Exemple de texte différent. Exemple de texte
+		différent. Ceci est un très long mot
+		intergouvernementalisationsintergouvernementalisations.
+	</p>
+</section>
+<h2 id="call-to-action">Bouton d'appel à l'action</h2>
+<p>
+	Ajouter la classe CSS <code>.btn-call-to-action</code> à votre bouton ou
+	lien qui définie l'appel à l'action principal de la page. Par example le
+	bouton ou le lien de lancement d'une page de lancements d'un service. De
+	plus amples renseignements sont disponibles dans la spécification du contenu
+	et de l'architecture de l'information pour Canada.ca.
+</p>
+<div class="row">
+	<div class="col-sm-6">
+		<h3>Lien</h3>
+		<p class="mrgn-bttm-0">
+			<a class="btn btn-call-to-action" href="#">[Appel à l'action]</a>
+		</p>
+		<pre><code>&lt;p&gt;&lt;a class="btn <strong>btn-call-to-action</strong>" href="#"&gt;[Appel à l'action]&lt;/a&gt;&lt;/p&gt;</code></pre>
+	</div>
+	<div class="col-sm-6">
+		<h3>Bouton</h3>
+		<button class="btn btn-call-to-action" type="button">
+			[Appel à l'action]
+		</button>
+		<pre><code>&lt;button class="btn <strong>btn-call-to-action</strong>" type="button"&gt;[Appel à l'action]&lt;/button&gt;</code></pre>
+	</div>
+</div>

--- a/templates/gcds-layout/gcds-layout-core-en.html
+++ b/templates/gcds-layout/gcds-layout-core-en.html
@@ -1,0 +1,56 @@
+---
+{
+	"title": "GCDS Layout - Core",
+	"language": "en",
+	"category": "templates",
+	"altLangPage": "gcds-layout-core-fr.html",
+	"dateModified": "2025-11-17",
+	"layout": "gcds",
+	"breadcrumbs": false,
+	"nomenu": true,
+	"nositesearch": true,
+	"noFooterMain": true
+}
+---
+
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
+{% include web-contents/placeholdercontent-en.html %}
+<h2 id="cnt-wdth-lmtd">Section with limited width content</h2>
+<p>
+	Add the CSS class name <code>.cnt-wdth-lmtd</code> to a sectioning element
+	<code>&lt;section class="cnt-wdth-lmtd"&gt;...&lt;section&gt;</code> inside
+	the main content of your page. More guidance are provided in the Content and
+	IA specification.
+</p>
+<section class="cnt-wdth-lmtd">
+	<h3>Section example with limited width content</h3>
+	<p>
+		Different example text. Different example text. Different example text.
+		Different example text. Different example text. Different example text.
+		Different example text. Different example text. This is a very long word
+		pneumonoultramicroscopicsilicovolcanoconiosis.
+	</p>
+</section>
+<h2 id="call-to-action">Call to action button</h2>
+<p>
+	Add the CSS class name <code>.btn-call-to-action</code> to a your button or
+	link that define the main call for action for a page. For example the
+	initiation button/link in a service initiation pages. More guidance are
+	provided in the Content and IA specification.
+</p>
+<div class="row">
+	<div class="col-sm-6">
+		<h3>Link</h3>
+		<p class="mrgn-bttm-0">
+			<a class="btn btn-call-to-action" href="#">[Call to action]</a>
+		</p>
+		<pre><code>&lt;p&gt;&lt;a class="btn <strong>btn-call-to-action</strong>" href="#"&gt;[Call to action]&lt;/a&gt;&lt;/p&gt;</code></pre>
+	</div>
+	<div class="col-sm-6">
+		<h3>Button</h3>
+		<button class="btn btn-call-to-action" type="button">
+			[Call to action]
+		</button>
+		<pre><code>&lt;button class="btn <strong>btn-call-to-action</strong>" type="button"&gt;[Call to action]&lt;/button&gt;</code></pre>
+	</div>
+</div>

--- a/templates/gcds-layout/gcds-layout-core-fr.html
+++ b/templates/gcds-layout/gcds-layout-core-fr.html
@@ -1,0 +1,59 @@
+---
+{
+	"title": "Disposition GCDS - Essentiel",
+	"language": "fr",
+	"category": "templates",
+	"altLangPage": "gcds-layout-core-en.html",
+	"dateModified": "2025-11-17",
+	"layout": "gcds",
+	"breadcrumbs": false,
+	"nomenu": true,
+	"nositesearch": true,
+	"noFooterMain": true
+}
+---
+
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>
+{% include web-contents/placeholdercontent-fr.html %}
+<h2 id="cnt-wdth-lmtd">Section avec une largeur de contenu limitée</h2>
+<p>
+	Ajouter la classe CSS <code>.cnt-wdth-lmtd</code> à l'élément de section
+	<code>&lt;section class="cnt-wdth-lmtd"&gt;...&lt;section&gt;</code> à
+	l'intérieur du contenu principal de votre page. De plus amples
+	renseignements sont disponibles dans la spécification du contenu et de
+	l'architecture de l'information pour Canada.ca.
+</p>
+<section class="cnt-wdth-lmtd">
+	<h3>Exemple de section avec une largeur de contenu limitée</h3>
+	<p>
+		Exemple de texte différent. Exemple de texte différent. Exemple de texte
+		différent. Exemple de texte différent. Exemple de texte différent.
+		Exemple de texte différent. Exemple de texte différent. Exemple de texte
+		différent. Ceci est un très long mot
+		intergouvernementalisationsintergouvernementalisations.
+	</p>
+</section>
+<h2 id="call-to-action">Bouton d'appel à l'action</h2>
+<p>
+	Ajouter la classe CSS <code>.btn-call-to-action</code> à votre bouton ou
+	lien qui définie l'appel à l'action principal de la page. Par example le
+	bouton ou le lien de lancement d'une page de lancements d'un service. De
+	plus amples renseignements sont disponibles dans la spécification du contenu
+	et de l'architecture de l'information pour Canada.ca.
+</p>
+<div class="row">
+	<div class="col-sm-6">
+		<h3>Lien</h3>
+		<p class="mrgn-bttm-0">
+			<a class="btn btn-call-to-action" href="#">[Appel à l'action]</a>
+		</p>
+		<pre><code>&lt;p&gt;&lt;a class="btn <strong>btn-call-to-action</strong>" href="#"&gt;[Appel à l'action]&lt;/a&gt;&lt;/p&gt;</code></pre>
+	</div>
+	<div class="col-sm-6">
+		<h3>Bouton</h3>
+		<button class="btn btn-call-to-action" type="button">
+			[Appel à l'action]
+		</button>
+		<pre><code>&lt;button class="btn <strong>btn-call-to-action</strong>" type="button"&gt;[Appel à l'action]&lt;/button&gt;</code></pre>
+	</div>
+</div>

--- a/templates/gcds-layout/gcds-layout-doc-en.html
+++ b/templates/gcds-layout/gcds-layout-doc-en.html
@@ -1,0 +1,9 @@
+---
+title: GCDS Layout
+description: Documentation for the GCDS Layout template.
+language: en
+altLangPage: gcds-layout-doc-fr.html
+dateModified: 2025-11-17
+layout: documentation
+index_json: index.json-ld
+---

--- a/templates/gcds-layout/gcds-layout-doc-fr.html
+++ b/templates/gcds-layout/gcds-layout-doc-fr.html
@@ -1,0 +1,9 @@
+---
+title: Disposition GCDS
+description: Documentation pour le gabarit de disposition GCDS.
+language: fr
+altLangPage: gcds-layout-doc-en.html
+dateModified: 2025-11-17
+layout: documentation
+index_json: index.json-ld
+---

--- a/templates/gcds-layout/index.json-ld
+++ b/templates/gcds-layout/index.json-ld
@@ -1,0 +1,216 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"dct": "http://purl.org/dc/terms/",
+		"title": { "@id": "dct:title", "@container": "@language" },
+		"description": { "@id": "dct:description", "@container": "@language" },
+		"modified": "dct:modified"
+	},
+	"title": {
+		"en": "GCDS Layout",
+		"fr": "Disposition GCDS"
+	},
+	"description": {
+		"en": "Page layout using the GCDS header and footer components.",
+		"fr": "Disposition de la page utilisant les composants d'en-tête et de pied de page GCDS."
+	},
+	"modified": "2025-11-17",
+	"componentName": "gcds-layout",
+	"status": "stable",
+	"version": "1.0",
+	"pages": {
+		"examples": [
+			{
+				"title": "GCDS Layout - Core",
+				"language": "en",
+				"path": "gcds-layout-core-en.html"
+			},
+			{
+				"title": "Disposition GCDS - Essentiel",
+				"language": "fr",
+				"path": "gcds-layout-core-fr.html"
+			},
+			{
+				"title": "GCDS Layout - Complete",
+				"language": "en",
+				"path": "gcds-layout-complete-en.html"
+			},
+			{
+				"title": "Disposition GCDS - Complet",
+				"language": "fr",
+				"path": "gcds-layout-complete-fr.html"
+			}
+		],
+		"docs": [
+			{
+				"title": "GCDS Layout",
+				"language": "en",
+				"path": "gcds-layout-doc-en.html"
+			},
+			{
+				"title": "Disposition GCDS",
+				"language": "fr",
+				"path": "gcds-layout-doc-fr.html"
+			}
+		]
+	},
+	"a11yGuidance": "No accessibility guidance.",
+	"variations": [
+		{
+			"name": {
+				"en": "GCDS Layout",
+				"fr": "Disposition GCDS"
+			},
+			"status": "stable",
+			"description": {
+				"en": "Page template leveraging the GCDS header and footer components.",
+				"fr": "Gabarit de page utilisant les composants d'en-tête et de pied de page GCDS."
+			},
+			"iteration": "_:iteration_gcdslayout_1",
+			"example": [
+				{
+					"en": { "href": "gcds-layout-core-en.html", "text": "GCDS Layout - Core" },
+					"fr": { "href": "gcds-layout-core-fr.html", "text": "Disposition GCDS - Essentiel" }
+				},
+				{
+					"en": { "href": "gcds-layout-complete-en.html", "text": "GCDS Layout - Complete" },
+					"fr": { "href": "gcds-layout-complete-fr.html", "text": "Disposition GCDS - Complet" }
+				}
+			],
+			"implementation": [
+				"_:implement_gcdslayout",
+				"_:implement_gcdslayout_dev"
+			],
+			"history": [
+				{
+					"en": "November 2025 - Initial implementation of the page template.",
+					"fr": "Novembre 2025 - Implémentation initiale du gabarit de page."
+				}
+			]
+		}
+	],
+	"implementation": [
+		{
+			"@id": "_:implement_gcdslayout",
+			"iteration": "_:iteration_gcdslayout_1",
+			"name": {
+				"en": "Standard",
+				"fr": "Standard"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers/publishers adding the template manually and wanting to use the new GCDS components.",
+				"fr": "Cette implémentation est destinée aux développeurs/éditeurs qui ajoutent le gabarit manuellement et souhaitent utiliser les nouveaux composants GCDS."
+
+			},
+			"instructions": {
+				"en": [
+					"Refer to the <a href=\"https://design-system.alpha.canada.ca\" target=\"_blank\">GCDS documentation</a> and examples for more information on implementing the components used in this page template."
+				],
+				"fr": [
+					"Référez-vous à <a href=\"https://systeme-design.alpha.canada.ca/fr/\" target=\"_blank\">la documentation GCDS</a> et aux exemples pour plus d'informations sur l'implémentation des composants utilisés dans ce gabarit."
+				]
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "GCDS Layout - Core",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\"></gcds-header>\n\n...\n\n<gcds-footer display=\"compact\"></gcds-footer>"
+					},
+					{
+						"@type": "source-code",
+						"description": "GCDS Layout - Complete",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\">\n\t<gcds-search slot=\"search\"></gcds-search>\n\t<gcds-topic-menu slot=\"menu\"></gcds-topic-menu>\n\t<gcds-breadcrumbs slot=\"breadcrumb\" class=\"mt-2\">\n\t\t<gcds-breadcrumbs-item href=\"#\">GCWeb</gcds-breadcrumbs-item>\n\t</gcds-breadcrumbs>\n</gcds-header>\n\n...\n\n<gcds-footer\n\tdisplay=\"full\"\n\tcontextual-heading=\"Contextual navigation\"\n\tcontextual-links='{\"Context link 1\": \"#\", \"Context link 2\": \"#\", \"Context link 3\": \"#\"}'\n\tsub-links='{\"Custom sublink 1\": \"#\", \"Custom sublink 2\": \"#\", \"Custom sublink 3\": \"#\", \"Terms and conditions\": \"#\", \"Privacy\": \"#\"}'>\n</gcds-footer>"					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Disposition GCDS - Essentiel",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\"></gcds-header>\n\n...\n\n<gcds-footer display=\"compact\"></gcds-footer>"
+
+					},
+					{
+						"@type": "source-code",
+						"description": "Disposition GCDS - Complet",
+						"code": "<gcds-header lang-href=\"#\" skip-to-href=\"#\">\n\t<gcds-search slot=\"search\"></gcds-search>\n\t<gcds-topic-menu slot=\"menu\"></gcds-topic-menu>\n\t<gcds-breadcrumbs slot=\"breadcrumb\" class=\"mt-2\">\n\t\t<gcds-breadcrumbs-item href=\"#\">GCWeb</gcds-breadcrumbs-item>\n\t</gcds-breadcrumbs>\n</gcds-header>\n\n...\n\n<gcds-footer\n\tdisplay=\"full\"\n\tcontextual-heading=\"Navigation contextuelle\"\n\tcontextual-links='{\"Lien contextuel 1\": \"#\", \"Lien contextuel 2\": \"#\", \"Lien contextuel 3\": \"#\"}'\n\tsub-links='{\"Sous-lien personnalisé 1\": \"#\", \"Sous-lien personnalisé 2\": \"#\", \"Sous-lien personnalisé 3\": \"#\", \"Avis\": \"#\", \"Confidentialité\": \"#\"}'>\n</gcds-footer>"
+					}
+				]
+			}
+		},
+		{
+			"@id": "_:implement_gcdslayout_dev",
+			"iteration": "_:iteration_gcdslayout_1",
+			"name": {
+				"en": "GCWeb Jekyll",
+				"fr": "GCWeb Jekyll"
+			},
+			"introduction": {
+				"en": "This implementation is meant for developers trying to implement this layout within a GCWeb Jekyll site. To apply the optional components of the header and/or footer on any given page, you will need to do the following in the page's front matter:",
+				"fr": "Cette implémentation est destinée aux développeurs essayant d'implémenter ce composant dans un site GCWeb Jekyll. Pour appliquer les composants optionnels de l’en-tête et/ou du pied de page sur une page donnée, vous devrez procéder comme suit dans le front-matter de la page :"
+			},
+			"instructions": {
+				"en": [
+					"To implement the GCDS layout, simply set the <code>layout</code> property to <code>gcds</code>.",
+					"If the page being migrated to GCDS layout used the <code>no-container</code> layout previously, set the <code>noContainer</code> property to <code>true</code> to maintain the same layout.",
+					"To add custom sublinks to the footer, add a <code>customSublinks</code> object with the desired link texts and urls.",
+					"To see more examples of optional properties that can be used with the GCDS layout, refer to the source code of the individual components (i.e. <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/header/includes/gcds-header.html\" target=\"_blank\">gcds-header</a> and <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/footers/includes/gcds-footer.html\" target=\"_blank\">gcds-footer</a>)."
+				],
+				"fr": [
+					"Pour appliquer la disposition GCDS, définissez simplement la variable <code>layout</code> à <code>gcds</code>.",
+					"Si la page en cours de migration vers la disposition GCDS utilisait précédemment la mise en page <code>no-container</code>, définissez la variable <code>noContainer</code> à <code>true</code> pour conserver la même mise en page.",
+					"Pour ajouter des sous-liens personnalisés au pied de page, ajoutez un objet <code>customSublinks</code> avec les textes et les URL des liens souhaités.",
+					"Pour voir plus d'exemples de propriétés optionnelles qui peuvent être utilisées avec la disposition GCDS, consultez le code source des composants individuels (i.e. <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/header/includes/gcds-header.html\" target=\"_blank\">gcds-header</a> et <a href=\"https://github.com/wet-boew/GCWeb/tree/master/sites/footers/includes/gcds-footer.html\" target=\"_blank\">gcds-footer</a>)."
+				]
+
+			},
+			"sample": {
+				"en": [
+					{
+						"@type": "source-code",
+						"description": "Using \"noContainer\" with the GCDS Layout",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"noContainer\": true\n\t...\n}\n---"
+
+
+					},
+					{
+						"@type": "source-code",
+						"description": "Using custom sublinks with the GCDS Layout",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"customSublinks\": {\n\t\t\"links\": [\n\t\t\t{\"url\": \"#\", \"text\": \"Custom sublink 1\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Custom sublink 2\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Custom sublink 3\"}\n\t\t]\n\t},\n\t...\n}\n---"
+					}
+				],
+				"fr": [
+					{
+						"@type": "source-code",
+						"description": "Utilisation de « noContainer » avec la disposition GCDS",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"noContainer\": true\n\t...\n}\n---"
+
+					},
+					{
+						"@type": "source-code",
+						"description": "Utlisation de sous-liens personnalisés avec la disposition GCDS",
+						"code": "---\n{\n\t...\n\t\"layout\": \"gcds\",\n\t\"customSublinks\": {\n\t\t\"links\": [\n\t\t\t{\"url\": \"#\", \"text\": \"Sous-lien personnalisé 1\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Sous-lien personnalisé 2\"},\n\t\t\t{\"url\": \"#\", \"text\": \"Sous-lien personnalisé 3\"}\n\t\t]\n\t},\n\t...\n}\n---"
+					}
+				]
+			}
+		}
+	],
+	"iteration": [
+		{
+			"@id": "_:iteration_gcdslayout_1",
+			"name": "GCDS Layout - Iteration 1",
+			"date": "2025-11",
+			"detectableBy": "<gcds-header> and <gcds-footer> components"
+		}
+	],
+	"changesets": [
+		{
+			"@id": "_:cs_gcdslayout",
+			"name": "GCDS Layout",
+			"status": "stable",
+			"detectableBy": "<gcds-header> and <gcds-footer> components",
+			"layout": "Not applicable",
+			"semantic": "Not applicable",
+			"notes": "Not applicable"
+		}
+	]
+}

--- a/wet-boew/paginate/index.json-ld
+++ b/wet-boew/paginate/index.json-ld
@@ -16,7 +16,7 @@
 	},
 	"modified": "2024-07-10",
 	"componentName": "paginate",
-	"status": "provisional",
+	"status": "stable",
 	"pages": {
 		"examples": [
 			{


### PR DESCRIPTION
**Jira Ticket Reference:** [WET-582](https://jtickets.atlassian.net/browse/WET-582)

**Preview pages:**
- [GCDS Layout - Core](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2672/templates/gcds-layout/gcds-layout-core-en.html)
- [GCDS Layout - Complete](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2672/templates/gcds-layout/gcds-layout-complete-en.html)
- [Documentation](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2672/templates/gcds-layout/gcds-layout-doc-en.html)

**Note**: In this PR I also updated the href attributes in index-en.md and index-fr.md for the "View source code" links as some of them had incorrect paths.