### PR TITLE
add fieldflow prop to preserve content visibility on submit

### DIFF
--- a/components/wb-fieldflow/alternative-en.html
+++ b/components/wb-fieldflow/alternative-en.html
@@ -6,7 +6,7 @@ category: "Plugins"
 description: "Find styling alternatives for field flow."
 tag: "fieldflow"
 parentdir: "fieldflow"
-dateModified: "2023-12-01"
+dateModified: "2026-08-12"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-en.html">Documentation</a></li>
@@ -335,7 +335,7 @@ dateModified: "2023-12-01"
 		<form action="ajax/confirmation-en.html" method="get">
 
 			<div class="form-group mrgn-lft-md mrgn-bttm-lg">
-				<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "renderas": "radio", "base": {"live": true}}'>
+				<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "renderas": "radio", "base": {"live": true, "keepOnSubmit": true}}'>
 					<p class="wb-fieldflow-label">What would you like to receive?</p>
 					<ul>
 						<li data-wb-fieldflow='{"action": "toggle", "toggle": "#news-all-content"}'>All advisories
@@ -378,7 +378,7 @@ dateModified: "2023-12-01"
 	&lt;form action=&quot;ajax/confirmation-en.html&quot; method=&quot;get&quot;&gt;
 
 		&lt;div class=&quot;form-group mrgn-lft-md mrgn-bttm-lg&quot;&gt;
-			&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;renderas&quot;: &quot;radio&quot;, &quot;base&quot;: {&quot;live&quot;: true}}'&gt;
+			&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;renderas&quot;: &quot;radio&quot;, &quot;base&quot;: {&quot;live&quot;: true, &quot;keepOnSubmit&quot;: true}}'&gt;
 				&lt;p class=&quot;wb-fieldflow-label&quot;&gt;What would you like to receive?&lt;/p&gt;
 				&lt;ul&gt;
 					&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#news-all-content&quot;}'&gt;All advisories&lt;/li&gt;

--- a/components/wb-fieldflow/alternative-fr.html
+++ b/components/wb-fieldflow/alternative-fr.html
@@ -6,7 +6,7 @@ category: "Plugiciels"
 description: "Trouver des alternatives de styles pour le déroulement de champs."
 tag: "fieldflow"
 parentdir: "fieldflow"
-dateModified: "2023-12-01"
+dateModified: "2026-08-12"
 ---
 <ul class="list-inline">
 	<li><a class="btn btn-primary" href="fieldflow-doc-fr.html">Documentation</a></li>
@@ -336,7 +336,7 @@ dateModified: "2023-12-01"
 		<form action="ajax/confirmation-fr.html" method="get">
 
 			<div class="form-group mrgn-lft-md mrgn-bttm-lg">
-				<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "renderas": "radio", "base": {"live": true}}'>
+				<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "renderas": "radio", "base": {"live": true, "keepOnSubmit": true}}'>
 					<p class="wb-fieldflow-label">Que souhaitez-vous recevoir?</p>
 					<ul>
 						<li data-wb-fieldflow='{"action": "toggle", "toggle": "#news-all-content"}'>Tous les avis
@@ -379,7 +379,7 @@ dateModified: "2023-12-01"
 	&lt;form action=&quot;ajax/confirmation-fr.html&quot; method=&quot;get&quot;&gt;
 
 		&lt;div class=&quot;form-group mrgn-lft-md mrgn-bttm-lg&quot;&gt;
-			&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;renderas&quot;: &quot;radio&quot;, &quot;base&quot;: {&quot;live&quot;: true}}'&gt;
+			&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;renderas&quot;: &quot;radio&quot;, &quot;base&quot;: {&quot;live&quot;: true, &quot;keepOnSubmit&quot;: true}}'&gt;
 				&lt;p class=&quot;wb-fieldflow-label&quot;&gt;Que souhaitez-vous recevoir?&lt;/p&gt;
 				&lt;ul&gt;
 					&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#news-all-content&quot;}'&gt;Tous les avis&lt;/li&gt;

--- a/components/wb-fieldflow/fieldflow-doc-en.html
+++ b/components/wb-fieldflow/fieldflow-doc-en.html
@@ -6,7 +6,7 @@ description: Transform a basic list into a drop down.
 tag: fieldflow
 parentdir: fieldflow
 altLangPage: fieldflow-doc-fr.html
-dateModified: 2021-04-28
+dateModified: 2026-08-12
 ---
 
 <div class="wb-prettify all-pre"></div>
@@ -950,6 +950,27 @@ dateModified: 2021-04-28
 				</td>
 				<td><code>data-wb-fieldflow='{&quot;live&quot;: true}'</code></td>
 				<td>URL</td>
+			</tr>
+			<tr>
+				<td>keepOnSubmit</td>
+				<td>ajax,toggle</td>
+				<td><p>Keep content visible during a submit. Without it, the content shown by a <code>live</code> action is hidden or emptied right before the browser navigates away.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#jQuerySelector&quot;, &quot;live&quot;: true, &quot;keepOnSubmit&quot;: true}'</code>
+				</td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Visible content will be hidden or emptied on form submission, the same way it is for a selection change. </dd>
+						<dt>true</dt>
+						<dd>The content stays as it is while the form is submitted.</dd>
+					</dl>
+				</td>
 			</tr>
 			<tr>
 				<td>type</td>

