### PR TITLE
Accessibility re-assessment

### DIFF
--- a/_data/templates.json
+++ b/_data/templates.json
@@ -2049,6 +2049,16 @@
 				"title": "Évaluation d'accessibilité #2 - Modèle de thème superposé",
 				"language": "fr",
 				"path": "reports/a11y-2-fr.html"
+			},
+			{
+				"title": "Accessibility assessment #3 - Layered theme template",
+				"language": "en",
+				"path": "reports/a11y-3-en.html"
+			},
+			{
+				"title": "Évaluation d'accessibilité #3 - Modèle de thème superposé",
+				"language": "fr",
+				"path": "reports/a11y-3-fr.html"
 			}
 		]
 	},

--- a/templates/theme/index.json-ld
+++ b/templates/theme/index.json-ld
@@ -63,6 +63,16 @@
 				"title": "Évaluation d'accessibilité #2 - Modèle de thème superposé",
 				"language": "fr",
 				"path": "reports/a11y-2-fr.html"
+			},
+			{
+				"title": "Accessibility assessment #3 - Layered theme template",
+				"language": "en",
+				"path": "reports/a11y-3-en.html"
+			},
+			{
+				"title": "Évaluation d'accessibilité #3 - Modèle de thème superposé",
+				"language": "fr",
+				"path": "reports/a11y-3-fr.html"
 			}
 		]
 	},

--- a/templates/theme/reports/a11y-3-en.html
+++ b/templates/theme/reports/a11y-3-en.html
@@ -1,0 +1,11 @@
+---
+{
+	"title": "Accessibility assessment #3 - Layered theme template",
+	"language": "en",
+	"description": "Re-evaluation of the GC theme template following recent updates in order to determine if it is aligned with our design and is compliant to our accessibility guideline when used as is without any special customization.",
+	"altLangPage": "a11y-3-fr.html",
+	"dateModified": "2026-06-17",
+	"layout": "assessment_wrote_en-en",
+	"reportURL": "a11y-3.json"
+}
+---

--- a/templates/theme/reports/a11y-3-fr.html
+++ b/templates/theme/reports/a11y-3-fr.html
@@ -1,0 +1,11 @@
+---
+{
+	"title": "Évaluation d'accessibilité #3 - Modèle de thème superposé",
+	"language": "fr",
+	"description": "Réévaluation du modèle de thème GC en suivant des mises à jour afin de déterminer s'il est aligné avec notre conception et est conforme à nos lignes directrices en matière d'accessibilité lorsqu'il est utilisé tel quel sans aucune personnalisation particulière.",
+	"altLangPage": "a11y-3-en.html",
+	"dateModified": "2026-06-17",
+	"layout": "assessment_wrote_en-fr",
+	"reportURL": "a11y-3.json"
+}
+---

