### PR TITLE
GC Panels: Added heading and title to all examples

### DIFF
--- a/components/panels/panels-en.html
+++ b/components/panels/panels-en.html
@@ -10,12 +10,15 @@
 <div class="wb-prettify all-pre"></div>
 
 <h2>Stacking options</h2>
-<p>Use to create  various container types. A panel can be broken up into a <code>.panel</code>, <code>.panel-heading</code>, <code>.panel-title</code>, <code>panel-body</code> and <code>.panel-footer</code>. Only the <code>.panel</code> is required. All the rest are optional.</p>
+<p>Use to create  various container types. A panel can be broken up into a <code>.panel</code>, <code>.panel-heading</code>, <code>.panel-title</code>, <code>panel-body</code> and <code>.panel-footer</code>. The <code>.panel</code>, <code>.panel-heading</code> and <code>.panel-title</code> elements are required; all other panel elements are optional.</p>
 
 <div class="row">
 	<div class="col-sm-6 col-lg-3">
 		<p>Padded content:</p>
 		<div class="panel panel-default">
+			<header class="panel-heading">
+				<h3 class="panel-title">Panel title</h3>
+			</header>
 			<div class="panel-body">
 				<p>Content</p>
 			</div>
@@ -24,6 +27,9 @@
 	<div class="col-sm-6 col-lg-3">
 		<p>Full-width content:</p>
 		<div class="panel panel-default">
+			<header class="panel-heading">
+				<h3 class="panel-title">Panel title</h3>
+			</header>
 			<table class="table">
 				<caption class="wb-inv">Caption text</caption>
 				<thead>
@@ -48,6 +54,9 @@
 	<div class="col-sm-6 col-lg-3">
 		<p>Padded plus full-width content:</p>
 		<div class="panel panel-default">
+			<header class="panel-heading">
+				<h3 class="panel-title">Panel title</h3>
+			</header>
 			<div class="panel-body">
 				<p>Content</p>
 			</div>
@@ -75,7 +84,7 @@
 		</div>
 	</div>
 	<div class="col-sm-6 col-lg-3">
-		<p>Add a heading and/or footer:</p>
+		<p>Add a footer:</p>
 		<div class="panel panel-default">
 			<header class="panel-heading">
 				<h3 class="panel-title">Panel title</h3>
@@ -92,12 +101,18 @@
 <dl>
 	<dt>Padded content:</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
+	&lt;header class="panel-heading"&gt;
+	&lt;h3 class="panel-title"&gt;Panel title&lt;/h3&gt;
+	&lt;/header&gt;
 	&lt;div class="panel-body"&gt;
 		&lt;p&gt;Content&lt;/p&gt;
 	&lt;/div&gt;
 &lt;/div&gt;</code></pre></dd>
 	<dt>Full-width content:</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
+	&lt;header class="panel-heading"&gt;
+		&lt;h3 class="panel-title"&gt;Panel title&lt;/h3&gt;
+	&lt;/header&gt;
 	&lt;table class="table"&gt;
 		&lt;caption class="wb-inv"&gt;Caption text&lt;/caption&gt;
 		&lt;thead&gt;
@@ -120,6 +135,9 @@
 &lt;/div&gt;</code></pre></dd>
 	<dt>Padded plus full-width content:</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
+	&lt;header class="panel-heading"&gt;
+		&lt;h3 class="panel-title"&gt;Panel title&lt;/h3&gt;
+	&lt;/header&gt;
 	&lt;div class="panel-body"&gt;
 		&lt;p&gt;Content&lt;/p&gt;
 	&lt;/div&gt;
@@ -145,7 +163,7 @@
 		&lt;/tbody&gt;
 	&lt;/table&gt;
 &lt;/div&gt;</code></pre></dd>
-	<dt>Add a heading and/or footer:</dt>
+	<dt>Add a footer:</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
 	&lt;header class="panel-heading"&gt;
 		&lt;h3 class="panel-title"&gt;Panel title&lt;/h3&gt;

--- a/components/panels/panels-fr.html
+++ b/components/panels/panels-fr.html
@@ -10,12 +10,15 @@
 <div class="wb-prettify all-pre"></div>
 
 <h2>Options d'énumération par ordre de priorité</h2>