--- a/components/wb-fieldflow/fieldflow-doc-fr.html
+++ b/components/wb-fieldflow/fieldflow-doc-fr.html
@@ -6,7 +6,7 @@ description: Transforme une simple liste en une liste de choix.
 tag: fieldflow
 parentdir: fieldflow
 altLangPage: fieldflow-doc-en.html
-dateModified: "2021-04-28"
+dateModified: "2026-08-12"
 ---
 
 <div class="wb-prettify all-pre"></div>
@@ -954,6 +954,28 @@ dateModified: "2021-04-28"
 				</td>
 				<td><code>data-wb-fieldflow='{&quot;live&quot;: true}'</code></td>
 				<td>URL</td>
+			</tr>
+			<tr>
+				<td>keepOnSubmit</td>
+				<td>ajax,toggle</td>
+				<td><p>Do not undo the action when the form is submitted. Without it, the content shown by a <code>live</code> action is hidden (or emptied) right before the browser navigates away, which is visible to the user.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#jQuerySelector&quot;, &quot;live&quot;: true, &quot;keepOnSubmit&quot;: true}'</code>
+					<p>It can be set for all the actions of a component with <code>data-wb-fieldflow='{&quot;base&quot;: {&quot;keepOnSubmit&quot;: true}}'</code></p>
+				</td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>The action is undone when the form is submitted, like it is on a selection change.</dd>
+						<dt>true</dt>
+						<dd>The action is only undone on a selection change, the content stay as it is while the form is submitted.</dd>
+					</dl>
+				</td>
 			</tr>
 			<tr>
 				<td>type</td>

--- a/components/wb-fieldflow/fieldflow.js
+++ b/components/wb-fieldflow/fieldflow.js
@@ -212,6 +212,20 @@ var componentName = "wb-fieldflow",
 		dtCache.push( data );
 		return $elm.data( prop, dtCache );
 	},
+
+
+	// Bind the clean event, and check if the cleaning should be done on submit or not
+	bindCleanEvent = function( $elm, data, cleanFunction ) {
+		$elm.on( cleanEvent, function cleanHandler( event, cleanData ) {
+			if ( data.keepOnSubmit && cleanData && cleanData.onSubmit ) {
+				return;
+			}
+			cleanFunction.call( this, event, cleanData );
+
+			// Cleaning event is unbinded after it's been executed so that it only runs once
+			$elm.off( cleanEvent, cleanHandler );
+		} );
+	},
 	subRedir = function( event, data ) {
 
 		var form = data.form,
@@ -268,7 +282,7 @@ var componentName = "wb-fieldflow",
 		}
 
 		if ( cleanSelector ) {
-			$( data.origin ).one( cleanEvent, function( ) {
+			bindCleanEvent( $( data.origin ), data, function( ) {
 				$( cleanSelector ).empty();
 			} );
 		}
@@ -314,7 +328,7 @@ var componentName = "wb-fieldflow",
 
 		// Set the cleaning task
 		toggleOpts.type = "off";
-		$origin.one( cleanEvent, function( ) {
+		bindCleanEvent( $origin, data, function( ) {
 			$origin.addClass( "wb-toggle" );
 			$origin.trigger( "toggle.wb-toggle", toggleOpts );
 			$origin.removeClass( "wb-toggle" );
@@ -1124,11 +1138,12 @@ $document.on( "submit", selectorForm + " form", function( event ) {
 		preventSubmit = false, lastProvEvt;
 
 	// Run the cleaning on the current items
+	// The "onSubmit" property lets an action opt out of it via the "keepOnSubmit" attribute
 	if ( i_len ) {
 		$wbFieldFlow = $( "#" + wbFieldFlowRegistered[ i_len - 1 ] );
 		fieldOrigin = $wbFieldFlow.data( registerJQData );
-		$( "#" + fieldOrigin[ fieldOrigin.length - 1 ] ).trigger( cleanEvent );
-		$wbFieldFlow.trigger( cleanEvent );
+		$( "#" + fieldOrigin[ fieldOrigin.length - 1 ] ).trigger( cleanEvent, { onSubmit: true } );
+		$wbFieldFlow.trigger( cleanEvent, { onSubmit: true } );
 	}
 
 	// For each wb-fieldflow component, execute submitting task.


### PR DESCRIPTION
When a form is submitted, a clean event is triggered before the submission goes through, which undoes any live toggle or ajax action. That results in the content being shown by a selection collapsing/emptying before the browser navigates away.

This PR creates an option for users to opt out of the clean event that is triggered on submit to keep content visible during submission. To opt out the clean event, the user can add `"keepOnSubmit": true` to the config options.

Live example can be seen [here](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2836/components/wb-fieldflow/alternative-en.html#wb-auto-88)