### PR TITLE
Build: Remove grunt-stylelint's stylelint v17 override

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,5 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "stylelint-order": "^8.1.1",
     "time-grunt": "^2.0.0"
-  },
-  "overrides": {
-    "grunt-stylelint": {
-      "stylelint": ">=17.0.0"
-    }
   }
 }


### PR DESCRIPTION
wet-boew/wet-boew#10112 mentioned it was necessary since grunt-stylelint appeared to have been abandoned at the time.

Since then, its GitHub repo has been archived and the project has migrated to GitLab (https://gitlab.wikimedia.org/repos/ci-tools/grunt-stylelint). It's also received a new version (0.21.0) that depends on stylelint 17.x.

#2780 recently bumped GCWeb's version of grunt-stylelint to 0.21.0. So the override is no longer necessary (at least not for the time being...).

Port of wet-boew/wet-boew#10144.

CC @nschonni