-<p>Les utiliser pour créer divers types de conteneurs.  Un panneau décomposé comprend les éléments suivants :  <code>.panel</code>, <code>.panel-heading</code>, <code>.panel-title</code>, <code>panel-body</code> et <code>.panel-footer</code>. Seul l'élément <code>.panel</code> est requis. Tous les autres sont facultatifs.</p>
+<p>Les utiliser pour créer divers types de conteneurs.  Un panneau décomposé comprend les éléments suivants :  <code>.panel</code>, <code>.panel-heading</code>, <code>.panel-title</code>, <code>panel-body</code> et <code>.panel-footer</code>. Les éléments <code>.panel</code>, <code>.panel-heading</code> et <code>.panel-title</code> sont requis; tous les autres éléments du panneau sont facultatifs.</p>
 
 <div class="row">
 	<div class="col-sm-6 col-lg-3">
 		<p>Contenu rempli :</p>
 		<div class="panel panel-default">
+			<header class="panel-heading">
+				<h3 class="panel-title">Titre du panneau</h3>
+			</header>
 			<div class="panel-body">
 				<p>Contenu</p>
 			</div>
@@ -24,6 +27,9 @@
 	<div class="col-sm-6 col-lg-3">
 		<p>Contenu à pleine chasse :</p>
 		<div class="panel panel-default">
+			<header class="panel-heading">
+				<h3 class="panel-title">Titre du panneau</h3>
+			</header>
 			<table class="table">
 				<caption class="wb-inv">Texte de la légende</caption>
 				<thead>
@@ -48,6 +54,9 @@
 	<div class="col-sm-6 col-lg-3">
 		<p>Contenu rempli et à pleine chasse :</p>
 		<div class="panel panel-default">
+			<header class="panel-heading">
+				<h3 class="panel-title">Titre du panneau</h3>
+			</header>
 			<div class="panel-body">
 				<p>Contenu</p>
 			</div>
@@ -73,7 +82,7 @@
 		</div>
 	</div>
 	<div class="col-sm-6 col-lg-3">
-		<p>Ajouter un en-tête et/ou un pied de page :</p>
+		<p>Ajouter un pied de page :</p>
 		<div class="panel panel-default">
 			<header class="panel-heading">
 				<h3 class="panel-title">Titre du panneau</h3>
@@ -90,12 +99,18 @@
 <dl>
 	<dt>Contenu rempli :</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
+		&lt;header class="panel-heading"&gt;
+		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
+		&lt;/header&gt;
 	&lt;div class="panel-body"&gt;
 		&lt;p&gt;Contenu&lt;/p&gt;
 	&lt;/div&gt;
 &lt;/div&gt;</code></pre></dd>
-	<dt>FContenu à pleine chasse :</dt>
+	<dt>Contenu à pleine chasse :</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
+		&lt;header class="panel-heading"&gt;
+		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
+		&lt;/header&gt;
 	&lt;table class="table"&gt;
 		&lt;caption class="wb-inv"&gt;Texte de la légende&lt;/caption&gt;
 		&lt;thead&gt;
@@ -118,12 +133,15 @@
 &lt;/div&gt;</code></pre></dd>
 	<dt>Contenu rempli et à pleine chasse :</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
-	&lt;div class="panel-body"&gt;
-		&lt;p&gt;Contenu&lt;/p&gt;
-	&lt;/div&gt;
-	&lt;table class="table"&gt;
-		&lt;caption class="wb-inv"&gt;Texte de la légende&lt;/caption&gt;
-		&lt;thead&gt;
+		&lt;header class="panel-heading"&gt;
+			&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
+		&lt;/header&gt;
+		&lt;div class="panel-body"&gt;
+			&lt;p&gt;Contenu&lt;/p&gt;
+		&lt;/div&gt;
+		&lt;table class="table"&gt;
+			&lt;caption class="wb-inv"&gt;Texte de la légende&lt;/caption&gt;
+			&lt;thead&gt;
 			&lt;tr&gt;
 				&lt;th&gt;En-tête de tableau&lt;/th&gt;
 				&lt;th&gt;En-tête de tableau&lt;/th&gt;
@@ -141,7 +159,7 @@
 		&lt;/tbody&gt;
 	&lt;/table&gt;
 &lt;/div&gt;</code></pre></dd>
-	<dt>Add a heading and/or footer:</dt>
+	<dt>Ajouter un pied de page :</dt>
 	<dd><pre><code>&lt;div class="panel panel-default"&gt;
 	&lt;header class="panel-heading"&gt;
 		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
@@ -166,7 +184,7 @@
 			</div>
 		</section>
 	</dd>
-	<dt>Primary panel</dt>
+	<dt>Panneau primaire</dt>
 	<dd><p>L'utiliser pour mettre en évidence des renseignements généraux ou des actions générales dans une boîte autonome.</p>
 		<section class="panel panel-primary mrgn-bttm-0">
 			<header class="panel-heading">
@@ -177,8 +195,8 @@
 			</div>
 		</section>
 	</dd>
