### PR TITLE
fix fieldflow behaviour when restoring page from cache

### DIFF
--- a/components/wb-fieldflow/ajax/confirmation-en.html
+++ b/components/wb-fieldflow/ajax/confirmation-en.html
@@ -1,0 +1,9 @@
+---
+title: "Submission received"
+language: "en"
+altLangPage: confirmation-fr.html
+dateModified: "2026-07-29"
+---
+<p>This page only exists as a confirmation page for the Fieldflow submitting form example.</p>
+<h2 class="h4">Testing restore from cache</h2>
+<p>Press your browser's <strong>Back</strong> button to return to the form. Your selection should be restored as you left it.</p>

--- a/components/wb-fieldflow/ajax/confirmation-fr.html
+++ b/components/wb-fieldflow/ajax/confirmation-fr.html
@@ -1,0 +1,9 @@
+---
+title: "Envoi reçu"
+language: "fr"
+altLangPage: confirmation-en.html
+dateModified: "2026-07-29"
+---
+<p>Cette page n'existe que comme page de confirmation pour l'exemple de formulaire avec envoi du déroulement de champs.</p>
+<h2 class="h4">Tester la restauration à partir de la mémoire cache</h2>
+<p>Appuyez sur le bouton <strong>Précédent</strong> de votre navigateur pour revenir au formulaire. Votre sélection devrait être restaurée telle que vous l'aviez laissée.</p>

--- a/components/wb-fieldflow/alternative-en.html
+++ b/components/wb-fieldflow/alternative-en.html
@@ -330,4 +330,89 @@ dateModified: "2023-12-01"
 	&lt;/form&gt;
 &lt;/div&gt;</code></pre>
 
+	<h3>Inside a form that submits to another page</h3>
+	<div class="wb-frmvld">
+		<form action="ajax/confirmation-en.html" method="get">
+
+			<div class="form-group mrgn-lft-md mrgn-bttm-lg">
+				<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "renderas": "radio", "base": {"live": true}}'>
+					<p class="wb-fieldflow-label">What would you like to receive?</p>
+					<ul>
+						<li data-wb-fieldflow='{"action": "toggle", "toggle": "#news-all-content"}'>All advisories
+						</li>
+						<li data-wb-fieldflow='{"action": "toggle", "toggle": "#news-custom-content"}'>Customized subscription</li>
+					</ul>
+				</div>
+
+
+				<div id="news-all-content" class="hidden mrgn-tp-md">
+					<div class="well well-sm mrgn-bttm-0">
+						<p class="mrgn-bttm-0"><strong>You are subscribing to all media advisories</strong></p>
+					</div>
+				</div>
+
+
+				<div id="news-custom-content" class="hidden mrgn-tp-md">
+					<div class="well well-sm mrgn-bttm-0">
+						<p class="mrgn-bttm-0"><strong>You are subscribing to media advisories from selected regions</strong></p>
+					</div>
+					<gc-combobox class="select-all-unstyled" id="news-regions" placeholder="Select region(s)..."
+						name="regions"
+						enable-select-all="Select all regions" all-options-tag="All regions">
+						<span slot="label">Regions</span>
+						<select slot="options">
+							<option value="ontario">Ontario</option>
+							<option value="toronto">Toronto</option>
+							<option value="gatineau">Gatineau</option>
+							<option value="ottawa">Ottawa</option>
+							<option value="quebec">Quebec</option>
+						</select>
+					</gc-combobox>
+				</div>
+			</div>
+
+			<button type="submit" class="btn btn-primary btn-lg">Subscribe</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;ajax/confirmation-en.html&quot; method=&quot;get&quot;&gt;
+
+		&lt;div class=&quot;form-group mrgn-lft-md mrgn-bttm-lg&quot;&gt;
+			&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;renderas&quot;: &quot;radio&quot;, &quot;base&quot;: {&quot;live&quot;: true}}'&gt;
+				&lt;p class=&quot;wb-fieldflow-label&quot;&gt;What would you like to receive?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#news-all-content&quot;}'&gt;All advisories&lt;/li&gt;
+					&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#news-custom-content&quot;}'&gt;Customized subscription&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+
+			&lt;div id=&quot;news-all-content&quot; class=&quot;hidden mrgn-tp-md&quot;&gt;
+				&lt;div class=&quot;well well-sm mrgn-bttm-0&quot;&gt;
+					&lt;p class=&quot;mrgn-bttm-0&quot;&gt;&lt;strong&gt;You are subscribing to all media advisories&lt;/strong&gt;&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;div id=&quot;news-custom-content&quot; class=&quot;hidden mrgn-tp-md&quot;&gt;
+				&lt;div class=&quot;well well-sm mrgn-bttm-0&quot;&gt;
+					&lt;p class=&quot;mrgn-bttm-0&quot;&gt;&lt;strong&gt;You are subscribing to media advisories from selected regions&lt;/strong&gt;&lt;/p&gt;
+				&lt;/div&gt;
+				&lt;gc-combobox class=&quot;select-all-unstyled&quot; id=&quot;news-regions&quot; placeholder=&quot;Select region(s)...&quot;
+					name=&quot;regions&quot;
+					enable-select-all=&quot;Select all regions&quot; all-options-tag=&quot;All regions&quot;&gt;
+					&lt;span slot=&quot;label&quot;&gt;Regions&lt;/span&gt;
+					&lt;select slot=&quot;options&quot;&gt;
+						&lt;option value=&quot;ontario&quot;&gt;Ontario&lt;/option&gt;
+						&lt;option value=&quot;toronto&quot;&gt;Toronto&lt;/option&gt;
+						&lt;option value=&quot;gatineau&quot;&gt;Gatineau&lt;/option&gt;
+						&lt;option value=&quot;ottawa&quot;&gt;Ottawa&lt;/option&gt;
+						&lt;option value=&quot;quebec&quot;&gt;Quebec&lt;/option&gt;
+					&lt;/select&gt;
+				&lt;/gc-combobox&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+
+		&lt;button type=&quot;submit&quot; class=&quot;btn btn-primary btn-lg&quot;&gt;Subscribe&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
 </section>

