### PR TITLE
GC Search: Relocation of specific results section styles

### DIFF
--- a/templates/search/_search.scss
+++ b/templates/search/_search.scss
@@ -14,27 +14,6 @@
 		h2 {
 			font-size: 1.5rem;
 		}
-	}
-
-	.results > section {
-		border-bottom: solid 1px #000;
-		margin-bottom: 1.5em;
-		padding-bottom: 1.5em;
-
-		.context-labels {
-			font-size: 1rem;
-			list-style: none;
-			padding-left: 0;
-
-			li {
-				background-color: #5e738b;
-				color:#fff;
-				display: inline-block;
-				font-weight: $bold-weight;
-				margin-bottom: 1px;
-				padding: 0 5px;
-			}
-		}
 
 		h3 {
 			font-size: 1.375rem;
@@ -64,6 +43,27 @@
 				a {
 					color: #1b6c1c;
 				}
+			}
+		}
+	}
+
+	.results > section {
+		border-bottom: solid 1px #000;
+		margin-bottom: 1.5em;
+		padding-bottom: 1.5em;
+
+		.context-labels {
+			font-size: 1rem;
+			list-style: none;
+			padding-left: 0;
+
+			li {
+				background-color: #5e738b;
+				color:#fff;
+				display: inline-block;
+				font-weight: $bold-weight;
+				margin-bottom: 1px;
+				padding: 0 5px;
 			}
 		}
 	}

--- a/templates/search/api-en.html
+++ b/templates/search/api-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"secondlevel": false,
 	"altLangPage": "api-fr.html",
-	"dateModified": "2025-11-25",
+	"dateModified": "2026-01-23",
 	"share": "true"
 }
 ---
@@ -70,6 +70,7 @@
 
 <h2>Version history</h2>
 <ul>
+	<li><time>2026-01-23</time> Version 3.3 - In the search css file, moved h3 and various location elements from results section to #wb-land</li>
 	<li><time>2025-11-25</time> Version 3.2 - Adjusted font sizes for h2, and ol and p elements in a list, and removed margin-top from "cite a"</li>
 	<li><time>2025-07-28</time> Version 3.1 - Alignement of Search UI with GCWeb:</li>
 		<ul>

--- a/templates/search/api-fr.html
+++ b/templates/search/api-fr.html
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"secondlevel": false,
 	"altLangPage": "api-en.html",
-	"dateModified": "2025-11-25",
+	"dateModified": "2026-01-23",
 	"share": "true"
 }
 ---
@@ -73,6 +73,7 @@
 
 	<h2>Version history</h2>
 	<ul>
+		<li><time>2026-01-23</time> Version 3.3 - In the search css file, moved h3 and various location elements from results section to #wb-land</li>
 		<li><time>2025-11-25</time> Version 3.2 - Adjusted font sizes for h2, and ol and p elements in a list, and removed margin-top from "cite a"</li>
 		<li><time>2025-07-28</time> Version 3.1 - Alignement of Search UI with GCWeb:</li>
 			<ul>

--- a/templates/search/results-advanced-en.html
+++ b/templates/search/results-advanced-en.html
@@ -5,7 +5,7 @@
 	"altLangPage": "results-advanced-fr.html",
 	"pageType": "search",
 	"pageclass": "page-type-search",
-	"dateModified": "2025-12-02",
+	"dateModified": "2026-02-05",
 	"share": "false",
 	"nositesearch": true
 }
@@ -60,8 +60,7 @@
 </div>
 
 <section class="results" id="wb-land">
-	<h2 class="wb-inv">Search results</h2>
-	<p class="h4">[number] search results for "[search term]"</p>
+	<h2>[number] search results for "[search term]"</h2>
 
 	<section>
 		<h3><a href="#">[Search result page title]</a></h3>

--- a/templates/search/results-advanced-fr.html
+++ b/templates/search/results-advanced-fr.html
@@ -5,7 +5,7 @@
 	"altLangPage": "results-advanced-en.html",
 	"pageType": "recherche",
 	"pageclass": "page-type-search",
-	"dateModified": "2025-12-02",
+	"dateModified": "2026-02-05",
 	"share": "false",
 	"nositesearch": true
 }