-	<dt>Success panel</dt>
-	<dd><p>Use to spotlight correct information/actions within a self-contained box.</p>
+	<dt>Panneau sur la réussite</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions correctes dans un encadré autonome.</p>
 		<section class="panel panel-success mrgn-bttm-0">
 			<header class="panel-heading">
 				<h3 class="panel-title">Titre du panneau</h3>
@@ -188,8 +206,8 @@
 			</div>
 		</section>
 	</dd>
-	<dt>Info panel</dt>
-	<dd><p>Use to spotlight specialized information/actions within a self-contained box.</p>
+	<dt>Panneau d'information</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions spécialisées dans un encadré autonome.</p>
 		<section class="panel panel-info mrgn-bttm-0">
 			<header class="panel-heading">
 				<h3 class="panel-title">Titre du panneau</h3>
@@ -199,8 +217,8 @@
 			</div>
 		</section>
 	</dd>
-	<dt>Warning panel</dt>
-	<dd><p>Use to spotlight warning information/actions within a self-contained box.</p>
+	<dt>Panneau d'avertissement</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions d'avertissement dans un encadré autonome.</p>
 		<section class="panel panel-warning mrgn-bttm-0">
 			<header class="panel-heading">
 				<h3 class="panel-title">Titre du panneau</h3>
@@ -210,8 +228,8 @@
 			</div>
 		</section>
 	</dd>
-	<dt>Danger panel</dt>
-	<dd><p>Use to spotlight dangerous information/actions within a self-contained box.</p>
+	<dt>Panneau de danger</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions dangereuses dans un encadré autonome.</p>
 	<section class="panel panel-danger mrgn-bttm-0">
 		<header class="panel-heading">
 			<h3 class="panel-title">Titre du panneau</h3>
@@ -225,7 +243,7 @@
 
 <h3>Source code</h3>
 <dl>
-	<dt>Default panel</dt>
+	<dt>Panneau par défaut</dt>
 	<dd><p>L'utiliser pour mettre en évidence des renseignements généraux ou des actions générales dans une boîte autonome.</p>
 		<pre><code>&lt;section class="panel panel-default mrgn-bttm-0"&gt;
 	&lt;header class="panel-heading"&gt;
@@ -236,7 +254,7 @@
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
 	</dd>
-	<dt>Primary panel</dt>
+	<dt>Panneau primaire</dt>
 	<dd><p>L'utiliser pour mettre en évidence des renseignements généraux ou des actions générales dans une boîte autonome.</p>
 		<pre><code>&lt;section class="panel panel-primary mrgn-bttm-0"&gt;
 	&lt;header class="panel-heading"&gt;
@@ -247,8 +265,8 @@
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
 	</dd>
-	<dt>Success panel</dt>
-	<dd><p>Use to spotlight correct information/actions within a self-contained box.</p>
+	<dt>Panneau sur la réussite</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions correctes dans un encadré autonome.</p>
 		<pre><code>&lt;section class="panel panel-success mrgn-bttm-0"&gt;
 	&lt;header class="panel-heading"&gt;
 		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
@@ -258,8 +276,8 @@
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
 	</dd>
-	<dt>Info panel</dt>
-	<dd><p>Use to spotlight specialized information/actions within a self-contained box.</p>
+	<dt>Panneau d'information</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions spécialisées dans un encadré autonome.</p>
 		<pre><code>&lt;section class="panel panel-info mrgn-bttm-0"&gt;
 	&lt;header class="panel-heading"&gt;
 		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
@@ -269,8 +287,8 @@
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
 	</dd>
-	<dt>Warning panel</dt>
-	<dd><p>Use to spotlight warning information/actions within a self-contained box.</p>
+	<dt>Panneau d'avertissement</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions d'avertissement dans un encadré autonome.</p>
 		<pre><code>&lt;section class="panel panel-warning mrgn-bttm-0"&gt;
 	&lt;header class="panel-heading"&gt;
 		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;
@@ -280,8 +298,8 @@
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
 	</dd>
-	<dt>Danger panel</dt>
-	<dd><p>Use to spotlight dangerous information/actions within a self-contained box.</p>
+	<dt>Panneau de danger</dt>
+	<dd><p>À utiliser pour mettre en évidence des informations ou des actions dangereuses dans un encadré autonome.</p>
 		<pre><code>&lt;section class="panel panel-danger mrgn-bttm-0"&gt;
 	&lt;header class="panel-heading"&gt;
 		&lt;h3 class="panel-title"&gt;Titre du panneau&lt;/h3&gt;


### PR DESCRIPTION
Added `.panel-heading` and `.panel-title` to every example of the panels component. Reference JIRA ticket WET-688.