### PR TITLE
Build: fix Jekyll build warnings, add build using Bundler instead of Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Gemfile.lock
 
 méli-mélo-demos/
 _wetboew-demos/
+_site/
 ~jekyll-dist/
 
 .secrets

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -879,6 +879,14 @@ module.exports = (grunt) ->
 				options: {
 					process: (content, srcpath) ->
 						return content.replace(/{{>alertariahidden}}/g, "")
+										.replace(/acr_wrote_en-en.hbs/g, "acr_wrote_en-en")
+										.replace(/acr_wrote_en-fr.hbs/g, "acr_wrote_en-fr")
+										.replace(/assessment_wrote_en-en.hbs/g, "assessment_wrote_en-en")
+										.replace(/assessment_wrote_en-fr.hbs/g, "assessment_wrote_en-fr")
+										.replace(/{{#escape}}/g, "{% raw %}")
+										.replace(/{{\/escape}}/g, "{% endraw %}")
+										.replace(/{{#stripbanner}}/g, "")
+										.replace(/{{\/stripbanner}}/g, "")
 				}
 
 			# méli-mélo tasks

--- a/docs/reporting-a11y.html
+++ b/docs/reporting-a11y.html
@@ -222,7 +222,6 @@ modified: 2023-08-28
           <h3 class="h5">{{ component.name }}</h3>
           <ul>
             {% for assessment in component.a11y %}
-	      <!-- <li data-wb-tags="{{ assessment.outcome }} {{% if assessment.isApplicable -%}}isApplicable{{%- endif -%}}"> -->
               <li><a href="../{{ assessment.link }}">{{ assessment.date }} - {{ assessment.outcome }}</a></li>
             {% else %}
               <li>None</li>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Web Experience Toolkit (WET): Canada.ca Theme Reorg",
   "main": "index.html",
   "scripts": {
-    "post": "grunt"
+    "post": "grunt",
+    "jekyll": "bundle exec jekyll serve --config _config.yml,_localJekyll.yml --incremental"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Removing all Jekyll build warnings
- Adding command in package.json to build the site using Bundler instead of docker
  - Required: Ruby and Bundler