@@ -61,8 +61,7 @@
 </div>
 
 <section class="results" id="wb-land">
-	<h2 class="wb-inv">Résultats de recherche</h2>
-	<p class="h4">[nombre de] résultats de recherché pour "[le terme recherché]"</p>
+	<h2>[nombre de] résultats de recherché pour "[le terme recherché]"</h2>
 	<section>
 		<h3><a href="#">[Titre du résultat de recherche]</a></h3>
 		<ol class="location">

--- a/templates/search/results-en.html
+++ b/templates/search/results-en.html
@@ -5,13 +5,13 @@
 	"altLangPage": "results-fr.html",
 	"pageType": "search",
 	"pageclass": "page-type-search",
-	"dateModified": "2025-12-02",
+	"dateModified": "2026-02-05",
 	"share": "false",
 	"nositesearch": true
 }
 ---
 <search>
-	<form id="gc-searchbox" class="mrgn-tp-sm">
+	<form>
 		<label class="wb-inv" for="sch-inp">Search Government of Canada websites</label>
 		<div class="input-group mrgn-tp-lg">
 			<input spellcheck="false" autocomplete="off" id="sch-inp" class="form-control" type="search" data-fusion-query name="q" aria-describedby="gc-pi">
@@ -24,9 +24,7 @@
 </search>
 
 <section id="wb-land">
-	<div>
-		<h2>[number] search results for "[search term]"</h2>
-	</div>
+	<h2>[number] search results for "[search term]"</h2>
 
 	<div class="results">
 		<section>

--- a/templates/search/results-filters-en.html
+++ b/templates/search/results-filters-en.html
@@ -5,7 +5,7 @@
 	"altLangPage": "results-filters-fr.html",
 	"pageType": "search",
 	"pageclass": "page-type-search",
-	"dateModified": "2025-12-02",
+	"dateModified": "2026-02-05",
 	"share": "false"
 }
 ---
@@ -44,8 +44,7 @@
 	</div>
 	<div class="col-md-8">
 		<section class="results" id="wb-land">
-			<h2 class="wb-inv">Search results</h2>
-			<p class="h4">[number] search results for "[search term]"</p>
+			<h2>[number] search results for "[search term]"</h2>
 
 			<section>
 				<h3><a href="#">[Search result page title]</a></h3>

--- a/templates/search/results-filters-fr.html
+++ b/templates/search/results-filters-fr.html
@@ -5,7 +5,7 @@
 	"altLangPage": "results-filters-en.html",
 	"pageType": "recherche",
 	"pageclass": "page-type-search",
-	"dateModified": "2025-12-02",
+	"dateModified": "2026-02-05",
 	"share": "false"
 }
 ---
@@ -44,8 +44,7 @@
 	</div>
 	<div class="col-md-8">
 		<section class="results" id="wb-land">
-			<h2 class="wb-inv">Résultats de recherche</h2>
-			<p class="h4">[nombre de] résultats de recherche pour "[le terme recherché]"</p>
+			<h2>[nombre de] résultats de recherche pour "[le terme recherché]"</h2>
 
 			<section>
 				<h3><a href="#">[Titre du résultat de recherche]</a></h3>

--- a/templates/search/results-fr.html
+++ b/templates/search/results-fr.html
@@ -5,7 +5,7 @@
 	"altLangPage": "results-en.html",
 	"pageType": "recherche",
 	"pageclass": "page-type-search",
-	"dateModified": "2025-12-02",
+	"dateModified": "2026-02-05",
 	"share": "false",
 	"nositesearch": true
 }
@@ -23,12 +23,10 @@
 	</form>
 </search>
 
-<section>
-	<div>
-		<h2>[nombre de] résultats de recherché pour "[le terme recherché]"</h2>
-	<div>
+<section id="wb-land">
+	<h2>[nombre de] résultats de recherché pour "[le terme recherché]"</h2>
 
-	<div class="results" id="wb-land">
+	<div class="results">
 		<section>
 			<h3><a href="#">[Titre du résultat de recherche]</a></h3>
 			<ol class="location">


### PR DESCRIPTION
Related to WET-639
Relocation of specific results section styles to #wb-land