### PR TITLE
chore: remove WET sprite workarounds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,11 +61,6 @@ jobs:
           npm i -g bower grunt-cli
           npm ci
 
-      - name: Copy the missing _sprite_share.scss file - related to GCWeb#1737 about wet-boew#cc340a6 commit
-        run: |
-          curl https://gist.githubusercontent.com/Garneauma/199314f72d9d01642771c37bbf8db0fa/raw/87c9de7dd61eb034a7d5ee4003a368934c370b50/_sprites_share.scss >> _sprites_share.scss
-          mv _sprites_share.scss node_modules/wet-boew/src/plugins/share/sprites/_sprites_share.scss
-
       - name: Checkout wet-boew latest build
         if: ${{ env.ACT }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,6 @@ jobs:
           npm i -g bower grunt-cli
           npm ci
 
-      - name: Copy the missing _sprite_share.scss file - related to GCWeb#1737 about wet-boew#cc340a6 commit
-        run: |
-          curl https://gist.githubusercontent.com/Garneauma/199314f72d9d01642771c37bbf8db0fa/raw/87c9de7dd61eb034a7d5ee4003a368934c370b50/_sprites_share.scss >> _sprites_share.scss
-          mv _sprites_share.scss node_modules/wet-boew/src/plugins/share/sprites/_sprites_share.scss
-
       - name: Checkout wet-boew latest build
         if: ${{ env.ACT }}
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Install npm dependencies
         run: npm ci --ignore-scripts
 
-      # Related to GCWeb#1737 about wet-boew#cc340a6 commit
-      - name: Copy the missing _sprite_share.scss file
-        run: |
-          curl https://gist.githubusercontent.com/duboisp/d69787b300eb1f4d40f937508e10d013/raw/86e7a0b15ad6a695754599e9793e986b460bf514/_sprites_share.scss >> _sprites_share.scss
-          mv _sprites_share.scss node_modules/wet-boew/src/plugins/share/sprites/_sprites_share.scss
-
       - name: Build GCWeb
         run: grunt build-gh-pages
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 node_modules/
 lib/
 dist/
-?sprite*.*css
-sprite*.png
 
 # gh-pages
 wet-boew-cdn/


### PR DESCRIPTION
## What does this pull request(PR) do?

Removes the old workarounds that downloaded the Sprite SCSS file, now that it is checked into the project. It might need to land after the new bump of the wet-boew NPM dependency.
I'm not sure if the workaround really worked before, since it wasn't also bringing down the sprite image.

## Contribution category (please only choose one)

- [ ] Stateless or basic component
- [ ] Interactive component
- [ ] Helper component
- [ ] Site wide component
- [ ] Baseline layout
- [ ] Page layout

## General checklist

- [ ] [Technical documentation](FEATURE.md) created/updated
- [ ] Conforms to the [style guides](https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html)
- [ ] Changelog entry added, if necessary
- [ ] Tests added for this feature/bug

## Related issues

Fixes #1737