### PR TITLE
Build (linters): Ignore Jekyll site folder

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -988,12 +988,14 @@ module.exports = (grunt) ->
 					"**/*.css"
 					"!**/*.min.css"
 					"!méli-mélo/compilation-gelé/"
+					"!_site/**"
 					"!node_modlules/"
 				]
 
 			scss:
 				src: [
 					"**/*.scss"
+					"!_site/**"
 					"!node_modlules"
 				]
 
@@ -1089,6 +1091,7 @@ module.exports = (grunt) ->
 				src: [
 					"**/*.js"
 					"**/*.mjs"
+					"!_site/**"
 					"!node_modules/**"
 				]
 
@@ -1170,6 +1173,7 @@ module.exports = (grunt) ->
 				src: [
 					'**/*.md'
 					'!node_modules/**/*.md'
+					'!_site/**/*.md'
 					'!_wetboew-demos/**/*.md',
 					'!~sites/**/*.md'
 				]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig( [ globalIgnores( [
 	"**/*.min.js",
 	"méli-mélo/**/*.js",
 	"**/méli-mélo-demos/",
+	"**/_site/",
 	"**/_wetboew-demos/",
 	"**/~jekyll-dist/",
 	"**/~sites/*",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -135,6 +135,7 @@ module.exports = {
 		"méli-mélo/compilation-gelé/**",
 		"méli-mélo/deprecated/**",
 		"node_modules/**",
+		"_site/**",
 		"~sites/**",
 		"dist/**"
 	]


### PR DESCRIPTION
The ``eslint``, ``stylelint`` and ``markdownlint`` tasks were previously evaluating copies of ignored files situated in the /_site/ folder - which in turn produced countless errors.

This resolves it by formally ignoring the ``/_site/`` folder in those tasks' settings.

Related to #2788's comment trail.

CC @nschonni @Garneauma