### PR TITLE
ZEV thematic: update expiry date

### DIFF
--- a/méli-mélo/th-zev/meta.md
+++ b/méli-mélo/th-zev/meta.md
@@ -4,7 +4,7 @@ lang: en
 title: Zero Emission Vehicles (ZEV) Theme
 description: Background colours used for NRCan's ZEV campaign
 componentName: th-zev
-expiry: May 31, 2026
+expiry: May 31, 2027
 mainPage: zev.html
 cssClass:
 - bg-zev-purple

--- a/thématique/gc-thématique-en.html
+++ b/thématique/gc-thématique-en.html
@@ -3,7 +3,7 @@ title: GC promotional thematic
 description: Custom CSS/JavaScript for GC promotional thematic use
 altLangPage: gc-thématique-fr.html
 lang: en
-dateModified: 2025-11-04
+dateModified: 2026-06-08
 ---
 
 <p>Custom CSS and/or JavaScript for GC promotional thematic use. Check out the <a href="#th-list">current list of promotional thematic projects below</a>.</p>

--- a/thématique/gc-thématique-fr.html
+++ b/thématique/gc-thématique-fr.html
@@ -3,7 +3,7 @@ title: Thématiques promotionnelles du GC
 description: Code CSS et/ou Javascript personnalisé à utiliser pour des thématiques promotionnelles du GC
 altLangPage: gc-thématique-en.html
 lang: fr
-dateModified: 2025-11-04
+dateModified: 2026-06-08
 ---
 
 <p>Code CSS et/ou Javascript personnalisé à utiliser pour des thématiques promotionnelles du GC. Voir la <a href="#th-list">liste des projets de thématiques promotionnelles ci-dessous</a>.</p>


### PR DESCRIPTION
Related to WET-668.

Updated the ZEV thematic expiry date to reflect May 31, 2027.