### PR TITLE
Build (stylelint): Polish globbing patterns

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1026,16 +1026,14 @@ module.exports = (grunt) ->
 				src: [
 					"**/*.css"
 					"!**/*.min.css"
-					"!méli-mélo/compilation-gelé/"
+					"!méli-mélo/compilation-gelé/**"
 					"!_site/**"
-					"!node_modlules/"
 				]
 
 			scss:
 				src: [
 					"**/*.scss"
 					"!_site/**"
-					"!node_modlules"
 				]
 
 		cssmin:

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -134,7 +134,6 @@ module.exports = {
 		"**/*.min.css",
 		"méli-mélo/compilation-gelé/**",
 		"méli-mélo/deprecated/**",
-		"node_modules/**",
 		"_site/**",
 		"~sites/**",
 		"_site/**",


### PR DESCRIPTION
Specifically:
* Remove node_modules exclusions (some of which had "node_modlules" typos):
  * Stylelint already ignores node_modules by default (https://stylelint.io/user-guide/configure/#ignorefiles)
* Add ``**`` suffix to the "!méli-mélo/compilation-gelé/" exclusion pattern:
  * Doesn't change anything in practice, but is more explicit and consistent with other globbing patterns throughout the Gruntfile

CC @nschonni