### PR TITLE
GCWeb Menu: Extra Spacing on small screen

### DIFF
--- a/sites/gcweb-menu/_screen-sm-max.scss
+++ b/sites/gcweb-menu/_screen-sm-max.scss
@@ -54,6 +54,10 @@
 		min-height: auto;
 		padding: 0;
 		width: auto;
+
+		[lang="fr"] & {
+			min-height: auto;
+		}
 	}
 
 	[role="menu"] [role="menu"] li {

--- a/sites/gcweb-menu/gcweb-menu-docs-en.html
+++ b/sites/gcweb-menu/gcweb-menu-docs-en.html
@@ -33,7 +33,7 @@
 <h2>Evaluation and report</h2>
 <p>There is no evaluation and report available for this component.</p>
 
-<h2 id="v3">API (Version 3.1.2)</h2>
+<h2 id="v3">API (Version 3.1.3)</h2>
 <table class="table table-bordered">
 	<tr>
 		<th>CSS Class</th>
@@ -43,7 +43,7 @@
 	</tr>
 	<tr>
 		<td>Version 1.0</td>
-		<td>Version 3.1.2</td>
+		<td>Version 3.1.3</td>
 		<td>Version 1.0.1</td>
 		<td>n.a.</td>
 	</tr>
@@ -53,6 +53,9 @@
 <p><code>gcweb-menu</code></p>
 
 <h2>History</h2>
+
+<h3>Version 3.1.3</h3>
+<p>Removed extra vertical whitespace between elements of the submenu for the French page.</p>
 
 <h3>Version 3.1.2</h3>
 <p>Added id and aria-labelledby to the menu button to improve accessibility. Also added aria-hidden to the button span.</p>

--- a/sites/gcweb-menu/gcweb-menu-docs-fr.html
+++ b/sites/gcweb-menu/gcweb-menu-docs-fr.html
@@ -32,7 +32,7 @@
 <h2>Évaluation et rapport</h2>
 <p>Il n'y a pas d'évaluation ni de rapport disponible pour ce composant.</p>
 
-<h2>API (version 3.1.2)</h2>
+<h2>API (version 3.1.3)</h2>
 <table class="table bordée de table">
 	<tr>
 		<th>Classe CSS</th>
@@ -42,7 +42,7 @@
 	</tr>
 	<tr>
 		<td>Version 1.0</td>
-		<td>Version 3.1.2</td>
+		<td>Version 3.1.3</td>
 		<td>Version 1.0.1</td>
 		<td>n.d.</td>
 	</tr>
@@ -52,6 +52,9 @@
 <p><code>gcweb-menu</code></p>
 
 <h2>Historique</h2>
+
+<h3>Version 3.1.3</h3>
+<p>Suppression des espaces verticaux extras entre les éléments du sous-menu de la page en français.</p>
 
 <h3>Version 3.1.2</h3>
 <p>Ajout des attributs id et aria-labelledby au bouton de menu pour améliorer son accessibilité. Ajout également de l'attribut aria-hidden à l'élément span du bouton.</p>


### PR DESCRIPTION
Related to WET-669.

Removal of extra vertical spacing between last sub-menu element and next primary navigation section, which only occurs on the French page.