### PR TITLE
Combobox additions and accessibility refinements

### DIFF
--- a/_data/components.json
+++ b/_data/components.json
@@ -430,7 +430,7 @@
 		"en": "An accessible multi-select combo box component that implements WCAG 2.1 accessibility standards and provides a modern, user-friendly interface for selecting multiple items from a list.",
 		"fr": "Un composant de boîte combo multi-sélection accessible qui met en œuvre les normes d'accessibilité WCAG 2.1 et fournit une interface conviviale et moderne pour sélectionner plusieurs éléments dans une liste."
 	},
-	"modified": "2026-05-27",
+	"modified": "2026-07-06",
 	"componentName": "combo-box",
 	"status": "provisional",
 	"version": "0.1.0",
@@ -531,13 +531,19 @@
 			"notes": {
 				"en": [
 					"A placeholder is optional but recommended. It works the same as a standard <code>input</code> placeholder.",
-					"Add the <code>select-all-options</code> attribute to enable a \"Select all options\" option at the top of the dropdown. When all options are selected, they are replaced by a single tag.",
-					"Tag colours can be customized using the <code>::part(tag)</code> CSS selector from outside the component."
+					"Add the <code>enable-select-all</code> attribute to enable a \"Select all options\" option at the top of the dropdown. When all options are selected, they are replaced by a single tag.",
+					"Add a value to the <code>enable-select-all</code> attribute to customize the \"Select all options\" text shown in the dropdown (e.g. <code>enable-select-all=\"Select all regions\"</code>). If no value is provided, it uses the default text.",
+					"Use the <code>all-options-tag</code> attribute to customize the tag text shown when all options are selected (e.g. <code>all-options-tag=\"All regions\"</code>). If omitted, the default text is used. The component automatically appends \"selected\" or \"deselected\" for screen reader announcements, so use clear, descriptive language.",
+					"To remove the default styling of the \"Select all options\" option, add the <code>select-all-unstyled</code> class to the component. Alternatively, you can use the <code>::part(select-all)</code> CSS selector to style it from outside the component.",
+					"Tag colours can be customized by using the <code>::part(tag)</code> CSS selector."
 				],
 				"fr": [
 					"Un espace réservé est optionnel mais recommandé. Il fonctionne de la même façon que le <code>placeholder</code> d'un <code>input</code> standard.",
-					"Ajoutez l'attribut <code>select-all-options</code> pour activer un option \"Sélectionner toutes les options\" en haut de la liste déroulante. Lorsque toutes les options sont sélectionnées, elles sont remplacées par un seul tag.",
-					"La couleur des étiquettes peut être personnalisée avec le sélecteur CSS <code>::part(tag)</code> depuis l'extérieur du composant."
+					"Ajoutez l'attribut <code>enable-select-all</code> pour activer une option « Sélectionner toutes les options » en haut de la liste déroulante. Lorsque toutes les options sont sélectionnées, elles sont remplacées par une seule étiquette.",
+					"Ajoutez une valeur à l'attribut <code>enable-select-all</code> pour personnaliser le texte « Sélectionner toutes les options » affiché dans la liste déroulante (ex. : <code>enable-select-all=\"Sélectionner toutes les régions\"</code>). Si aucune valeur n'est fournie, le texte par défaut est utilisé.",
+					"Utilisez l'attribut <code>all-options-tag</code> pour personnaliser le texte de l'étiquette affichée lorsque toutes les options sont sélectionnées (ex. : <code>all-options-tag=\"Toutes les régions\"</code>). S'il est omis, le texte par défaut est utilisé. Le composant ajoute automatiquement « sélectionné » ou « désélectionnées » pour les annonces aux lecteurs d'écran; utilisez donc un langage clair et descriptif.",
+					"Pour retirer le style par défaut de l'option « Sélectionner toutes les options », ajoutez la classe <code>select-all-unstyled</code> au composant. Vous pouvez aussi utiliser le sélecteur CSS <code>::part(select-all)</code> pour la styliser depuis l'extérieur du composant.",
+					"La couleur des étiquettes peut être personnalisée avec le sélecteur CSS <code>::part(tag)</code>."
 				]
 			},
 			"sample": {

--- a/_data/templates.json
+++ b/_data/templates.json
@@ -2040,6 +2040,11 @@
 				"title": "AEM Authoring",
 				"language": "en",
 				"path": "theme-aem-authoring.html"
+			},
+			{
+				"title": "AEM as published",
+				"language": "en",
+				"path": "theme-aem-aspublish.html"
 			}
 		],
 		"docs": [

--- a/components/combo-box/_combo-box_custom.scss
+++ b/components/combo-box/_combo-box_custom.scss
@@ -1,0 +1,4 @@
+gc-combobox.select-all-unstyled::part(select-all) {
+	border: none;
+	font-weight: normal;
+}

--- a/components/combo-box/combo-box-docs-en.html
+++ b/components/combo-box/combo-box-docs-en.html
@@ -2,7 +2,7 @@
 {
 	"layout": "documentation",
 	"altLangPage": "combo-box-docs-fr.html",
-	"dateModified": "2026-05-27",
+	"dateModified": "2026-07-06",
 	"index_json": "index.json-ld",
 	"description": "GC Combo Box documentation",
 	"language": "en",

--- a/components/combo-box/combo-box-docs-fr.html
+++ b/components/combo-box/combo-box-docs-fr.html
@@ -2,7 +2,7 @@
 {
 	"layout": "documentation",
 	"altLangPage": "combo-box-docs-en.html",
-	"dateModified": "2026-05-27",
+	"dateModified": "2026-07-06",
 	"index_json": "index.json-ld",
 	"description": "Documentation pour la Boîte Combo GC",
 	"language": "fr",

--- a/components/combo-box/combo-box-en.html
+++ b/components/combo-box/combo-box-en.html
@@ -1,7 +1,7 @@
 ---
 {
 	"title": "GC Combo Box Web Component",
-	"dateModified": "2026-05-13",
+	"dateModified": "2026-07-06",
 	"breadcrumbs": [
 		{ "title": "GC Combo Box - Documentation", "link": "components/combo-box/combo-box-docs-en.html" }
 	],
@@ -81,7 +81,7 @@
 </details>
 
 <h2>Example 6: With Select All Options Enabled</h2>
-<gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" select-all-options>
+<gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" enable-select-all>
 	<span slot="label">Fruit(s)</span>
 	<select slot="options">
 		<option value="apple">Apple</option>
@@ -93,7 +93,7 @@
 
 <details>
 	<summary>View code</summary>
-	<pre><code>&lt;gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" select-all-options&gt;
+	<pre><code>&lt;gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" enable-select-all&gt;
 	&lt;span slot="label"&gt;Fruit(s)&lt;/span&gt;
 	&lt;select slot="options"&gt;
 		&lt;option value="apple"&gt;Apple&lt;/option&gt;
@@ -104,7 +104,55 @@
 &lt;/gc-combobox&gt;</code></pre>
 </details>
 
-<h2>Example 7: Public API Tests</h2>
+<h2>Example 7: Customized Select All Labels</h2>
+<gc-combobox placeholder="Fruit(s)..." name="fruits-custom-labels" enable-select-all="Select all fruits" all-options-tag="All fruits">
+	<span slot="label">Fruit(s)</span>
+	<select slot="options">
+		<option value="apple">Apple</option>
+		<option value="banana">Banana</option>
+		<option value="orange">Orange</option>
+		<option value="grape">Grape</option>
+	</select>
+</gc-combobox>
+
+<details>
+	<summary>View code</summary>
+	<pre><code>&lt;gc-combobox placeholder="Fruit(s)..." name="fruits-custom-labels" enable-select-all="Select all fruits" all-options-tag="All fruits"&gt;
+	&lt;span slot="label"&gt;Fruit(s)&lt;/span&gt;
+	&lt;select slot="options"&gt;
+		&lt;option value="apple"&gt;Apple&lt;/option&gt;
+		&lt;option value="banana"&gt;Banana&lt;/option&gt;
+		&lt;option value="orange"&gt;Orange&lt;/option&gt;
+		&lt;option value="grape"&gt;Grape&lt;/option&gt;
+	&lt;/select&gt;
+&lt;/gc-combobox&gt;</code></pre>
+</details>
+
+<h2>Example 8: Unstyled Select All Option</h2>
+<gc-combobox class="select-all-unstyled" placeholder="Fruit(s)..." name="fruits-select-all-unstyled" enable-select-all>
+	<span slot="label">Fruit(s)</span>
+	<select slot="options">
+		<option value="apple">Apple</option>
+		<option value="banana">Banana</option>
+		<option value="orange">Orange</option>
+		<option value="grape">Grape</option>
+	</select>
+</gc-combobox>
+
+<details>
+	<summary>View code</summary>
+	<pre><code>&lt;gc-combobox class="select-all-unstyled" placeholder="Fruit(s)..." name="fruits-select-all-unstyled" enable-select-all&gt;
+	&lt;span slot="label"&gt;Fruit(s)&lt;/span&gt;
+	&lt;select slot="options"&gt;
+		&lt;option value="apple"&gt;Apple&lt;/option&gt;
+		&lt;option value="banana"&gt;Banana&lt;/option&gt;
+		&lt;option value="orange"&gt;Orange&lt;/option&gt;
+		&lt;option value="grape"&gt;Grape&lt;/option&gt;
+	&lt;/select&gt;
+&lt;/gc-combobox&gt;</code></pre>
+</details>
+
+<h2>Example 9: Public API Tests</h2>
 <gc-combobox id="demo-api" placeholder="Fruit(s)..." name="fruits-api">
 	<span slot="label">Fruit(s)</span>
 	<select slot="options">

--- a/components/combo-box/combo-box-fr.html
+++ b/components/combo-box/combo-box-fr.html
@@ -1,7 +1,7 @@
 ---
 {
 	"title": "Composant Boîte Combo GC",
-	"dateModified": "2026-05-13",
+	"dateModified": "2026-07-06",
 	"breadcrumbs": [
 		{ "title": "Boîte Combo GC - Documentation", "link": "components/combo-box/combo-box-docs-fr.html" }
 	],
@@ -99,7 +99,7 @@
 </details>
 
 <h2>Exemple 6 : Avec l'option Sélectionner tout activée</h2>
-<gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" select-all-options>
+<gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" enable-select-all>
 	<span slot="label">Fruit(s)</span>
 	<select slot="options">
 		<option value="apple">Pomme</option>
@@ -111,7 +111,7 @@
 
 <details>
 	<summary>Visualiser le code</summary>
-	<pre><code>&lt;gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" select-all-options&gt;
+	<pre><code>&lt;gc-combobox placeholder="Fruit(s)..." name="fruits-select-all" enable-select-all&gt;
 	&lt;span slot="label"&gt;Fruit(s)&lt;/span&gt;
 	&lt;select slot="options"&gt;
 		&lt;option value="apple"&gt;Pomme&lt;/option&gt;
@@ -122,7 +122,55 @@
 &lt;/gc-combobox&gt;</code></pre>
 </details>
 
-<h2>Exemple 7 : Tests d'API publique</h2>
+<h2>Exemple 7 : Libellé « Sélectionner tout » personnalisé</h2>
+<gc-combobox placeholder="Fruit(s)..." name="fruits-custom-labels" enable-select-all="Sélectionner tous les fruits" all-options-tag="Tous les fruits">
+	<span slot="label">Fruit(s)</span>
+	<select slot="options">
+		<option value="apple">Pomme</option>
+		<option value="banana">Banane</option>
+		<option value="orange">Orange</option>
+		<option value="grape">Raisin</option>
+	</select>
+</gc-combobox>
+
+<details>
+	<summary>Visualiser le code</summary>
+	<pre><code>&lt;gc-combobox placeholder="Fruit(s)..." name="fruits-custom-labels" enable-select-all="Sélectionner tous les fruits" all-options-tag="Tous les fruits"&gt;
+	&lt;span slot="label"&gt;Fruit(s)&lt;/span&gt;
+	&lt;select slot="options"&gt;
+		&lt;option value="apple"&gt;Pomme&lt;/option&gt;
+		&lt;option value="banana"&gt;Banane&lt;/option&gt;
+		&lt;option value="orange"&gt;Orange&lt;/option&gt;
+		&lt;option value="grape"&gt;Raisin&lt;/option&gt;
+	&lt;/select&gt;
+&lt;/gc-combobox&gt;</code></pre>
+</details>
+
+<h2>Exemple 8 : Option « Sélectionner tout » non stylisée</h2>
+<gc-combobox class="select-all-unstyled" placeholder="Fruit(s)..." name="fruits-select-all-unstyled" enable-select-all>
+	<span slot="label">Fruit(s)</span>
+	<select slot="options">
+		<option value="apple">Pomme</option>
+		<option value="banana">Banane</option>
+		<option value="orange">Orange</option>
+		<option value="grape">Raisin</option>
+	</select>
+</gc-combobox>
+
+<details>
+	<summary>Visualiser le code</summary>
+	<pre><code>&lt;gc-combobox class="select-all-unstyled" placeholder="Fruit(s)..." name="fruits-select-all-unstyled" enable-select-all&gt;
+	&lt;span slot="label"&gt;Fruit(s)&lt;/span&gt;
+	&lt;select slot="options"&gt;
+		&lt;option value="apple"&gt;Pomme&lt;/option&gt;
+		&lt;option value="banana"&gt;Banane&lt;/option&gt;
+		&lt;option value="orange"&gt;Orange&lt;/option&gt;
+		&lt;option value="grape"&gt;Raisin&lt;/option&gt;
+	&lt;/select&gt;
+&lt;/gc-combobox&gt;</code></pre>
+</details>
+
+<h2>Exemple 9 : Tests d'API publique</h2>
 <gc-combobox id="demo-api" placeholder="Fruit(s)..." name="fruits-api">
 	<span slot="label">Fruit(s)</span>
 	<select slot="options">

--- a/components/combo-box/combo-box.css
+++ b/components/combo-box/combo-box.css
@@ -133,8 +133,8 @@
 	&.combo-box-option-select-all {
 		border-bottom: 1px solid #ccc;
 		font-weight: 700;
-		margin-bottom: 4px;
-		padding-bottom: 8px;
+		padding-top: 6px;
+		padding-bottom: 6px;
 	}
 
 	&:focus {
@@ -149,7 +149,7 @@
 }
 
 
-.sr-only {
+.wb-inv {
 	position: absolute;
 	width: 1px;
 	height: 1px;

--- a/components/combo-box/combo-box.js
+++ b/components/combo-box/combo-box.js
@@ -22,30 +22,26 @@ class GcComboBoxComponent extends HTMLElement {
 	static defaults = {
 		i18n: {
 			"en": {
-				selectAll: "Select all",
 				itemsSelected: "items selected",
 				selectAllOptions: "Select all options",
-				deselectAllOptions: "Deselect all options",
 				availableOptions: "Available options",
 				selected: "selected",
+				deselected: "deselected",
 				removed: "removed",
 				remove: "Remove",
 				noMatchingOptions: "No matching options",
-				allOptionsSelected: "All options selected",
-				allOptionsDeselected: "All options deselected"
+				allOptions: "All options"
 			},
 			"fr": {
-				selectAll: "Sélectionner tous",
 				itemsSelected: "éléments sélectionnés",
 				selectAllOptions: "Sélectionner toutes les options",
-				deselectAllOptions: "Désélectionner toutes les options",
 				availableOptions: "Options disponibles",
 				selected: "sélectionné",
+				deselected: "désélectionnées",
 				removed: "supprimé",
 				remove: "Supprimer",
 				noMatchingOptions: "Aucune option correspondante",
-				allOptionsSelected: "Toutes les options sélectionnées",
-				allOptionsDeselected: "Toutes les options désélectionnées"
+				allOptions: "Toutes les options"
 			}
 		}
 	};
@@ -70,13 +66,28 @@ class GcComboBoxComponent extends HTMLElement {
 		return this.constructor.defaults.i18n[ this.pageLanguage ] || {};
 	}
 
+	getAllOptionsTag() {
+		return this.getAttribute( "all-options-tag" )?.trim() || this.getLocalizedText().allOptions;
+	}
+
+	getSelectAllOption() {
+		return this.getAttribute( "enable-select-all" )?.trim() || this.getLocalizedText().selectAllOptions;
+	}
+
+	// In the case the customized tag has the word "selected", this method ensures that it is not read twice by screen readers
+	getSanitizedAllOptionsAnnouncement() {
+		const tagText = this.getAllOptionsTag();
+		const selected = this.getLocalizedText().selected;
+		return tagText.toLowerCase().endsWith( selected.toLowerCase() ) ? tagText : `${ tagText } ${ selected }`;
+	}
+
 	connectedCallback() {
 
 		// Set page language from document or fallback to English
 		this.pageLanguage = ( typeof wb !== "undefined" && wb.lang ) ? wb.lang : "en";
 
-		// Check if select-all-options attribute is present
-		this.allowSelectAll = this.hasAttribute( "select-all-options" );
+		// Check if enable-select-all attribute is present
+		this.allowSelectAll = this.hasAttribute( "enable-select-all" );
 
 		this.initializeComponent();
 	}
@@ -136,7 +147,7 @@ class GcComboBoxComponent extends HTMLElement {
 			this.selectAllOptionElement.className = "combo-box-option combo-box-option-select-all";
 			this.selectAllOptionElement.setAttribute( "role", "option" );
 			this.selectAllOptionElement.setAttribute( "data-select-all", "true" );
-			this.selectAllOptionElement.textContent = this.getLocalizedText().selectAllOptions;
+			this.selectAllOptionElement.textContent = this.getSelectAllOption();
 		}
 
 		// Build the empty state element once
@@ -222,6 +233,7 @@ class GcComboBoxComponent extends HTMLElement {
 								autocomplete="off"
 								aria-autocomplete="list"
 								aria-controls="combo-box-list"
+								aria-describedby="combo-box-selection-desc"
 								aria-expanded="false"
 								aria-haspopup="listbox"
 							>
@@ -240,7 +252,8 @@ class GcComboBoxComponent extends HTMLElement {
 				</div>
 
 				<!-- Live region for screen reader announcements -->
-				<div id="liveRegion" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+				<div id="liveRegion" class="wb-inv" aria-live="polite" aria-atomic="true"></div>
+				<span id="combo-box-selection-desc" class="wb-inv"></span>
 			</div>
 		`;
 	}
@@ -251,10 +264,23 @@ class GcComboBoxComponent extends HTMLElement {
 		this.list = this.shadowRoot.getElementById( "combo-box-list" );
 		this.tagsContainer = this.shadowRoot.getElementById( "tagsContainer" );
 		this.liveRegion = this.shadowRoot.getElementById( "liveRegion" );
+		this.selectionDescription = this.shadowRoot.getElementById( "combo-box-selection-desc" );
 
 		// Store the original placeholder text
 		this.originalPlaceholder = this.input.placeholder;
 	}
+
+	// Updates the description for AT that is announced when the input is focused
+	updateSelectionDescription() {
+		if ( this.allOptionsSelected ) {
+			this.selectionDescription.textContent = this.getSanitizedAllOptionsAnnouncement();
+		} else if ( this.selectedOptions.length > 0 ) {
+			this.selectionDescription.textContent = `${ this.selectedOptions.length } ${ this.getLocalizedText().itemsSelected }`;
+		} else {
+			this.selectionDescription.textContent = "";
+		}
+	}
+
 
 	// Attaches all event listeners
 	attachEventListeners() {
@@ -321,6 +347,10 @@ class GcComboBoxComponent extends HTMLElement {
 
 	// Filters options based on user input
 	handleInput( e ) {
+		if ( this.allOptionsSelected ) {
+			return;
+		}
+
 		const value = e.target.value.trim();
 
 		this.filteredOptions = [ ...this.allOptions ].filter( option => {
@@ -498,8 +528,7 @@ class GcComboBoxComponent extends HTMLElement {
 			}
 
 			// Announce selection to screen readers
-			const count = this.selectedOptions.length;
-			this.announce( `${ option.label } ${ this.getLocalizedText().selected }. ${ count } ${ this.getLocalizedText().itemsSelected }.` );
+			this.announce( `${ option.label } ${ this.getLocalizedText().selected }.` );
 
 			// Dispatch change event
 			this.dispatchChangeEvent();
@@ -558,8 +587,9 @@ class GcComboBoxComponent extends HTMLElement {
 		tag.dataset.tagValue = item.value;
 		tag.tabIndex = -1;
 
-		// tag.setAttribute( "part", "tag" );
-		tag.innerHTML = `<span class="wb-inv" hidden>${ this.getLocalizedText().remove } </span><span class="tag-text">${ this.escapeHtml( item.label ) }</span><span class="tag-dismiss" aria-hidden="true">×</span>`;
+		tag.setAttribute( "part", "tag" );
+		tag.setAttribute( "aria-label", `${ this.getLocalizedText().remove } ${ item.label }` );
+		tag.innerHTML = `<span class="tag-text">${ this.escapeHtml( item.label ) }</span><span class="tag-dismiss" aria-hidden="true">×</span>`;
 		return tag;
 	}
 
@@ -571,8 +601,9 @@ class GcComboBoxComponent extends HTMLElement {
 		tag.dataset.tagValue = "all-options";
 		tag.tabIndex = -1;
 
-		// tag.setAttribute( "part", "tag" );
-		tag.innerHTML = `<span class="wb-inv" hidden>${ this.getLocalizedText().remove } </span><span class="tag-text">${ this.getLocalizedText().allOptionsSelected }</span><span class="tag-dismiss" aria-hidden="true">×</span>`;
+		tag.setAttribute( "part", "tag" );
+		tag.setAttribute( "aria-label", `${ this.getLocalizedText().remove } ${ this.getAllOptionsTag() }` );
+		tag.innerHTML = `<span class="tag-text">${ this.getAllOptionsTag() }</span><span class="tag-dismiss" aria-hidden="true">×</span>`;
 		return tag;
 	}
 
@@ -610,7 +641,6 @@ class GcComboBoxComponent extends HTMLElement {
 		this.input.value = "";
 		if ( allSelected ) {
 			this.input.placeholder = "";
-			this.tagsContainer.setAttribute( "aria-label", this.getLocalizedText().allOptionsSelected );
 			this.tagsContainer.setAttribute( "role", "toolbar" ); // AT Compatibility - See following comment about the role=toolbar used the subsequent instruction
 		} else {
 			this.input.placeholder = this.originalPlaceholder;
@@ -625,6 +655,8 @@ class GcComboBoxComponent extends HTMLElement {
 
 		// Ensure the input is always last
 		this.tagsContainer.appendChild( this.input );
+
+		this.updateSelectionDescription();
 
 		if ( hadFocus ) {
 			this.input.focus();
@@ -643,6 +675,7 @@ class GcComboBoxComponent extends HTMLElement {
 			// Prepend "Select all options" from cache if enabled
 			if ( this.allowSelectAll ) {
 				this.selectAllOptionElement.classList.remove( "active" );
+				this.selectAllOptionElement.setAttribute( "part", "select-all" );
 				this.list.appendChild( this.selectAllOptionElement );
 			}
 
@@ -661,7 +694,7 @@ class GcComboBoxComponent extends HTMLElement {
 
 	// Opens the dropdown list
 	openList() {
-		if ( !this.isOpen ) {
+		if ( !this.isOpen && !this.allOptionsSelected ) {
 			this.isOpen = true;
 			this.list.removeAttribute( "hidden" );
 			this.input.setAttribute( "aria-expanded", "true" );
@@ -766,15 +799,23 @@ class GcComboBoxComponent extends HTMLElement {
 			return;
 		}
 
-		// Create hidden input for each selected item to be submitted with forms
-		this.selectedOptions.forEach( item => {
+		if ( this.allOptionsSelected ) {
 			const input = document.createElement( "input" );
 			input.type = "hidden";
 			input.name = name;
-			input.value = item.value;
+			input.value = "all";
 			input.dataset.comboValue = "true";
 			this.appendChild( input );
-		} );
+		} else {
+			this.selectedOptions.forEach( item => {
+				const input = document.createElement( "input" );
+				input.type = "hidden";
+				input.name = name;
+				input.value = item.value;
+				input.dataset.comboValue = "true";
+				this.appendChild( input );
+			} );
+		}
 	}
 
 	// Public API: Get selected values as array (useful for form handling)
@@ -816,8 +857,7 @@ class GcComboBoxComponent extends HTMLElement {
 
 		this.syncHiddenInputs();
 
-		// Announce action to screen readers
-		this.announce( `${ this.getLocalizedText().allOptionsSelected }` );
+		this.announce( this.getSanitizedAllOptionsAnnouncement() );
 
 		// Dispatch change event
 		this.dispatchChangeEvent();
@@ -836,7 +876,7 @@ class GcComboBoxComponent extends HTMLElement {
 		this.syncHiddenInputs();
 
 		// Announce action to screen readers
-		this.announce( `${ this.getLocalizedText().allOptionsDeselected }` );
+		this.announce( `${ this.getAllOptionsTag() } ${ this.getLocalizedText().deselected }` );
 
 		// Dispatch change event
 		this.dispatchChangeEvent();

--- a/components/combo-box/index.json-ld
+++ b/components/combo-box/index.json-ld
@@ -14,7 +14,7 @@
 		"en": "An accessible multi-select combo box component that implements WCAG 2.1 accessibility standards and provides a modern, user-friendly interface for selecting multiple items from a list.",
 		"fr": "Un composant de boîte combo multi-sélection accessible qui met en œuvre les normes d'accessibilité WCAG 2.1 et fournit une interface conviviale et moderne pour sélectionner plusieurs éléments dans une liste."
 	},
-	"modified": "2026-05-27",
+	"modified": "2026-07-06",
 	"componentName": "combo-box",
 	"status": "provisional",
 	"version": "0.1.0",
@@ -115,13 +115,19 @@
 			"notes": {
 				"en": [
 					"A placeholder is optional but recommended. It works the same as a standard <code>input</code> placeholder.",
-					"Add the <code>select-all-options</code> attribute to enable a \"Select all options\" option at the top of the dropdown. When all options are selected, they are replaced by a single tag.",
-					"Tag colours can be customized using the <code>::part(tag)</code> CSS selector from outside the component."
+					"Add the <code>enable-select-all</code> attribute to enable a \"Select all options\" option at the top of the dropdown. When all options are selected, they are replaced by a single tag.",
+					"Add a value to the <code>enable-select-all</code> attribute to customize the \"Select all options\" text shown in the dropdown (e.g. <code>enable-select-all=\"Select all regions\"</code>). If no value is provided, it uses the default text.",
+					"Use the <code>all-options-tag</code> attribute to customize the tag text shown when all options are selected (e.g. <code>all-options-tag=\"All regions\"</code>). If omitted, the default text is used. The component automatically appends \"selected\" or \"deselected\" for screen reader announcements, so use clear, descriptive language.",
+					"To remove the default styling of the \"Select all options\" option, add the <code>select-all-unstyled</code> class to the component. Alternatively, you can use the <code>::part(select-all)</code> CSS selector to style it from outside the component.",
+					"Tag colours can be customized by using the <code>::part(tag)</code> CSS selector."
 				],
 				"fr": [
 					"Un espace réservé est optionnel mais recommandé. Il fonctionne de la même façon que le <code>placeholder</code> d'un <code>input</code> standard.",
-					"Ajoutez l'attribut <code>select-all-options</code> pour activer un option \"Sélectionner toutes les options\" en haut de la liste déroulante. Lorsque toutes les options sont sélectionnées, elles sont remplacées par un seul tag.",
-					"La couleur des étiquettes peut être personnalisée avec le sélecteur CSS <code>::part(tag)</code> depuis l'extérieur du composant."
+					"Ajoutez l'attribut <code>enable-select-all</code> pour activer une option « Sélectionner toutes les options » en haut de la liste déroulante. Lorsque toutes les options sont sélectionnées, elles sont remplacées par une seule étiquette.",
+					"Ajoutez une valeur à l'attribut <code>enable-select-all</code> pour personnaliser le texte « Sélectionner toutes les options » affiché dans la liste déroulante (ex. : <code>enable-select-all=\"Sélectionner toutes les régions\"</code>). Si aucune valeur n'est fournie, le texte par défaut est utilisé.",
+					"Utilisez l'attribut <code>all-options-tag</code> pour personnaliser le texte de l'étiquette affichée lorsque toutes les options sont sélectionnées (ex. : <code>all-options-tag=\"Toutes les régions\"</code>). S'il est omis, le texte par défaut est utilisé. Le composant ajoute automatiquement « sélectionné » ou « désélectionnées » pour les annonces aux lecteurs d'écran; utilisez donc un langage clair et descriptif.",
+					"Pour retirer le style par défaut de l'option « Sélectionner toutes les options », ajoutez la classe <code>select-all-unstyled</code> au composant. Vous pouvez aussi utiliser le sélecteur CSS <code>::part(select-all)</code> pour la styliser depuis l'extérieur du composant.",
+					"La couleur des étiquettes peut être personnalisée avec le sélecteur CSS <code>::part(tag)</code>."
 				]
 			},
 			"sample": {

--- a/sites/theme.scss
+++ b/sites/theme.scss
@@ -114,6 +114,7 @@
 @import "bootstrap-sass/assets/stylesheets/bootstrap/close";
 @import "wet-boew/src/base/bootstrap-overrides/components";
 @import "wet-boew/src/base/ellipsis/base";
+@import "../components/combo-box/combo-box_custom";
 
 // Provisional wet-boew components
 @import "wet-boew/src/base/provisional";


### PR DESCRIPTION
_Related to [WET-677](https://jtickets.atlassian.net/browse/WET-677)_

Preivew page: [GC Combo Box Web Component
](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2807/components/combo-box/combo-box-en.html)
Changes include:
- Added the option to style the "Select all options" option from an external CSS file using the `::part(select-all)` selector
- Added optional class `select-all-unstyled` that users can add on the component to remove the default styling on the "Select all options" option
- Renamed the `select-all-options` attribute to `enable-all-options` and added the option to assign a value to replace the default "Select all options" text
- Added the optional attribute `all-options-tag` to allow for the customization of the "All options" tag text
- Changed the all options tag default text to "All options" instead of "All options selected" (screen readers still announce "selected")
- Hide empty state when all options are selected
- In form submissions: send "all" instead of every individual tag when all options are selected
- Updated documentation to reflect changes

Closes PR #2806