--- a/templates/theme/reports/a11y-3.json
+++ b/templates/theme/reports/a11y-3.json
@@ -1,0 +1,631 @@
+{
+  "@context": "https://wet-boew.github.io/vocab/context/2023/assessment-report-en.json-ld",
+  "@type": [
+    "earl:Assertion",
+    "acr:AssessmentReport"
+  ],
+  "dct:date": "2026-06-17",
+  "earl:subject": {
+    "@id": "_:subject",
+    "dct:references": [
+      "https://wet-boew.github.io/GCWeb/templates/theme/theme-en.html"
+    ],
+    "@type": [
+      "earl:TestSubject",
+      "schema:WebPage"
+    ],
+    "dct:description": "",
+    "oa:hasState": [
+      {
+        "@type": "acr:MediaQueryList",
+        "acr:stateValue": "(min-width: 992px) and (max-width: 1199px)"
+      },
+      {
+        "@type": "acr:MediaQueryList",
+        "acr:stateValue": "(min-width: 768px) and (max-width: 991px)"
+      }
+    ],
+    "earl:pointer": {
+      "@type": "oa:CssSelector",
+      "@value": "main"
+    }
+  },
+  "dct:description": "Re-evaluation of the GC theme template following recent updates in order to determine if it is aligned with our design and is compliant to our accessibility guideline when used as is without any special customization.",
+  "earl:result": [
+    {
+      "earl:test": "WCAG21:non-text-content",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:audio-only-and-video-only-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:captions-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:audio-description-or-media-alternative-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:captions-live",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:audio-description-prerecorded",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:info-and-relationships",
+      "earl:subject": {
+        "@id": "_info-and-relationships_itm1",
+        "dct:isPartOf": "_:subject",
+        "@type": [
+          "earl:TestSubject",
+          "schema:WebPageElement"
+        ],
+        "dct:description": ""
+      },
+      "earl:result": [
+        {
+          "earl:test": "WCAG2xTech:html/H48",
+          "earl:outcome": "earl:passed",
+          "earl:mode": "earl:manual",
+          "earl:subject": "_info-and-relationships_itm1",
+          "dct:description": "h1,h2, and h3 tags are used to identify headings and subheadings, respectively."
+        },
+        {
+          "earl:test": "act:rules/wcag2x/sc/1_3_1_situation_a",
+          "earl:outcome": "earl:passed",
+          "earl:mode": "earl:manual",
+          "earl:subject": "_info-and-relationships_itm1",
+          "dct:description": "ul tags are used for groups of links."
+        }
+      ],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "The page provides semantic structure, including headings and lists, to make information and relationships clear and accessible.",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:meaningful-sequence",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:sensory-characteristics",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:orientation",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:identify-input-purpose",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:use-of-color",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:audio-control",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:contrast-minimum",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:resize-text",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "Page tested with 200 percent zoom on Chrome, Edge, Firefox and Safari",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:image-of-text",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:reflow",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:non-text-contrast",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:text-spacing",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "Tested using a text spacing bookmarklet",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:content-on-hover-or-focus",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:keyboard",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:no-keyboard-trap",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:character-key-shortcuts",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:timing-adjustable",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:pause-stop-hide",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:three-flashes-or-below-threshold",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:bypass-blocks",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:page-titled",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:focus-order",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:link-purpose-in-context",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "Previously failed for button text inconsistency between different viewports. Passes now that the text used for the sign in button on the jobs page is consistent across viewports. Since there is enough context on the Jobs page, coupled with the fact that the sign in button leads to a page with several sign in/register links for different services, the general “Sign in” text on the button suffices.",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:multiple-ways",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:headings-and-labels",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:focus-visible",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:pointer-gestures",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:pointer-cancellation",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:label-in-name",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:motion-actuation",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:language-of-page",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:language-of-parts",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:on-focus",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:on-input",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:consistent-navigation",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:consistent-identification",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:error-identification",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:labels-or-instructions",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:error-suggestion",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:error-prevention-legal-financial-data",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    },
+    {
+      "earl:test": "WCAG21:parsing",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:automatic",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "Tested using W3C Markup Validation Service",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:name-role-value",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:forEvaluation",
+      "acr:relevancy": "acr:forEvaluation",
+      "dct:description": "",
+      "earl:outcome": "earl:passed"
+    },
+    {
+      "earl:test": "WCAG21:status-messages",
+      "earl:subject": "_:subject",
+      "earl:result": [],
+      "acr:asset": [],
+      "earl:mode": "earl:manual",
+      "acr:severity": "acr:notRelevant",
+      "acr:relevancy": "acr:notRelevant",
+      "dct:description": "",
+      "earl:outcome": "earl:inapplicable"
+    }
+  ],
+  "acr:standard": "https://www.w3.org/TR/WCAG21",
+  "acr:conformanceOption": "act:standard/profiles/wcag#levelAA",
+  "acr:stateValue": "(min-width: 768px) and (max-width: 991px)",
+  "earl:assertedBy": {
+    "@type": [
+      "earl:Assertor",
+      "foaf:Organization"
+    ],
+    "earl:mainAssertor": {
+      "@type": [
+        "earl:Assertor",
+        "foaf:Person"
+      ],
+      "foaf:name": "Tristan Dasilva",
+      "foaf:homepage": "https://github.com/tristandasilva"
+    },
+    "foaf:name": "Service Canada - Principal Publisher",
+    "foaf:homepage": "https://github.com/ServiceCanada"
+  },
+  "foaf:name": "Service Canada - Principal Publisher",
+  "foaf:homepage": "https://github.com/ServiceCanada",
+  "workspace-id": "0"
+}


### PR DESCRIPTION
Related to [WET-650](https://jtickets.atlassian.net/browse/WET-650)

In this PR, a 3rd [accessibility report](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2804/templates/theme/reports/a11y-3-en.html) was added to the Theme template. The purpose of this reassessment was to confirm that the previously failed criteria (SC 2.4.4 Link Purpose) now passes after being addressed.

