### PR TITLE
Action manager: fixes accessing uninitialized DataTables instance

### DIFF
--- a/components/wb-actionmng/actionmng.js
+++ b/components/wb-actionmng/actionmng.js
@@ -179,10 +179,20 @@ var $document = wb.doc,
 			colInt = parseInt( column, 10 ),
 			regex = !!data.regex,
 			smart = ( !data.smart ) ? true : !!data.smart,
-			caseinsen = ( !data.caseinsen ) ? true : !!data.caseinsen;
+			caseinsen = ( !data.caseinsen ) ? true : !!data.caseinsen,
+			sourceElm = $source.get( 0 );
 
 		if ( $source.get( 0 ).nodeName !== "TABLE" ) {
 			throw "Table filtering can only applied on table";
+		}
+
+		// If the DataTables plugin has not been initialized yet, listen for when wb-tables fires wb.ready(), then retry
+		// This ensures DataTables is initialized before attempting to call .api() on it
+		if ( sourceElm.className.indexOf( "wb-tables-inited" ) === -1 || !$.fn.dataTable || !$.fn.dataTable.isDataTable( sourceElm ) ) {
+			$source.one( "wb-ready.wb-tables", function() {
+				tblflrAct( event, data );
+			} );
+			return;
 		}
 
 		$datatable = $source.dataTable( { "retrieve": true } ).api();


### PR DESCRIPTION
_Related to [WET-661](https://jtickets.atlassian.net/browse/WET-661)_

[Pierre's comment](https://jtickets.atlassian.net/browse/WET-661?focusedCommentId=224608) goes into detail about the issue this fixes, but essentially:
- The action manager crashes sometimes due to a race condition involving the DataTables plugin, which causes the URL mapping to also fail
- You would see in the console: `TypeError: p.dataTable is not a function`
- The error seemed to have only happened in Firefox (at least for me)

How I tested my proposed changes:
- Modified the actionmng.js file locally, then ran grunt dist to compile the prod files
- In Firefox, added a script override to the theme.min.js file and replaced it with the compiled theme.min.js file that included the changes in actionmng.js
- Hard refreshed the page to apply the changes, and the error did not appear even after continuous refreshes/hard refreshes

