### PR TITLE
Add tzinfo-data gem to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     github-pages \
     jekyll-github-metadata \
     minitest \
-	tzinfo-data \
+    tzinfo-data \
   && gem install rake html-proofer \
   && gem install webrick \
   && mkdir -p /usr/src/app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     github-pages \
     jekyll-github-metadata \
     minitest \
+	tzinfo-data \
   && gem install rake html-proofer \
   && gem install webrick \
   && mkdir -p /usr/src/app \


### PR DESCRIPTION
Added missing tzinfo-data dependency for jekyll. It appears it was missed when it was added to the Gemfile as part of https://github.com/wet-boew/GCWeb/pull/2733.