### PR TITLE
GCWeb Menu: Updating instructions in an aria-describedby

### DIFF
--- a/sites/gcweb-menu/gcweb-menu-docs-en.html
+++ b/sites/gcweb-menu/gcweb-menu-docs-en.html
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPage": "gcweb-menu-docs-fr.html",
 	"secondlevel": false,
-	"dateModified": "2025-05-26",
+	"dateModified": "2026-05-20",
 	"share": "true",
 	sitemenuPath: "ajax/sitemenu-v5-en.html"
 }
@@ -17,7 +17,7 @@
 	<dt>Type</dt>
 	<dd>Canada.ca site functionality</dd>
 	<dt>Last review</dt>
-	<dd>2025-05-26</dd>
+	<dd>2026-05-20</dd>
 </dl>
 
 <h2>Purpose</h2>
@@ -33,7 +33,7 @@
 <h2>Evaluation and report</h2>
 <p>There is no evaluation and report available for this component.</p>
 
-<h2 id="v3">API (Version 3.1)</h2>
+<h2 id="v3">API (Version 3.1.1)</h2>
 <table class="table table-bordered">
 	<tr>
 		<th>CSS Class</th>
@@ -43,7 +43,7 @@
 	</tr>
 	<tr>
 		<td>Version 1.0</td>
-		<td>Version 3.1</td>
+		<td>Version 3.1.1</td>
 		<td>Version 1.0.1</td>
 		<td>n.a.</td>
 	</tr>
@@ -53,6 +53,9 @@
 <p><code>gcweb-menu</code></p>
 
 <h2>History</h2>
+
+<h3>Version 3.1.1</h3>
+<p>Replaced aria-label attribute with aria-describedby to improve accessibility.</p>
 
 <h3>Version 3.1</h3>
 <p>Added a new link to the menu for "Manage life events".</p>

--- a/sites/gcweb-menu/gcweb-menu-docs-fr.html
+++ b/sites/gcweb-menu/gcweb-menu-docs-fr.html
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"altLangPage": "gcweb-menu-docs-en.html",
 	"secondlevel": false,
-	"dateModified": "2025-05-26",
+	"dateModified": "2026-05-20",
 	"share": "true",
 	sitemenuPath: "ajax/sitemenu-v5-fr.html"
 }
@@ -17,7 +17,7 @@
 	<dt>Type</dt>
 	<dd>Fonctionnalité du site Canada.ca</dd>
 	<dt>Dernière révision</dt>
-	<dd>2025-05-26</dd>
+	<dd>2026-05-20</dd>
 </dl>
 
 <h2>Objectif</h2>
@@ -32,7 +32,7 @@
 <h2>Évaluation et rapport</h2>
 <p>Il n'y a pas d'évaluation ni de rapport disponible pour ce composant.</p>
 
-<h2>API (version 3.1)</h2>
+<h2>API (version 3.1.1)</h2>
 <table class="table bordée de table">
 	<tr>
 		<th>Classe CSS</th>
@@ -42,7 +42,7 @@
 	</tr>
 	<tr>
 		<td>Version 1.0</td>
-		<td>Version 3.1</td>
+		<td>Version 3.1.1</td>
 		<td>Version 1.0.1</td>
 		<td>n.d.</td>
 	</tr>
@@ -52,6 +52,9 @@
 <p><code>gcweb-menu</code></p>
 
 <h2>Historique</h2>
+
+<h3>Version 3.1.1</h3>
+<p>L'attribut aria-label a été remplacé par aria-describedby afin d'améliorer l'accessibilité.</p>
 
 <h3>Version 3.1</h3>
 <p>Ajout d'un nouveau lien au menu pour "Gérer les événements de la vie".</p>

--- a/sites/gcweb-menu/menu.js
+++ b/sites/gcweb-menu/menu.js
@@ -63,8 +63,15 @@ var componentName = "gcweb-menu",
 			setMnu3LevelOrientationExpandState( false, isMediumView );
 		}
 
+		const desc = document.createElement( "p" );
+		desc.id = "gcweb-menu-desc";
+		desc.hidden = true;
+		desc.textContent = i18nInstruction;
+
+		subElm.previousElementSibling.insertAdjacentElement( "beforebegin", desc );
+
 		// Add menu navigation instruction
-		subElm.previousElementSibling.setAttribute( "aria-label", i18nInstruction );
+		subElm.previousElementSibling.setAttribute( "aria-describedby", "gcweb-menu-desc" );
 
 		// Identify that initialization has completed
 		wb.ready( $elm, componentName );


### PR DESCRIPTION
Related to WET-666.
Replaced the aria-label attribute providing the instructions of the GCWeb menu button with aria-describedby.