--- a/components/wb-fieldflow/alternative-fr.html
+++ b/components/wb-fieldflow/alternative-fr.html
@@ -330,4 +330,90 @@ dateModified: "2023-12-01"
 		&lt;button&gt;Soumettre&lt;/button&gt;
 	&lt;/form&gt;
 &lt;/div&gt;</code></pre>
+
+	<h3>À l'intérieur d'un formulaire qui envoie vers une autre page</h3>
+	<div class="wb-frmvld">
+		<form action="ajax/confirmation-fr.html" method="get">
+
+			<div class="form-group mrgn-lft-md mrgn-bttm-lg">
+				<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "renderas": "radio", "base": {"live": true}}'>
+					<p class="wb-fieldflow-label">Que souhaitez-vous recevoir?</p>
+					<ul>
+						<li data-wb-fieldflow='{"action": "toggle", "toggle": "#news-all-content"}'>Tous les avis
+						</li>
+						<li data-wb-fieldflow='{"action": "toggle", "toggle": "#news-custom-content"}'>Abonnement personnalisé</li>
+					</ul>
+				</div>
+
+
+				<div id="news-all-content" class="hidden mrgn-tp-md">
+					<div class="well well-sm mrgn-bttm-0">
+						<p class="mrgn-bttm-0"><strong>Vous vous abonnez à tous les avis aux médias</strong></p>
+					</div>
+				</div>
+
+
+				<div id="news-custom-content" class="hidden mrgn-tp-md">
+					<div class="well well-sm mrgn-bttm-0">
+						<p class="mrgn-bttm-0"><strong>Vous vous abonnez aux avis aux médias de régions sélectionnées</strong></p>
+					</div>
+					<gc-combobox class="select-all-unstyled" id="news-regions" placeholder="Sélectionner une ou des régions..."
+						name="regions"
+						enable-select-all="Sélectionner toutes les régions" all-options-tag="Toutes les régions">
+						<span slot="label">Régions</span>
+						<select slot="options">
+							<option value="ontario">Ontario</option>
+							<option value="toronto">Toronto</option>
+							<option value="gatineau">Gatineau</option>
+							<option value="ottawa">Ottawa</option>
+							<option value="quebec">Québec</option>
+						</select>
+					</gc-combobox>
+				</div>
+			</div>
+
+			<button type="submit" class="btn btn-primary btn-lg">S'abonner</button>
+		</form>
+	</div>
+	<pre class="mrgn-tp-md"><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form action=&quot;ajax/confirmation-fr.html&quot; method=&quot;get&quot;&gt;
+
+		&lt;div class=&quot;form-group mrgn-lft-md mrgn-bttm-lg&quot;&gt;
+			&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;renderas&quot;: &quot;radio&quot;, &quot;base&quot;: {&quot;live&quot;: true}}'&gt;
+				&lt;p class=&quot;wb-fieldflow-label&quot;&gt;Que souhaitez-vous recevoir?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#news-all-content&quot;}'&gt;Tous les avis&lt;/li&gt;
+					&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#news-custom-content&quot;}'&gt;Abonnement personnalisé&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+
+			&lt;div id=&quot;news-all-content&quot; class=&quot;hidden mrgn-tp-md&quot;&gt;
+				&lt;div class=&quot;well well-sm mrgn-bttm-0&quot;&gt;
+					&lt;p class=&quot;mrgn-bttm-0&quot;&gt;&lt;strong&gt;Vous vous abonnez à tous les avis aux médias&lt;/strong&gt;&lt;/p&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;
+
+			&lt;div id=&quot;news-custom-content&quot; class=&quot;hidden mrgn-tp-md&quot;&gt;
+				&lt;div class=&quot;well well-sm mrgn-bttm-0&quot;&gt;
+					&lt;p class=&quot;mrgn-bttm-0&quot;&gt;&lt;strong&gt;Vous vous abonnez aux avis aux médias de régions sélectionnées&lt;/strong&gt;&lt;/p&gt;
+				&lt;/div&gt;
+				&lt;gc-combobox class=&quot;select-all-unstyled&quot; id=&quot;news-regions&quot; placeholder=&quot;Sélectionner une ou des régions...&quot;
+					name=&quot;regions&quot;
+					enable-select-all=&quot;Sélectionner toutes les régions&quot; all-options-tag=&quot;Toutes les régions&quot;&gt;
+					&lt;span slot=&quot;label&quot;&gt;Régions&lt;/span&gt;
+					&lt;select slot=&quot;options&quot;&gt;
+						&lt;option value=&quot;ontario&quot;&gt;Ontario&lt;/option&gt;
+						&lt;option value=&quot;toronto&quot;&gt;Toronto&lt;/option&gt;
+						&lt;option value=&quot;gatineau&quot;&gt;Gatineau&lt;/option&gt;
+						&lt;option value=&quot;ottawa&quot;&gt;Ottawa&lt;/option&gt;
+						&lt;option value=&quot;quebec&quot;&gt;Québec&lt;/option&gt;
+					&lt;/select&gt;
+				&lt;/gc-combobox&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+
+		&lt;button type=&quot;submit&quot; class=&quot;btn btn-primary btn-lg&quot;&gt;S'abonner&lt;/button&gt;
+	&lt;/form&gt;
+&lt;/div&gt;</code></pre>
+
 </section>

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -1174,7 +1174,10 @@ $document.on( "submit", selectorForm + " form", function( event ) {
 
 	// Before to submit, remove jj-down accessory control
 	if ( !preventSubmit ) {
-		$elm.find( basenameInputSelector ).removeAttr( "name" );
+		$elm.find( basenameInputSelector ).each( function() {
+			this.dataset.wbFieldflowName = this.name;
+			this.removeAttribute( "name" );
+		} );
 
 		// Fix an issue when clicking back with the mouse
 		i_len = wbRegisteredHidden.length;
@@ -1370,6 +1373,23 @@ $document.on( fieldflowActionsEvents, selector, function( event, data ) {
 			}
 			break;
 	}
+} );
+
+// On a page restore from cache, undo the two changes the submit handler made to the page just before navigating away to preserve the original state
+window.addEventListener( "pageshow", function( event ) {
+	if ( !event.persisted ) {
+		return;
+	}
+
+	$( "[data-" + componentName + "-name]" ).each( function() {
+		this.setAttribute( "name", this.dataset.wbFieldflowName );
+	} );
+
+	$( selectorForm + " " + crtlSelectSelector ).each( function() {
+		if ( $( this ).find( ":checked" ).length ) {
+			$( this ).trigger( "change" );
+		}
+	} );
 } );
 
 // Bind the init event of the plugin


### PR DESCRIPTION
Before a form submission, the plugin removes the `name` attribute from the controls that it generates (e.g. radio buttons). So if a user submits a form, gets redirected to a confirmation page, then presses the browser back button, the restored version is broken.

This fix stores the `name` attribute for each generated control so that on a page restore it can put them back. If any panels were selected/open prior to navigating away, their state gets restored accordingly.

**To reproduce the bug:**
- Go to https://canada-aem-s3-stage.adobecqms.net/en/news/subscribe-media-advisories.html **_using Edge of Firefox_** (doesn't happen always in Chrome)
- Make a test submission selecting "customized subscription" and whichever instiutions/regions
- Click subscribe
- Once you see the confirmation page, navigate back using the browser back button
- Notice customized subscription is selected but the panel doesn't show, and if you select "all advisories" both radio buttons are selected at once

You can see a working example with the fix implemented here:
https://servicecanada.github.io/wet-boew-demos/gcweb-pr2825/components/wb-fieldflow/alternative-en.html