### PR TITLE
Authentication: setting character limit for contextual sign in button

### DIFF
--- a/sites/authentication/authentication-en.html
+++ b/sites/authentication/authentication-en.html
@@ -4,7 +4,7 @@
 	"breadcrumb": {
 		"title": "Canada.ca", "link": "https://www.canada.ca/en.html"
 	},
-	"dateModified": "2022-06-30",
+	"dateModified": "2026-06-26",
 	"description": "Documentation on how to use the various authentication patterns.",
 	"language": "en",
 	"title": "Authentication patterns"
@@ -43,6 +43,14 @@
 		<li><code>labelExtended</code> with a maximum length of 25 characters allowed including spaces, this parameter is optional but must be set along with the <code>label</code> parameter and if set, it will generate the text appearing on the button for small viewport and up (sm, md, lg and xl).</li>
 	</ul>
 </details>
+
+<h3>Content Specifications</h3>
+
+<p>Use "Sign in" as the label</p>
+<ul>
+	<li><b>Small screens:</b> total of 12 characters including spaces (no additional descriptive text)</li>
+	<li><b>Large/medium screens:</b> total of 25 characters including spaces (for additional descriptive text if needed, such as “Sign in to [account name]”)</li>
+</ul>
 
 <h2>Signed-off / Signed-on</h2>
 

--- a/sites/authentication/authentication-fr.html
+++ b/sites/authentication/authentication-fr.html
@@ -4,7 +4,7 @@
 	"breadcrumb": {
 		"title": "Canada.ca", "link": "https://www.canada.ca/fr.html"
 	},
-	"dateModified": "2022-06-30",
+	"dateModified": "2026-06-26",
 	"description": "Documentation sur l'utilisation des divers modèles d'authentification.",
 	"language": "fr",
 	"title": "Modèles d'authentification"
@@ -42,6 +42,14 @@
 		<li><code>labelExtend</code> avec un maximum de 25 caractères alloué incluant les espacements, ce paramètre est optionnel et si défini, il générera le text du bouton pour les fenêtre d'affichages petite et au dessus (sm, md, lg et xl).</li>
 	</ul>
 </details>
+
+<h3>Contenu et conception</h3>
+
+<p>Utiliser « Se connecter » comme étiquette</p>
+<ul>
+	<li><b>Petits écrans :</b> 12 caractères au total y compris les espaces (pas de texte descriptif supplémentaire)</li>
+	<li><b>Écrans de taille moyenne et de grande taille :</b> 25 caractères au total (pour du texte descriptif supplémentaire au besoin, par exemple « Se connecter à [nom du compte] »)</li>
+</ul>
 
 <h2>Modèles de Session fermée / Session ouverte</h2>
 

--- a/sites/authentication/includes/authentication.html
+++ b/sites/authentication/includes/authentication.html
@@ -7,7 +7,7 @@
 		{%- endunless -%}
 	</h2>
 {%- if page.auth.type == "contextual" -%}
-	{% assign label = page.auth.label | truncate: 25, "" %}
+	{% assign label = page.auth.label | truncate: 12, "" %}
 	{% assign labelExtended = page.auth.labelExtended | truncate: 25, "" %}
 	<a class="btn btn-primary" href="{{ page.auth.link }}">
 	{%- if label and labelExtended -%}


### PR DESCRIPTION
Related to WET-676.
Set character limit for contextual sign in button: 12 characters total (including spaces) for small screens and 25 characters total (including spaces) for large screens.